### PR TITLE
feat: process-wide Send+Sync PmixClient session (Arc rewrite)

### DIFF
--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -65,9 +65,6 @@ use crate::{Info, PmixDeviceType, PmixError, PmixStatus};
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
-#[cfg(any(test, feature = "mock_ffi"))]
-
-
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixFabric — safe wrapper for pmix_fabric_t
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,22 @@
 //!
 //! # Concurrency model
 //!
-//! PMIx client/server state is **process-global** and not free-threaded for most
-//! operations:
+//! OpenPMIx **≥ 6.1** threadshifts most `PMIx_*` entry points onto the progress
+//! engine, so concurrent **calls** into C are intended to be OK while progress
+//! runs. Rust still owns session lifetime and C-handle discipline:
 //!
-//! - Prefer a single [`init`] / finalize cycle per process.
-//! - [`Info`] (and other raw-handle wrappers marked below) are **`!Send` + `!Sync`**
-//!   via `PhantomData<*mut u8>` — do not share them across threads without a mutex.
+//! - Prefer one process-wide [`PmixClient`] session: `Clone` is cheap (`Arc`),
+//!   and the type is **`Send + Sync`** so clones can move to worker threads.
+//! - Do **not** lock every put/get in Rust by default — OpenPMIx serializes entry.
+//!   Lock only Rust-owned shared state (the session does this for cached `Proc`).
+//! - Data ops stay as free functions ([`put_value`], [`get_value`], [`commit`],
+//!   [`fence`], …). Pass proc handles from the client; build [`Info`] per call.
+//! - [`Info`] and other raw-handle wrappers are **`!Send` + `!Sync`**
+//!   (`PhantomData<*mut u8>`). Share only behind your own `Mutex` if you must.
+//! - One logical init/finalize cycle per process. [`PmixClient::disconnect`] is
+//!   explicit — **Drop does not finalize** (avoids double-finalize with clones).
+//! - Legacy [`init`] / [`Context`] share the same session state machine; `Context`
+//!   still finalizes on Drop for backward compatibility.
 //! - Server upcalls may run on PMIx internal threads; keep callbacks short.
 //!
 use std::fmt::Debug;
@@ -3371,6 +3381,318 @@ pub fn info_with_string_key(key: &str, value: &str) -> Info {
     }
 }
 
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PmixClient — process-wide Arc session (Send + Sync)
+// ─────────────────────────────────────────────────────────────────────────────
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Lifecycle state of the process-wide PMIx client session.
+///
+/// Transitions: `Uninitialized` → `Live` → `Finalizing` → `Dead`.
+///
+/// Re-init after `Dead` is not supported (matches typical OpenPMIx process
+/// lifetime). Use one logical connect/disconnect cycle per process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PmixClientState {
+    /// No successful `PMIx_Init` for this process session yet.
+    Uninitialized = 0,
+    /// Session is active; ops may call into OpenPMIx.
+    Live = 1,
+    /// `disconnect` / finalize is in progress.
+    Finalizing = 2,
+    /// Session torn down; further `connect` fails.
+    Dead = 3,
+}
+
+impl PmixClientState {
+    fn from_raw(val: u8) -> Self {
+        match val {
+            0 => Self::Uninitialized,
+            1 => Self::Live,
+            2 => Self::Finalizing,
+            _ => Self::Dead,
+        }
+    }
+}
+
+/// Process-wide inner session. Fields are `Send + Sync` so `Arc<Self>` (and
+/// thus [`PmixClient`]) can move across threads. Do **not** add
+/// `PhantomData<*mut u8>` here — that would make the session `!Send` and defeat
+/// multi-threaded cloning.
+struct PmixClientInner {
+    /// Cached proc from `PMIx_Init`; only meaningful while state is `Live`.
+    proc: Mutex<Option<Proc>>,
+    state: AtomicU8,
+}
+
+impl std::fmt::Debug for PmixClientInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PmixClientInner")
+            .field("state", &self.state())
+            .field("proc", &"Mutex<Option<Proc>>")
+            .finish()
+    }
+}
+
+impl PmixClientInner {
+    fn state(&self) -> PmixClientState {
+        PmixClientState::from_raw(self.state.load(Ordering::Acquire))
+    }
+}
+
+/// Process-wide client session storage. Created on first [`PmixClient::new`].
+static CLIENT_SESSION: OnceLock<Arc<PmixClientInner>> = OnceLock::new();
+
+fn client_session() -> Arc<PmixClientInner> {
+    CLIENT_SESSION
+        .get_or_init(|| {
+            Arc::new(PmixClientInner {
+                proc: Mutex::new(None),
+                state: AtomicU8::new(PmixClientState::Uninitialized as u8),
+            })
+        })
+        .clone()
+}
+
+/// Thread-shareable handle to the process-wide PMIx client session.
+///
+/// Cloning is an `Arc` clone: every handle refers to the **same** process
+/// session and state machine. OpenPMIx ≥ 6.1 threadshifts C API entry; this type
+/// is `Send + Sync` so applications can move clones onto worker threads.
+///
+/// # Lifecycle
+///
+/// 1. [`PmixClient::new`] / [`Default`] — attach to the process session (`Uninitialized`
+///    until connect).
+/// 2. [`connect`](Self::connect) — `PMIx_Init`, `Uninitialized` → `Live`.
+/// 3. Clone across threads; use free functions ([`put_value`], [`get_value`],
+///    [`commit`], [`fence`], …) with [`proc`](Self::proc) / [`get_proc`](Self::get_proc).
+/// 4. [`disconnect`](Self::disconnect) — `PMIx_Finalize`, `Live` → `Dead`.
+///
+/// # Drop / finalize rules
+///
+/// - **Drop does not finalize.** Clones must not each run `PMIx_Finalize`.
+/// - Call [`disconnect`](Self::disconnect) once (or legacy [`finalize`]).
+/// - Further disconnect/finalize calls are no-ops once not `Live`.
+/// - Legacy [`Context`] still finalizes on Drop and shares this state machine.
+///
+/// # Example
+///
+/// ```no_run
+/// use pmix::{PmixClient, put_value, commit, fence, PmixScope};
+/// use std::ffi::CString;
+///
+/// let client = PmixClient::new();
+/// client.connect(None)?;
+///
+/// let worker = client.clone();
+/// std::thread::spawn(move || {
+///     let _ = worker.rank();
+///     // put_value / get_value / … with worker.proc()
+/// });
+///
+/// client.disconnect(None)?;
+/// # Ok::<(), pmix::PmixError>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct PmixClient {
+    inner: Arc<PmixClientInner>,
+}
+
+impl Default for PmixClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PmixClient {
+    /// Attach to the process-wide client session (creates it on first call).
+    ///
+    /// Does not call `PMIx_Init`. Use [`connect`](Self::connect) or
+    /// [`connect_new`](Self::connect_new).
+    pub fn new() -> Self {
+        Self {
+            inner: client_session(),
+        }
+    }
+
+    /// `new()` + [`connect`](Self::connect).
+    pub fn connect_new(info: Option<Info>) -> Result<Self, PmixError> {
+        let client = Self::new();
+        client.connect(info)?;
+        Ok(client)
+    }
+
+    /// Whether `self` and `other` refer to the same process session (`Arc` identity).
+    ///
+    /// All `PmixClient` values in a process share one session today, so this is
+    /// true for any pair created via [`new`](Self::new).
+    pub fn same_session(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> PmixClientState {
+        self.inner.state()
+    }
+
+    /// `true` when state is [`PmixClientState::Live`].
+    pub fn is_live(&self) -> bool {
+        self.state() == PmixClientState::Live
+    }
+
+    /// Initialize PMIx for this process (`PMIx_Init`).
+    ///
+    /// Transitions `Uninitialized` → `Live`. Fails if already `Live`
+    /// ([`PmixError::ErrExists`]) or after finalize ([`PmixError::ErrInit`]).
+    ///
+    /// Serialized on the session mutex so concurrent `connect` calls cannot
+    /// double-init.
+    pub fn connect(&self, info: Option<Info>) -> Result<(), PmixError> {
+        let mut proc_guard = self
+            .inner
+            .proc
+            .lock()
+            .expect("pmix: client proc mutex poisoned");
+
+        match self.inner.state() {
+            PmixClientState::Uninitialized => {}
+            PmixClientState::Live => return Err(PmixError::ErrExists),
+            PmixClientState::Finalizing | PmixClientState::Dead => {
+                return Err(PmixError::ErrInit);
+            }
+        }
+
+        let mut uninit_proc = mem::MaybeUninit::<pmix_proc_t>::uninit();
+        let status = match info {
+            Some(ref info) => unsafe {
+                PMIx_Init(uninit_proc.as_mut_ptr(), info.handle, info.len)
+            },
+            None => unsafe { PMIx_Init(uninit_proc.as_mut_ptr(), ptr::null_mut(), 0) },
+        };
+
+        let pmix_status = PmixStatus::from_raw(status);
+        if pmix_status.is_success() {
+            let proc = unsafe { uninit_proc.assume_init() };
+            *proc_guard = Some(Proc {
+                handle: proc,
+                len: 1,
+            });
+            self.inner
+                .state
+                .store(PmixClientState::Live as u8, Ordering::Release);
+            Ok(())
+        } else if let Some(known) = pmix_status.known() {
+            Err(known)
+        } else {
+            Err(PmixError::Error)
+        }
+    }
+
+    /// Finalize PMIx for this process (`PMIx_Finalize`).
+    ///
+    /// Transitions `Live` → `Finalizing` → `Dead`. No-op if not `Live`
+    /// (already finalized or never connected).
+    pub fn disconnect(&self, info: Option<Info>) -> Result<(), pmix_status_t> {
+        let mut proc_guard = self
+            .inner
+            .proc
+            .lock()
+            .expect("pmix: client proc mutex poisoned");
+
+        if self.inner.state() != PmixClientState::Live {
+            return Ok(());
+        }
+
+        self.inner
+            .state
+            .store(PmixClientState::Finalizing as u8, Ordering::Release);
+        *proc_guard = None;
+
+        let status = match info {
+            Some(ref x) => unsafe { PMIx_Finalize(x.handle, x.len) },
+            None => unsafe { PMIx_Finalize(ptr::null_mut(), 0) },
+        };
+
+        self.inner
+            .state
+            .store(PmixClientState::Dead as u8, Ordering::Release);
+
+        if status as u32 == PMIX_SUCCESS {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+
+    /// Copy of the process handle when live.
+    pub fn proc(&self) -> Option<Proc> {
+        self.inner
+            .proc
+            .lock()
+            .expect("pmix: client proc mutex poisoned")
+            .clone()
+    }
+
+    /// Borrow-style access via clone of the cached `Proc` when live.
+    ///
+    /// Named for parity with [`Context::get_proc`]; returns owned `Proc`
+    /// because the cache lives behind a mutex.
+    pub fn get_proc(&self) -> Option<Proc> {
+        self.proc()
+    }
+
+    /// Rank from the cached process handle when live.
+    pub fn rank(&self) -> Option<u32> {
+        self.inner
+            .proc
+            .lock()
+            .expect("pmix: client proc mutex poisoned")
+            .as_ref()
+            .map(|p| p.get_rank())
+    }
+
+    /// Alias for [`rank`](Self::rank) matching [`Context::get_rank`] naming.
+    pub fn get_rank(&self) -> Option<u32> {
+        self.rank()
+    }
+
+    /// `Proc` for `rank` in this client's namespace.
+    ///
+    /// Returns [`PmixError::ErrInit`] if not connected.
+    pub fn proc_with_nspace(&self, rank: u32) -> Result<Proc, PmixError> {
+        let guard = self
+            .inner
+            .proc
+            .lock()
+            .expect("pmix: client proc mutex poisoned");
+        let my = guard.as_ref().ok_or(PmixError::ErrInit)?;
+        my.new_with_nspace(rank).map_err(|_| PmixError::ErrBadParam)
+    }
+
+    /// Error if the session is not [`PmixClientState::Live`].
+    pub fn check_live(&self) -> Result<(), PmixError> {
+        if self.is_live() {
+            Ok(())
+        } else {
+            Err(PmixError::ErrInit)
+        }
+    }
+}
+
+/// Legacy RAII client context — prefer [`PmixClient`] for multi-threaded code.
+///
+/// `Context` is retained for backward compatibility. It performs finalize in
+/// [`Drop`] via [`finalize`], which is coordinated with the process-wide
+/// [`PmixClient`] state machine (double-finalize becomes a no-op).
+///
+/// `Context` itself is not the shareable session type: clone/move a
+/// [`PmixClient`] across threads instead.
+
 pub struct Context {
     pub(crate) proc: Proc,
 }
@@ -3408,33 +3730,18 @@ impl Drop for Context {
     }
 }
 
+/// Initialize the process-wide PMIx client session and return a legacy [`Context`].
+///
+/// Prefer [`PmixClient::connect_new`] / [`PmixClient::connect`] for multi-threaded
+/// code. This function uses the same process session state machine as
+/// [`PmixClient`]; a second init while live returns [`PmixError::ErrExists`].
 pub fn init(info: Option<Info>) -> Result<Context, PmixError> {
-    let proc: pmix_proc_t;
-    let mut uninit_proc = mem::MaybeUninit::<pmix_proc_t>::uninit();
-    let status = match info {
-        Some(info) => unsafe { PMIx_Init(uninit_proc.as_mut_ptr(), info.handle, info.len) },
-        None => unsafe { PMIx_Init(uninit_proc.as_mut_ptr(), ptr::null_mut(), 0) },
-    };
-
-    let pmix_status = PmixStatus::from_raw(status);
-
-    if pmix_status.is_success() {
-        unsafe {
-            proc = uninit_proc.assume_init();
-        }
-        Ok(Context {
-            proc: Proc {
-                handle: proc,
-                len: 1,
-            },
-        })
-    } else {
-        if let Some(known) = pmix_status.known() {
-            Err(known)
-        } else {
-            Err(PmixError::Error)
-        }
-    }
+    let client = PmixClient::new();
+    client.connect(info)?;
+    let proc = client
+        .proc()
+        .expect("pmix: proc must be set after successful connect");
+    Ok(Context { proc })
 }
 
 pub fn get_value(proc: &Proc, key: &[u8], info: Option<Info>) -> Result<PmixOwnedValue, PmixError> {
@@ -3585,16 +3892,12 @@ pub fn progress_thread_stop() {
     }
 }
 
+/// Finalize the process-wide PMIx client session (`PMIx_Finalize`).
+///
+/// Delegates to [`PmixClient::disconnect`]. No-op if the session is not live.
+/// Prefer explicit [`PmixClient::disconnect`] when using [`PmixClient`].
 pub fn finalize(info: Option<Info>) -> Result<(), pmix_status_t> {
-    let status = match info {
-        Some(x) => unsafe { PMIx_Finalize(x.handle, x.len) },
-        None => unsafe { PMIx_Finalize(ptr::null_mut(), 0) },
-    };
-    if status as u32 == PMIX_SUCCESS {
-        Result::Ok(())
-    } else {
-        Result::Err(status)
-    }
+    PmixClient::new().disconnect(info)
 }
 
 #[cfg(test)]
@@ -5088,5 +5391,86 @@ mod tests {
         let info = opts.build();
         // 5 options set
         assert_eq!(info.len(), 5);
+    }
+
+    // ── PmixClient (process-wide Arc session) ─────────────────────────────
+
+    #[test]
+    fn test_pmixclient_send_sync_clone() {
+        use static_assertions::assert_impl_all;
+        assert_impl_all!(PmixClient: Clone, Send, Sync);
+        assert_impl_all!(PmixClientState: Send, Sync);
+    }
+
+    #[test]
+    fn test_pmixclient_new_is_uninitialized_or_consistent() {
+        let client = PmixClient::new();
+        // Fresh process in unit tests: Uninitialized. If another test already
+        // connected (unlikely without daemon), state is still well-formed.
+        let state = client.state();
+        assert!(
+            matches!(
+                state,
+                PmixClientState::Uninitialized
+                    | PmixClientState::Live
+                    | PmixClientState::Finalizing
+                    | PmixClientState::Dead
+            )
+        );
+        assert_eq!(client.is_live(), state == PmixClientState::Live);
+    }
+
+    #[test]
+    fn test_pmixclient_process_wide_same_session() {
+        let a = PmixClient::new();
+        let b = PmixClient::new();
+        let c = a.clone();
+        assert!(a.same_session(&b));
+        assert!(a.same_session(&c));
+        assert_eq!(a.state(), b.state());
+    }
+
+    #[test]
+    fn test_pmixclient_clone_moves_to_thread() {
+        let client = PmixClient::new();
+        let state = client.state();
+        let worker = client.clone();
+        let handle = std::thread::spawn(move || worker.state());
+        assert_eq!(handle.join().expect("thread join"), state);
+    }
+
+    #[test]
+    fn test_pmixclient_accessors_none_when_not_live() {
+        let client = PmixClient::new();
+        if client.is_live() {
+            return;
+        }
+        assert!(client.proc().is_none());
+        assert!(client.get_proc().is_none());
+        assert!(client.rank().is_none());
+        assert!(client.check_live().is_err());
+        assert!(client.proc_with_nspace(0).is_err());
+    }
+
+    #[test]
+    fn test_pmixclient_disconnect_noop_when_not_live() {
+        let client = PmixClient::new();
+        if client.is_live() {
+            return;
+        }
+        let before = client.state();
+        assert!(client.disconnect(None).is_ok());
+        assert_eq!(client.state(), before);
+    }
+
+    #[test]
+    fn test_finalize_delegates_to_session_noop_when_not_live() {
+        let client = PmixClient::new();
+        if client.is_live() {
+            return;
+        }
+        let before = client.state();
+        assert!(finalize(None).is_ok());
+        assert_eq!(PmixClient::new().state(), before);
     }
 }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -43,6 +43,9 @@ use std::sync::{LazyLock, Mutex};
 use crate::ffi;
 use crate::{Info, PmixError, PmixStatus};
 
+#[cfg(any(test, feature = "mock_ffi"))]
+use crate::mock_ffi;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixQuery — safe Rust wrapper around `pmix_query_t`
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/server/cred.rs
+++ b/src/server/cred.rs
@@ -3,6 +3,7 @@
 use super::*;
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
+use crate::security::PmixCredential;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_Get_credential — get credential (server context)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -59,7 +59,6 @@ use std::sync::{LazyLock, Mutex};
 use crate::mock_ffi;
 
 
-#[cfg(any(test, feature = "mock_ffi"))]
 mod pset;
 mod data;
 mod cred;

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -150,7 +150,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_handle_debug_format() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let debug_str = format!("{:?}", handle);
         assert!(!debug_str.is_empty(), "Debug output should not be empty");
         assert!(debug_str.starts_with("PmixServerHandle"));
@@ -158,8 +158,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_handle_construction() {
-        let handle = PmixServerHandle { initialized: true };
-        assert!(handle.initialized);
+        let handle = PmixServerHandle { active: true };
+        assert!(handle.active);
     }
 
     // ── is_server_initialized tests ──────────────────────────────────────────
@@ -364,7 +364,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     #[test]
     fn test_server_connect_rejects_empty_procs() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_connect(&handle, &[], &[]);
         assert!(
             result.is_err(),
@@ -374,7 +374,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_disconnect_rejects_empty_procs() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_disconnect(&handle, &[], &[]);
         assert!(
             result.is_err(),
@@ -437,7 +437,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     // ── server_connect_nb error path ─────────────────────────────────────────
     #[test]
     fn test_server_connect_nb_rejects_empty_procs() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let wrapper = FenceNbCallbackWrapper::new(|_status: PmixStatus| {});
         let result = server_connect_nb(&handle, &[], &[], wrapper);
         assert!(result.is_err(), "connect_nb should reject empty proc list");
@@ -447,7 +447,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_disconnect_nb_rejects_empty_procs() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let wrapper = FenceNbCallbackWrapper::new(|_status: PmixStatus| {});
         let result = server_disconnect_nb(&handle, &[], &[], wrapper);
         assert!(
@@ -573,14 +573,14 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_handle_initialized_true() {
-        let handle = PmixServerHandle { initialized: true };
-        assert!(handle.initialized);
+        let handle = PmixServerHandle { active: true };
+        assert!(handle.active);
     }
 
     #[test]
     fn test_server_handle_initialized_false() {
-        let handle = PmixServerHandle { initialized: false };
-        assert!(!handle.initialized);
+        let handle = PmixServerHandle { active: false };
+        assert!(!handle.active);
     }
 
     // ── Registry and sequence counter tests ────────────────────────────────
@@ -1089,7 +1089,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_handle_debug_format_false() {
-        let handle = PmixServerHandle { initialized: false };
+        let handle = PmixServerHandle { active: false };
         let debug_str = format!("{:?}", handle);
         assert!(debug_str.contains("PmixServerHandle"));
         assert!(debug_str.contains("false"));
@@ -1214,7 +1214,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_delete_rejects_nul_in_key() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_delete(&handle, "testnspace", "test\0key");
         assert!(
             result.is_err(),
@@ -1224,7 +1224,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_delete_empty_key() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         // Empty key is valid (no NUL), but will fail on FFi without init.
         // We just verify it doesn't panic on the CString::new path.
         let result = server_delete(&handle, "testnspace", "");
@@ -1236,7 +1236,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_lookup_empty_key() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_lookup(&handle, "testnspace", "", &[]);
         // Empty key is technically valid input — FFi will fail without init.
         let _ = result;
@@ -1244,7 +1244,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_lookup_long_key_truncated() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         // Key longer than 511 chars should be silently truncated by the
         // implementation (pdata.key is fixed-size).
         let long_key = "a".repeat(600);
@@ -1256,7 +1256,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_publish_empty_info() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_publish(&handle, "testnspace", &info);
         let _ = result;
@@ -1266,7 +1266,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_fence_zero_timeout() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_fence(&handle, &[], 0);
         let _ = result;
     }
@@ -1426,8 +1426,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_handle_multiple_constructions() {
-        let h1 = PmixServerHandle { initialized: true };
-        let h2 = PmixServerHandle { initialized: false };
+        let h1 = PmixServerHandle { active: true };
+        let h2 = PmixServerHandle { active: false };
         let d1 = format!("{:?}", h1);
         let d2 = format!("{:?}", h2);
         assert!(d1.contains("true"));
@@ -1438,7 +1438,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_connect_rejects_empty_procs_with_info() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_connect(&handle, &[], &[info]);
         assert!(result.is_err());
@@ -1446,7 +1446,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_server_disconnect_rejects_empty_procs_with_info() {
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_disconnect(&handle, &[], &[info]);
         assert!(result.is_err());
@@ -2575,7 +2575,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_publish_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_publish(&handle, "test.nspace", &info);
         assert!(result.is_ok(), "server_publish wrapper should succeed with mocks");
@@ -2586,7 +2586,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_publish", crate::mock_ffi::PMIX_ERR_NOT_FOUND);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_publish(&handle, "test.nspace", &info);
         assert!(result.is_err(), "server_publish wrapper should fail with configured error");
@@ -2596,7 +2596,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[ignore] // Mock returns success but doesn't populate pdata.value, so wrapper returns ErrNotFound
     fn test_mock_wrapper_server_lookup_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_lookup(&handle, "test.nspace", "test_key", &[]);
         assert!(result.is_ok(), "server_lookup wrapper should succeed with mocks");
     }
@@ -2604,7 +2604,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_lookup_returns_error_with_default_mocks() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_lookup(&handle, "test.nspace", "missing_key", &[]);
         // Default mock returns PMIX_ERR_NOT_FOUND for lookup
         assert!(result.is_err(), "server_lookup wrapper should fail for missing key with mocks");
@@ -2613,7 +2613,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_delete_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_delete(&handle, "test.nspace", "test_key");
         assert!(result.is_ok(), "server_delete wrapper should succeed with mocks");
     }
@@ -2623,7 +2623,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_delete", crate::mock_ffi::PMIX_ERR_NOT_FOUND);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_delete(&handle, "test.nspace", "test_key");
         assert!(result.is_err(), "server_delete wrapper should fail with configured error");
     }
@@ -2631,7 +2631,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_fence_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_fence(&handle, &[], 5000);
         assert!(result.is_ok(), "server_fence wrapper should succeed with mocks");
     }
@@ -2641,7 +2641,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_fence", crate::mock_ffi::PMIX_ERR_TIMEOUT);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_fence(&handle, &[], 5000);
         assert!(result.is_err(), "server_fence wrapper should fail with configured error");
     }
@@ -2649,7 +2649,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_connect_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let procs = vec![Proc::new("test.nspace", 0).unwrap()];
         let result = server_connect(&handle, &procs, &[]);
         assert!(result.is_ok(), "server_connect wrapper should succeed with mocks");
@@ -2658,7 +2658,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_connect_rejects_empty_procs() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_connect(&handle, &[], &[]);
         assert!(result.is_err(), "server_connect wrapper should reject empty procs");
     }
@@ -2668,7 +2668,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_fence", crate::mock_ffi::PMIX_ERR_TIMEOUT);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let procs = vec![Proc::new("test.nspace", 0).unwrap()];
         let result = server_connect(&handle, &procs, &[]);
         assert!(result.is_err(), "server_connect wrapper should fail with configured error");
@@ -2677,7 +2677,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_disconnect_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let procs = vec![Proc::new("test.nspace", 0).unwrap()];
         let result = server_disconnect(&handle, &procs, &[]);
         assert!(result.is_ok(), "server_disconnect wrapper should succeed with mocks");
@@ -2686,7 +2686,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_disconnect_rejects_empty_procs() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let result = server_disconnect(&handle, &[], &[]);
         assert!(result.is_err(), "server_disconnect wrapper should reject empty procs");
     }
@@ -2696,7 +2696,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_fence", crate::mock_ffi::PMIX_ERR_TIMEOUT);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let procs = vec![Proc::new("test.nspace", 0).unwrap()];
         let result = server_disconnect(&handle, &procs, &[]);
         assert!(result.is_err(), "server_disconnect wrapper should fail with configured error");
@@ -2802,7 +2802,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_tool_attach_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_tool_attach_to_server(&handle, None, false, &info);
         assert!(result.is_ok(), "server_tool_attach_to_server wrapper should succeed with mocks");
@@ -2813,7 +2813,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_tool_attach_to_server", crate::mock_ffi::PMIX_ERR_BAD_PARAM);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = crate::InfoBuilder::new().build();
         let result = server_tool_attach_to_server(&handle, None, false, &info);
         assert!(result.is_err(), "server_tool_attach_to_server should fail with configured error");
@@ -2822,7 +2822,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_mock_wrapper_server_get_credential_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = vec![];
         let result = server_get_credential(&handle, &info);
         assert!(result.is_ok(), "server_get_credential wrapper should succeed with mocks");
@@ -2833,7 +2833,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let config = crate::mock_ffi::MockConfig::new()
             .with_function_status("PMIx_server_get_credential", crate::mock_ffi::PMIX_ERR_NOT_FOUND);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let handle = PmixServerHandle { initialized: true };
+        let handle = PmixServerHandle { active: true };
         let info = vec![];
         let result = server_get_credential(&handle, &info);
         assert!(result.is_err(), "server_get_credential should fail with configured error");


### PR DESCRIPTION
## Phase 2a — Client session (rewrite)

Parent plan: `THREADPLAN.md` §6–7 Phase 2 / Closes #48

### Design decision

Arc is correct **for the process-wide session handle**, not as a blanket MT story.

| Layer | Approach |
|--------|----------|
| Session | Library-owned `PmixClient` — one process-wide `Arc` inner |
| C entry MT | Trust OpenPMIx ≥ 6.1 threadshift; no global op mutex by default |
| Owned C handles (`Info`, …) | Stay `!Send`/`!Sync`; app builds per-call or wraps itself |
| Data ops | Remain free functions (`put_value` / `get_value` / …) |

### What was wrong in the first PR attempt

1. `PhantomData<*mut u8>` on `PmixClientInner` made `Arc`/`PmixClient` **`!Send`**, so clones could not move to other threads
2. Each `PmixClient::new()` created a **fresh** Arc — not process-wide; double-init still possible
3. Duplicated put/get/commit/fence on the client (~450 LOC of API surface)

### What this rewrite does

- **`PmixClient`**: `Clone` via process-wide `OnceLock<Arc<Inner>>`; **`Send + Sync`**
- **State machine**: `Uninitialized → Live → Finalizing → Dead` under session mutex for connect/disconnect
- **Thin API**: `new` / `connect` / `connect_new` / `disconnect` / `proc` / `rank` / `proc_with_nspace` / `check_live` / `same_session`
- **No Drop finalize** on `PmixClient` (avoids double-finalize with clones); explicit `disconnect`
- **Legacy** `init` / `finalize` / `Context::Drop` share the same session SM
- **Tests**: Send+Sync asserts, process-wide identity, clone-to-thread, accessors, disconnect/finalize no-op when not live

### Incidental main fixes (required to build/test)

- `server::pset` always compiled (was cfg-gated while still `pub use`d)
- Removed stray `#[cfg]` in `fabric.rs` that hid `PmixFabric` in non-test builds
- `query_log`: `use crate::mock_ffi` under test
- `server` tests: `PmixServerHandle.active` field name

### Acceptance

- [x] `PmixClient: Clone + Send + Sync`
- [x] Multi-thread compile/runtime: clone moves to worker thread
- [x] Drop/finalize rules documented — single logical finalize, no auto-finalize on `PmixClient` Drop
- [x] Process-wide session (all handles share one inner)
- [x] Unit tests under lib

### Test plan

```bash
export PMIX_PREFIX=/path/to/openpmix-or-prrte-install
cargo test --lib pmixclient
cargo check --lib
```