### PR TITLE
TASK-114: Add mock FFI + tests for query_log.rs — coverage 55.5% → 87.2%

### DIFF
--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -209,6 +209,10 @@ pub const PMIX_ERR_PACK_FAILURE: i32 = -21;
 pub const PMIX_ERR_UNPACK_FAILURE: i32 = -20;
 /// PMIX_ERROR (-1)
 pub const PMIX_ERROR: i32 = -1;
+/// PMIX_ERR_NOT_SUPPORTED (-47)
+pub const PMIX_ERR_NOT_SUPPORTED: i32 = -47;
+/// PMIX_ERR_PARTIAL_SUCCESS (-52)
+pub const PMIX_ERR_PARTIAL_SUCCESS: i32 = -52;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx data type constants
@@ -1517,6 +1521,129 @@ pub fn mock_cpuset_construct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
 /// Mock implementation of `PMIx_Cpuset_destruct()`.
 pub fn mock_cpuset_destruct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
     // No-op in mock
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock query/log FFI implementations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mock implementation of `PMIx_Query_create()`.
+/// Allocates a pmix_query_t struct and returns a pointer.
+pub fn mock_query_create(n: usize) -> *mut crate::ffi::pmix_query_t {
+    let _ = n;
+    if is_mock_enabled() {
+        let status = get_mock_status("PMIx_Query_create");
+        if status == PMIX_SUCCESS {
+            let ptr = unsafe {
+                libc::calloc(1, std::mem::size_of::<crate::ffi::pmix_query_t>())
+                    as *mut crate::ffi::pmix_query_t
+            };
+            if !ptr.is_null() {
+                unsafe {
+                    (*ptr).keys = std::ptr::null_mut();
+                    (*ptr).qualifiers = std::ptr::null_mut();
+                    (*ptr).nqual = 0;
+                }
+            }
+            ptr
+        } else {
+            std::ptr::null_mut()
+        }
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+/// Mock implementation of `PMIx_Query_free()`.
+/// Frees a pmix_query_t struct allocated by mock_query_create.
+pub fn mock_query_free(p: *mut crate::ffi::pmix_query_t, n: usize) {
+    if is_mock_enabled() {
+        for i in 0..n {
+            let ptr = unsafe { p.add(i) };
+            unsafe {
+                libc::free(ptr as *mut std::ffi::c_void);
+            }
+        }
+    }
+}
+
+/// Mock implementation of `PMIx_Query_info()`.
+/// Simulates a query response by writing to the output parameters.
+pub fn mock_query_info(
+    _queries: *mut crate::ffi::pmix_query_t,
+    _nqueries: usize,
+    results: *mut *mut crate::ffi::pmix_info_t,
+    nresults: *mut usize,
+) -> i32 {
+    if is_mock_enabled() {
+        let status = get_mock_status("PMIx_Query_info");
+        // Return empty results regardless of status
+        unsafe {
+            *results = std::ptr::null_mut();
+            *nresults = 0;
+        }
+        status
+    } else {
+        crate::mock_ffi::PMIX_ERR_INIT
+    }
+}
+
+/// Mock implementation of `PMIx_Query_info_nb()`.
+/// Simulates an async query — returns status immediately.
+pub fn mock_query_info_nb(
+    _queries: *mut crate::ffi::pmix_query_t,
+    _nqueries: usize,
+    _cbfunc: Option<unsafe extern "C" fn(
+        crate::ffi::pmix_status_t,
+        *mut crate::ffi::pmix_info_t,
+        usize,
+        *mut std::ffi::c_void,
+        crate::ffi::pmix_release_cbfunc_t,
+        *mut std::ffi::c_void,
+    )>,
+    _cbdata: *mut std::ffi::c_void,
+) -> i32 {
+    if is_mock_enabled() {
+        get_mock_status("PMIx_Query_info_nb")
+    } else {
+        crate::mock_ffi::PMIX_ERR_INIT
+    }
+}
+
+/// Mock implementation of `PMIx_Log()`.
+pub fn mock_log(
+    _data: *const crate::ffi::pmix_info_t,
+    _ndata: usize,
+    _directives: *const crate::ffi::pmix_info_t,
+    _ndirs: usize,
+) -> i32 {
+    if is_mock_enabled() {
+        get_mock_status("PMIx_Log")
+    } else {
+        crate::mock_ffi::PMIX_ERR_INIT
+    }
+}
+
+/// Mock implementation of `PMIx_Log_nb()`.
+pub fn mock_log_nb(
+    _data: *const crate::ffi::pmix_info_t,
+    _ndata: usize,
+    _directives: *const crate::ffi::pmix_info_t,
+    _ndirs: usize,
+    _cbfunc: Option<unsafe extern "C" fn(crate::ffi::pmix_status_t, *mut std::ffi::c_void)>,
+    _cbdata: *mut std::ffi::c_void,
+) -> i32 {
+    if is_mock_enabled() {
+        get_mock_status("PMIx_Log_nb")
+    } else {
+        crate::mock_ffi::PMIX_ERR_INIT
+    }
+}
+
+/// Mock implementation of `PMIx_Info_free()`.
+/// No-op in mock mode (handles are fake).
+pub fn mock_info_free(_info: *mut crate::ffi::pmix_info_t, _ninfo: usize) {
+    // In mock mode, handles are fake — just skip
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -95,7 +95,16 @@ impl PmixQuery {
         let query_ptr = unsafe {
             // SAFETY: PMIx_Query_create allocates and zero-initializes a
             // pmix_query_t. It always returns a non-null pointer.
-            ffi::PMIx_Query_create(1)
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                mock_ffi::mock_query_create(1)
+            } else {
+                ffi::PMIx_Query_create(1)
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                ffi::PMIx_Query_create(1)
+            }
         };
         if query_ptr.is_null() {
             return Err(PmixError::ErrNomem.into());
@@ -107,8 +116,16 @@ impl PmixQuery {
             Ok(v) => v,
             Err(_) => {
                 unsafe {
-                    // SAFETY: query_ptr was allocated by PMIx_Query_create.
-                    ffi::PMIx_Query_free(query_ptr, 1);
+                    #[cfg(any(test, feature = "mock_ffi"))]
+                    if mock_ffi::is_mock_enabled() {
+                        mock_ffi::mock_query_free(query_ptr, 1);
+                    } else {
+                        ffi::PMIx_Query_free(query_ptr, 1);
+                    }
+                    #[cfg(not(any(test, feature = "mock_ffi")))]
+                    {
+                        ffi::PMIx_Query_free(query_ptr, 1);
+                    }
                 }
                 return Err(PmixError::ErrBadParam.into());
             }
@@ -122,7 +139,16 @@ impl PmixQuery {
 
         if keys_array.is_null() {
             unsafe {
-                ffi::PMIx_Query_free(query_ptr, 1);
+                #[cfg(any(test, feature = "mock_ffi"))]
+                if mock_ffi::is_mock_enabled() {
+                    mock_ffi::mock_query_free(query_ptr, 1);
+                } else {
+                    ffi::PMIx_Query_free(query_ptr, 1);
+                }
+                #[cfg(not(any(test, feature = "mock_ffi")))]
+                {
+                    ffi::PMIx_Query_free(query_ptr, 1);
+                }
             }
             return Err(PmixError::ErrNomem.into());
         }
@@ -301,7 +327,16 @@ pub fn query_info(queries: &[PmixQuery]) -> Result<QueryResults, PmixStatus> {
         //   owned by the PmixQuery borrows passed by the caller.
         // - results and nresults are output pointers that PMIx will write to.
         // - PMIx does not retain queries_ptr after this call returns.
-        ffi::PMIx_Query_info(queries_ptr, nqueries, &mut results, &mut nresults)
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            mock_ffi::mock_query_info(queries_ptr, nqueries, &mut results, &mut nresults)
+        } else {
+            ffi::PMIx_Query_info(queries_ptr, nqueries, &mut results, &mut nresults)
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            ffi::PMIx_Query_info(queries_ptr, nqueries, &mut results, &mut nresults)
+        }
     };
 
     let pmix_status = PmixStatus::from_raw(status);
@@ -316,8 +351,16 @@ pub fn query_info(queries: &[PmixQuery]) -> Result<QueryResults, PmixStatus> {
         // On error, PMIx may have still allocated a results array — free it.
         if !results.is_null() && nresults > 0 {
             unsafe {
-                // SAFETY: PMIx allocated this array; free it on the error path.
-                ffi::PMIx_Info_free(results, nresults);
+                #[cfg(any(test, feature = "mock_ffi"))]
+                if mock_ffi::is_mock_enabled() {
+                    mock_ffi::mock_info_free(results, nresults);
+                } else {
+                    ffi::PMIx_Info_free(results, nresults);
+                }
+                #[cfg(not(any(test, feature = "mock_ffi")))]
+                {
+                    ffi::PMIx_Info_free(results, nresults);
+                }
             }
         }
         Err(pmix_status)
@@ -380,7 +423,16 @@ extern "C" fn query_callback_bridge(
             // Callback already consumed — free the info array to avoid leak.
             if !info.is_null() && ninfo > 0 {
                 unsafe {
-                    ffi::PMIx_Info_free(info, ninfo);
+                    #[cfg(any(test, feature = "mock_ffi"))]
+                    if mock_ffi::is_mock_enabled() {
+                        mock_ffi::mock_info_free(info, ninfo);
+                    } else {
+                        ffi::PMIx_Info_free(info, ninfo);
+                    }
+                    #[cfg(not(any(test, feature = "mock_ffi")))]
+                    {
+                        ffi::PMIx_Info_free(info, ninfo);
+                    }
                 }
             }
             return;
@@ -444,7 +496,16 @@ pub fn query_info_nb(
         // - cbfunc is a valid extern "C" function pointer.
         // - cbdata encodes the request ID; PMIx passes it back unchanged.
         // - PMIx does not retain queries_ptr after this call returns.
-        ffi::PMIx_Query_info_nb(queries_ptr, nqueries, Some(query_callback_bridge), cbdata)
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            mock_ffi::mock_query_info_nb(queries_ptr, nqueries, Some(query_callback_bridge), cbdata)
+        } else {
+            ffi::PMIx_Query_info_nb(queries_ptr, nqueries, Some(query_callback_bridge), cbdata)
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            ffi::PMIx_Query_info_nb(queries_ptr, nqueries, Some(query_callback_bridge), cbdata)
+        }
     };
 
     let pmix_status = PmixStatus::from_raw(status);
@@ -526,7 +587,16 @@ pub fn log_data(data: &[Info], directives: &[Info]) -> Result<(), PmixStatus> {
         // - PMIx does not retain these pointers after this call returns.
         // - The caller must keep data and directives alive until this
         //   function returns.
-        ffi::PMIx_Log(data_ptr, ndata, dirs_ptr, ndirs)
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            mock_ffi::mock_log(data_ptr, ndata, dirs_ptr, ndirs)
+        } else {
+            ffi::PMIx_Log(data_ptr, ndata, dirs_ptr, ndirs)
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            ffi::PMIx_Log(data_ptr, ndata, dirs_ptr, ndirs)
+        }
     };
 
     let pmix_status = PmixStatus::from_raw(status);
@@ -650,14 +720,37 @@ pub fn log_data_nb(
         // - PMIx does not retain data_ptr or dirs_ptr after this call returns.
         // - The caller must keep data and directives alive until the
         //   callback is invoked.
-        ffi::PMIx_Log_nb(
-            data_ptr,
-            ndata,
-            dirs_ptr,
-            ndirs,
-            Some(log_callback_bridge),
-            cbdata,
-        )
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            mock_ffi::mock_log_nb(
+                data_ptr,
+                ndata,
+                dirs_ptr,
+                ndirs,
+                Some(log_callback_bridge),
+                cbdata,
+            )
+        } else {
+            ffi::PMIx_Log_nb(
+                data_ptr,
+                ndata,
+                dirs_ptr,
+                ndirs,
+                Some(log_callback_bridge),
+                cbdata,
+            )
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            ffi::PMIx_Log_nb(
+                data_ptr,
+                ndata,
+                dirs_ptr,
+                ndirs,
+                Some(log_callback_bridge),
+                cbdata,
+            )
+        }
     };
 
     let pmix_status = PmixStatus::from_raw(status);
@@ -1446,5 +1539,254 @@ mod tests {
         let info = crate::info_with_string_key("PMIX_LOG_STDOUT", "test message");
         assert!(!info.is_empty());
         assert_eq!(info.len(), 1);
+    }
+
+    // ── TASK-114: New tests to improve coverage ─────────────────────────────────
+
+    #[test]
+    fn test_query_info_success_with_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let query = PmixQuery::new(&["pmix.version"]).unwrap();
+        let result = query_info(&[query]);
+        // With mock returning PMIX_SUCCESS, we should get Ok(QueryResults)
+        assert!(result.is_ok());
+        let results = result.unwrap();
+        assert_eq!(results.len(), 0);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_info_error_path_with_mock() {
+        let _guard = mock_ffi::MockGuard::with_config(
+            mock_ffi::MockConfig::new()
+                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_INIT)
+        );
+        let query = PmixQuery::new(&["pmix.version"]).unwrap();
+        let result = query_info(&[query]);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrInit));
+    }
+
+    #[test]
+    fn test_query_info_nb_success_with_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let query = PmixQuery::new(&["pmix.version"]).unwrap();
+
+        struct TestCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl QueryCallback for TestCallback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus, _results: QueryResults) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let cb = Box::new(TestCallback {
+            called: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        });
+
+        let result = query_info_nb(&[query], cb);
+        // With mock returning PMIX_SUCCESS, the request is accepted
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_query_info_nb_error_cleanup_with_mock() {
+        let _guard = mock_ffi::MockGuard::with_config(
+            mock_ffi::MockConfig::new()
+                .with_function_status("PMIx_Query_info_nb", mock_ffi::PMIX_ERR_INIT)
+        );
+        let query = PmixQuery::new(&["pmix.version"]).unwrap();
+
+        struct TestCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl QueryCallback for TestCallback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus, _results: QueryResults) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let cb = Box::new(TestCallback {
+            called: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        });
+
+        let result = query_info_nb(&[query], cb);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrInit));
+    }
+
+    #[test]
+    fn test_log_data_success_with_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let directives: Vec<Info> = vec![];
+        let result = log_data(&data, &directives);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_log_data_error_with_mock() {
+        let _guard = mock_ffi::MockGuard::with_config(
+            mock_ffi::MockConfig::new()
+                .with_function_status("PMIx_Log", mock_ffi::PMIX_ERR_NOT_SUPPORTED)
+        );
+        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let directives: Vec<Info> = vec![];
+        let result = log_data(&data, &directives);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrNotSupported));
+    }
+
+    #[test]
+    fn test_log_data_nb_success_with_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let directives: Vec<Info> = vec![];
+
+        struct TestLogCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl LogCallback for TestLogCallback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let cb = Box::new(TestLogCallback {
+            called: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        });
+
+        let result = log_data_nb(&data, &directives, cb);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_log_data_nb_error_cleanup_with_mock() {
+        let _guard = mock_ffi::MockGuard::with_config(
+            mock_ffi::MockConfig::new()
+                .with_function_status("PMIx_Log_nb", mock_ffi::PMIX_ERR_INIT)
+        );
+        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let directives: Vec<Info> = vec![];
+
+        struct TestLogCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl LogCallback for TestLogCallback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let cb = Box::new(TestLogCallback {
+            called: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        });
+
+        let result = log_data_nb(&data, &directives, cb);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrInit));
+    }
+
+    #[test]
+    fn test_query_callback_bridge_success_path() {
+        let _guard = mock_ffi::MockGuard::new();
+
+        // Register a callback
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        struct BridgeTestCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl QueryCallback for BridgeTestCallback {
+            fn on_complete(self: Box<Self>, status: PmixStatus, _results: QueryResults) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+                assert!(status.is_success());
+            }
+        }
+
+        let req_id = {
+            let mut seq = QUERY_SEQ.lock().expect("mutex poisoned");
+            *seq += 1;
+            *seq
+        };
+
+        {
+            let mut registry = QUERY_REGISTRY.lock().expect("mutex poisoned");
+            registry.insert(req_id, Box::new(BridgeTestCallback { called: called_clone }));
+        }
+
+        // Simulate the callback being invoked
+        let cbdata = (req_id << 2) as *mut std::ffi::c_void;
+        unsafe {
+            query_callback_bridge(
+                0, // PMIX_SUCCESS
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                None,
+                cbdata,
+            );
+        }
+
+        assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_log_callback_bridge_success_path() {
+        let _guard = mock_ffi::MockGuard::new();
+
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        struct BridgeLogTestCallback {
+            called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl LogCallback for BridgeLogTestCallback {
+            fn on_complete(self: Box<Self>, status: PmixStatus) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+                assert!(status.is_success());
+            }
+        }
+
+        let req_id = {
+            let mut seq = LOG_SEQ.lock().expect("mutex poisoned");
+            *seq += 1;
+            *seq
+        };
+
+        {
+            let mut registry = LOG_REGISTRY.lock().expect("mutex poisoned");
+            registry.insert(req_id, Box::new(BridgeLogTestCallback { called: called_clone }));
+        }
+
+        let cbdata = (req_id << 2) as *mut std::ffi::c_void;
+        unsafe {
+            log_callback_bridge(0, cbdata);
+        }
+
+        assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_query_info_partial_success_with_mock() {
+        let _guard = mock_ffi::MockGuard::with_config(
+            mock_ffi::MockConfig::new()
+                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_PARTIAL_SUCCESS)
+        );
+        let query = PmixQuery::new(&["pmix.version"]).unwrap();
+        let result = query_info(&[query]);
+        // Partial success should still return Ok(QueryResults)
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_log_data_with_both_data_and_directives() {
+        let _guard = mock_ffi::MockGuard::new();
+        let data = vec![crate::info_with_string_key("log.message", "Hello, world!")];
+        let directives = vec![crate::info_with_string_key("pmix.log.stdout", "true")];
+        let result = log_data(&data, &directives);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Add mock FFI implementations and 12 new unit tests for `query_log.rs` to improve code coverage from **55.5% → 87.2%** (171/196 lines).

## Changes

### `src/mock_ffi.rs`
- 2 new error constants: `PMIX_ERR_NOT_SUPPORTED` (-47), `PMIX_ERR_PARTIAL_SUCCESS` (-52)
- 7 mock FFI functions: `mock_query_create`, `mock_query_free`, `mock_query_info`, `mock_query_info_nb`, `mock_log`, `mock_log_nb`, `mock_info_free`

### `src/query_log.rs`
- Mock dispatch at 7 FFI call sites using `#[cfg(any(test, feature = "mock_ffi"))]` pattern
- 12 new unit tests covering:
  - query_info success/error/partial-success paths
  - query_info_nb success/error with callback cleanup
  - log_data success/error paths
  - log_data_nb success/error with callback cleanup
  - query_callback_bridge success path
  - log_callback_bridge success path
  - log_data with both data and directives

## Results
- **query_log.rs coverage:** 86/155 (55.5%) → **171/196 (87.2%)**
- **All 1752 tests pass** (1740 original + 12 new), 27 ignored
- No regressions
