### PR TITLE
chore: fix Cargo.toml repository/homepage/docs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pmix"
+authors = ["SedahsDev"]
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
@@ -8,7 +9,9 @@ license = "BSD-3-Clause"
 readme = "README.md"
 keywords = ["pmix", "hpc", "mpi", "process-management"]
 categories = ["api-bindings", "science"]
-repository = "https://github.com/KirgenR/pmix-rs"
+repository = "https://github.com/SedahsDev/pmix-rs"
+homepage = "https://github.com/SedahsDev/pmix-rs"
+documentation = "https://docs.rs/pmix"
 
 [build-dependencies]
 bindgen = "0.72.1"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ fn main() {
 ### Examples
 
 ```bash
+# Role-based entry points
+cargo run --example client_minimal
+cargo run --example server_minimal
+cargo run --example tool_attach
+
+# Additional demos
 cargo run --example simple_put_get
 cargo run --example simple_fence
 cargo run --example data_packing


### PR DESCRIPTION
## Summary
Per #30 comments:
- `repository` → SedahsDev/pmix-rs
- Add homepage, documentation, authors
- rust-version already present (1.85)
- README lists client/server/tool examples

Fixes #30