### PR TITLE
breaking: remove Context/init — PmixClient-only client API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ See also: [`../BUILDING.md`](../BUILDING.md).
 use std::ffi::CString;
 
 fn main() {
-    let ctx = pmix::init(None).expect("init");
+    let client = pmix::PmixClient::connect_new(None).expect("connect");
+    let proc = client.require_proc();
 
     let key = CString::new("my_key").unwrap();
     let mut value = pmix::PmixValueBuilder::new()
@@ -47,13 +48,14 @@ fn main() {
     pmix::put_value(pmix::PmixScope::Global.to_raw(), &key, &mut value)
         .expect("put");
     pmix::commit().expect("commit");
-    pmix::fence(ctx.get_proc(), None).expect("fence");
+    pmix::fence(&proc, None).expect("fence");
 
-    match pmix::get_value(ctx.get_proc(), b"my_key\0", None) {
+    match pmix::get_value(&proc, b"my_key\0", None) {
         Ok(_) => println!("got value"),
         Err(e) => println!("get: {e:?}"),
     }
-    // Context drop → finalize
+
+    client.disconnect(None).expect("disconnect");
 }
 ```
 

--- a/THREADING.md
+++ b/THREADING.md
@@ -1,274 +1,114 @@
 # Threading Model & Send/Sync Inventory
 
-**Date:** 2026-07-18
-**Related:** [THREADPLAN.md](./THREADPLAN.md) — parent plan
-**Issue:** [#45](https://github.com/SedahsDev/pmix-rs/issues/45)
+**Date:** 2026-07-27  
+**Issues:** [#64](https://github.com/SedahsDev/pmix-rs/issues/64), [#45](https://github.com/SedahsDev/pmix-rs/issues/45)  
+**Related:** [#49](https://github.com/SedahsDev/pmix-rs/issues/49)–[#52](https://github.com/SedahsDev/pmix-rs/issues/52), [#54](https://github.com/SedahsDev/pmix-rs/issues/54), [#66](https://github.com/SedahsDev/pmix-rs/issues/66)–[#67](https://github.com/SedahsDev/pmix-rs/issues/67)
+
+Crate-root docs in `src/lib.rs` (`//! # Concurrency model`) match this document.
 
 ---
 
-## 1. OpenPMIx Version Assumption
+## 1. Strategy (one-liner)
 
-**This crate assumes OpenPMIx ≥ 6.1.**
+| Layer | Policy |
+|--------|--------|
+| **Session** | Process-wide `OnceLock<Arc<Inner>>`. Handle is **`Clone + Send + Sync`**. **No** `PhantomData<*mut u8>` on the session Inner. |
+| **Client API** | **`PmixClient` only** — no legacy `Context` / `init()`. Explicit `connect` / `disconnect`. **Drop never finalizes.** |
+| **C API entry** | Trust OpenPMIx **≥ 6.1** threadshift. No global op mutex by default. |
+| **C-owned handles** | `Info`, buffers, fabric, … → **`!Send + !Sync`**. Prefer build-per-call. |
+| **Data ops** | Free functions (`put_value`, `get_value`, `commit`, `fence`, `data_ops::*`, …). |
+| **Callbacks / upcalls** | PMIx **progress thread**. No blocking PMIx in-handler (#51, #52, #67). |
 
-From the [OpenPMIx 6.1.0 NEWS](https://github.com/openpmix/openpmix/blob/v6.1.0/docs/news/news-v6.x.rst):
-
-> *all APIs are now threadshifted prior to execution for thread safety. Hosts that are providing their own progress engine (in lieu of using the PMIx internal progress thread) must ensure that progress is being provided sufficient to avoid threadlock when calling PMIx APIs.*
-
-**What this means for pmix-rs callers:**
-
-| Layer | Who serializes? | Implication |
-|-------|-----------------|-------------|
-| C library entry | OpenPMIx `PMIX_THREADSHIFT` onto internal `evbase` / progress thread | Multiple Rust threads **may** call most `PMIx_*` APIs concurrently, provided the progress engine is running |
-| Progress engine | One (or more) internal progress thread(s), or the host via `PMIx_Progress` | Without progress, non-blocking ops and many blocking ops can deadlock |
-| Rust wrappers | **Not** currently designed for multi-thread sharing of owned handles | Even if C is MT-safe, Rust types with raw pointers / process-global state still need `Arc<Mutex<T>>` wrappers for shared access |
-| Callbacks / server module | Delivered on **PMIx progress thread** (not the caller's thread) | Handlers must not block; blocking APIs need an app-side thread shift |
-
-**If you link against OpenPMIx < 6.1**, most APIs are **not** internally serialized. In that case, all `PMIx_*` calls must be externally synchronized (single-threaded or mutex-guarded).
+**Anti-pattern:** `PhantomData<*mut u8>` on `PmixClientInner` while advertising multi-thread clones.
 
 ---
 
-## 2. Public Type Inventory
+## 2. OpenPMIx ≥ 6.1
 
-Every public Rust type with its intended `Send` / `Sync` status.
-
-### 2.1 Definitely `!Send` / `!Sync` (raw handle wrappers)
-
-These types wrap raw pointers to PMIx-allocated memory or process-global state. They must **not** be shared across threads without a `Mutex`.
-
-| Type | Location | Rationale |
-|------|----------|-----------|
-| `Info` | `src/lib.rs:2932` | Wraps `*mut pmix_info_t` — PMIx-allocated array |
-| `InfoBuilder` | `src/lib.rs:2998` | Owns `Vec<InfoEntry>` with `CString` keys — pre-build state, not MT-safe to share mid-build |
-| `Context` | `src/lib.rs:3098` | Wraps `*mut pmix_proc_t` — process-global init state |
-| `PmixOwnedValue` | `src/lib.rs:2847` | Wraps `*mut pmix_value_t` — PMIx-allocated value |
-| `Proc` | `src/lib.rs:2927` | Wraps `*mut pmix_proc_t` — PMIx-allocated proc identifier |
-| `PmixServerHandle` | `src/server/mod.rs:295` | Tracks server init state — process-global singleton |
-| `PmixToolHandle` | `src/tool.rs:65` | Wraps tool connection state — process-global |
-| `PmixCredential` | `src/security.rs:56` | Wraps `*mut pmix_credential_t` — PMIx-allocated credential |
-| `PmixByteObject` | `src/data_serialization.rs:97` | Wraps `pmix_byte_object_t` with PMIx-allocated buffer |
-| `PmixDataBuffer` | `src/data_serialization.rs:211` | Wraps `*mut pmix_data_buffer_t` — PMIx-allocated buffer |
-| `PmixProcRef` | `src/data_serialization.rs:63` | Borrowed `&'a Proc` — inherits Proc's thread constraints |
-| `AllocationResults` | `src/allocation.rs:160` | Wraps PMIx-allocated job/id strings |
-| `JobControlResults` | `src/allocation.rs:529` | Wraps PMIx-allocated result strings |
-| `SessionControlResults` | `src/allocation.rs:853` | Wraps PMIx-allocated result data |
-| `MonitorResults` | `src/monitoring.rs:66` | Wraps PMIx-allocated monitoring data |
-| `QueryResults` | `src/query_log.rs:232` | Wraps `*mut pmix_info_t` array |
-| `CredentialResults` | `src/security.rs:320` | Wraps PMIx-allocated credential |
-| `ValidationResults` | `src/security.rs:546` | Wraps PMIx-allocated validation data |
-| `PmixFabric` | `src/fabric.rs:85` | Wraps `*mut pmix_fabric_t` — PMIx-allocated |
-| `PmixTopology` | `src/fabric.rs:611` | Wraps `*mut pmix_topology_t` — PMIx-allocated |
-| `PmixCpuset` | `src/fabric.rs:728` | Wraps `*mut pmix_cpuset_t` — PMIx-allocated |
-| `DeviceDistances` | `src/fabric.rs:914` | Wraps `*mut pmix_device_distances_t` — PMIx-allocated |
-| `SpawnCallbackWrapper` | `src/process_mgmt.rs:486` | Boxed callback + cbdata — not MT-safe to share |
-| `ConnectCallbackWrapper` | `src/process_mgmt.rs:774` | Boxed callback + cbdata |
-| `DisconnectCallbackWrapper` | `src/process_mgmt.rs:996` | Boxed callback + cbdata |
-| `GroupConstructCallbackWrapper` | `src/groups.rs:120` | Boxed callback + cbdata |
-| `GroupInviteCallbackWrapper` | `src/groups.rs:329` | Boxed callback + cbdata |
-| `GroupJoinCallbackWrapper` | `src/groups.rs:535` | Boxed callback + cbdata |
-| `GroupLeaveCallbackWrapper` | `src/groups.rs:689` | Boxed callback + cbdata |
-| `GroupDestructCallbackWrapper` | `src/groups.rs:811` | Boxed callback + cbdata |
-
-### 2.2 Pure Rust / Copy types — `Send + Sync`
-
-These types contain no raw pointers to PMIx-allocated memory. They are safe to share across threads.
-
-| Type | Location | Rationale |
-|------|----------|-----------|
-| `PmixError` | `src/lib.rs:81` | Pure Rust enum with owned strings |
-| `PmixStatus` | `src/lib.rs:406` | Newtype around `i32`, derives Copy |
-| `PmixProcState` | `src/lib.rs:729` | Pure Rust enum |
-| `PmixScope` | `src/lib.rs:958` | Pure Rust enum |
-| `PmixJobState` | `src/lib.rs:1045` | Pure Rust enum |
-| `PmixLinkState` | `src/lib.rs:1160` | Pure Rust enum |
-| `PmixDeviceType` | `src/lib.rs:1237` | Pure Rust enum |
-| `PmixPersistence` | `src/lib.rs:1325` | Pure Rust enum |
-| `PmixDataRange` | `src/lib.rs:1412` | Pure Rust enum |
-| `PmixDataType` | `src/lib.rs:1515` | Pure Rust enum |
-| `PmixAllocDirective` | `src/lib.rs:1966` | Pure Rust enum |
-| `IOFChannelFlags` | `src/lib.rs:2018` | Newtype around `u16` |
-| `BuilderError` | `src/lib.rs:2090` | Pure Rust enum |
-| `ValueError` | `src/lib.rs:2136` | Pure Rust enum |
-| `PmixTimeval` | `src/lib.rs:2177` | Pure Rust struct with two `i64` fields |
-| `PmixEnvar` | `src/lib.rs:2200` | Pure Rust struct with `String` fields |
-| `InfoFlags` | `src/lib.rs:2264` | Newtype around `u32` |
-| `PmixPayload` | `src/lib.rs:2311` | Pure Rust enum with owned data |
-| `PmixValueBuilder` | `src/lib.rs:2420` | Pure Rust builder (no raw pointers) |
-| `PmixApp` | `src/process_mgmt.rs:162` | Pure Rust struct with `String`/`Vec<String>` fields |
-| `PmixAppBuilder` | `src/process_mgmt.rs:219` | Pure Rust builder |
-| `PmixQuery` | `src/query_log.rs:63` | Pure Rust struct |
-| `PmixDeviceDistance` | `src/fabric.rs:822` | Pure Rust struct with `u16` fields |
-| `PmixBindEnvelope` | `src/cpu_locality.rs:38` | Pure Rust enum |
-| `PmixLocality` | `src/cpu_locality.rs:199` | Bitflags struct, `Send + Sync` |
-| `PmixPrintOutput` | `src/data_serialization.rs:837` | Pure Rust struct with owned strings |
-| `PmixJobCtrlAction` | `src/allocation.rs:476` | Pure Rust enum |
-
-### 2.3 Type aliases — inherit constraints
-
-| Alias | Location | Underlying type | Constraint |
-|-------|----------|-----------------|------------|
-| `EventHandlerRef` | `src/events.rs:62` | `usize` | `Send + Sync` (just an integer) |
-| `NotificationFn` | `src/events.rs:93` | `Option<unsafe extern "C" fn(...)>` | `Send + Sync` (function pointers are) |
-| `HandlerRegCbFn` | `src/events.rs:122` | `unsafe extern "C" fn(...)` | `Send + Sync` (function pointer) |
-| `OpCbFn` | `src/events.rs:131` | `Option<unsafe extern "C" fn(...)>` | `Send + Sync` (function pointer) |
-| `SpawnCallback` | `src/process_mgmt.rs:322` | `unsafe extern "C" fn(...)` | `Send + Sync` (function pointer) |
-
-### 2.4 Summary
-
-| Category | Count | Send/Sync |
-|----------|-------|-----------|
-| Raw handle wrappers | 26 | `!Send`, `!Sync` |
-| Pure Rust types | 25 | `Send + Sync` |
-| Type aliases | 4 | `Send + Sync` (function pointers / integers) |
-
-**Recommendation:** Add `PhantomData<*mut u8>` fields to all 26 raw-handle types to enforce `!Send`/`!Sync` at compile time. See PR #42 for the pattern already applied to `Info`.
+Threadshift on C entry. Progress must run (internal thread or `external_progress` + `pmix::progress()`). Pre-6.1 needs external sync (unsupported default).
 
 ---
 
-## 3. FFI Bridge Inventory
+## 3. `PmixClient` (only client session)
 
-Every `extern "C"` bridge function in pmix-rs, categorized by thread context.
+| Property | Behavior |
+|----------|----------|
+| Storage | `OnceLock<Arc<PmixClientInner>>` |
+| Auto-traits | **`Clone + Send + Sync`** (asserted) |
+| State | `Uninitialized → Live → Finalizing → Dead` |
+| Connect | `PmixClient::connect_new(info)` or `new()` + `connect` |
+| Disconnect | `client.disconnect(info)` or free-fn `finalize(info)` |
+| Drop | **No** finalize |
+| Identity | `proc()` / `require_proc()` / `rank()` / `require_rank()` |
 
-### 3.1 Client-side API calls (runs on caller thread → threadshifted by OpenPMIx ≥ 6.1)
+```rust
+let client = pmix::PmixClient::connect_new(None)?;
+let w = client.clone();
+std::thread::spawn(move || { let _ = w.rank(); });
+client.disconnect(None)?;
+```
 
-These are Rust functions that call `ffi::PMIx_*`. On OpenPMIx ≥ 6.1, the C side threadshifts to the progress thread internally.
+### Server / tool
 
-| Function | File | FFI Call |
-|----------|------|----------|
-| `init()` | `src/lib.rs:3135` | `PMIx_Init` |
-| `finalize()` | `src/lib.rs:3267` | `PMIx_Finalize` |
-| `fence()` | `src/lib.rs:3244` | `PMIx_Fence` |
-| `is_initialized()` | `src/utility/mod.rs:46` | `PMIx_Initialized` |
-| `publish()` | `src/data_ops/mod.rs` | `PMIx_Publish` |
-| `get_value()` | `src/data_ops/mod.rs` | `PMIx_Get` |
-| `lookup()` | `src/data_ops/mod.rs` | `PMIx_Lookup_nspace` |
-| `unpublish()` | `src/data_ops/mod.rs` | `PMIx_Unpublish` |
-| `fence_nb()` | `src/data_ops/mod.rs` | `PMIx_Fence_nb` |
-| `spawn()` | `src/process_mgmt.rs:452` | `PMIx_Spawn` |
-| `connect()` | `src/server/data.rs:470` | `PMIx_Connect` |
-| `disconnect()` | `src/server/data.rs` | `PMIx_Disconnect` |
-| `resolve_peers()` | `src/process_mgmt.rs:1173` | `PMIx_Resolve_peers` |
-| `resolve_nodes()` | `src/process_mgmt.rs:1250` | `PMIx_Resolve_nodes` |
-| `fabric_register()` | `src/fabric.rs:275` | `PMIx_Fabric_register` |
-| `fabric_update()` | `src/fabric.rs:427` | `PMIx_Fabric_update` |
-| `fabric_update_nb()` | `src/fabric.rs:470` | `PMIx_Fabric_update_nb` |
-| `fabric_deregister()` | `src/fabric.rs:516` | `PMIx_Fabric_deregister` |
-| `load_topology()` | `src/fabric.rs:1059` | `PMIx_Load_topology` |
-| `register_event_handler()` | `src/events.rs` | `PMIx_Register_event_handler` |
-| `deregister_event_handler()` | `src/events.rs:382` | `PMIx_Deregister_event_handler` |
-| `notify_event()` | `src/events.rs` | `PMIx_Notify_event` |
-| `server_init()` | `src/server/mod.rs` | `PMIx_server_init` |
-| `server_finalize()` | `src/server/mod.rs:322` | `PMIx_server_finalize` |
-| `tool_init()` | `src/tool.rs` | `PMIx_tool_init` |
-| `tool_finalize()` | `src/tool.rs` | `PMIx_tool_finalize` |
-| `tool_is_connected()` | `src/tool.rs:794` | `PMIx_tool_is_connected` |
-| `group_construct()` | `src/groups.rs` | `PMIx_Group_construct` |
-| `group_invite()` | `src/groups.rs` | `PMIx_Group_invite` |
-| `group_join()` | `src/groups.rs` | `PMIx_Group_join` |
-| `group_leave()` | `src/groups.rs:674` | `PMIx_Group_leave` |
-| `group_destruct()` | `src/groups.rs:796` | `PMIx_Group_destruct` |
-| `register_nspace()` | `src/server/mod.rs` | `PMIx_server_register_nspace` |
-| `deregister_nspace()` | `src/server/mod.rs` | `PMIx_server_deregister_nspace` |
-| `register_client()` | `src/server/mod.rs` | `PMIx_server_register_client` |
-| `deregister_client()` | `src/server/mod.rs` | `PMIx_server_deregister_client` |
-| `job_control()` | `src/allocation.rs` | `PMIx_server_job_control` |
-| `allocate()` | `src/allocation.rs` | `PMIx_server_allocate` |
-| `session_control()` | `src/allocation.rs` | `PMIx_server_session_control` |
-| `monitor()` | `src/monitoring.rs` | `PMIx_server_monitor` |
-| `query()` | `src/query_log.rs` | `PMIx_Query` |
-| `log()` | `src/query_log.rs` | `PMIx_Log` |
-| `get_credential()` | `src/security.rs` | `PMIx_server_get_credential` |
-| `validate_credential()` | `src/security.rs` | `PMIx_server_validate_credential` |
-| `iof_channel_register()` | `src/utility/mod.rs` | `PMIx_IOF_channel_register` |
-| `iof_channel_deregister()` | `src/utility/mod.rs` | `PMIx_IOF_channel_deregister` |
-| `iof_push()` | `src/utility/mod.rs` | `PMIx_IOF_push` |
-| `iof_pull()` | `src/utility/mod.rs` | `PMIx_IOF_pull` |
-| `pdata_construct()` | `src/server/data.rs:127` | `PMIx_Pdata_construct` |
-| `pdata_destruct()` | `src/server/data.rs:175` | `PMIx_Pdata_destruct` |
-| `data_buffer_create()` | `src/data_serialization.rs:309` | `PMIx_Data_buffer_create` |
-| `data_buffer_release()` | `src/data_serialization.rs:262` | `PMIx_Data_buffer_release` |
-| `byte_object_destruct()` | `src/data_serialization.rs:175` | `PMIx_Byte_object_destruct` |
-| `data_unload()` | `src/data_serialization.rs:584` | `PMIx_Data_unload` |
-| `data_copy_payload()` | `src/data_serialization.rs:716` | `PMIx_Data_copy_payload` |
-| `app_create()` | `src/process_mgmt.rs:360` | `PMIx_App_create` |
-| `app_free()` | `src/process_mgmt.rs:374` | `PMIx_App_free` |
-| `topology_destruct()` | `src/fabric.rs:701` | `PMIx_Topology_destruct` |
-| `cpuset_construct()` | `src/fabric.rs:751` | `PMIx_Cpuset_construct` |
-| `cpuset_destruct()` | `src/fabric.rs:797` | `PMIx_Cpuset_destruct` |
-
-### 3.2 Callback bridges (runs on PMIx progress thread)
-
-These `extern "C"` functions are invoked by the PMIx library as callbacks. They run on the **PMIx internal progress thread**, NOT the caller's thread.
-
-| Bridge | File | Invoked by |
-|--------|------|------------|
-| `notification_bridge` | `src/events.rs:143` | PMIx notification delivery |
-| `publish_callback_bridge` | `src/data_ops/mod.rs:89` | `PMIx_server_publish` upcall |
-| `get_value_callback_bridge` | `src/data_ops/mod.rs:212` | `PMIx_Get` completion |
-| `lookup_callback_bridge` | `src/data_ops/mod.rs:634` | `PMIx_Lookup_nspace` completion |
-| `unpublish_callback_bridge` | `src/data_ops/mod.rs:854` | `PMIx_Unpublish` completion |
-| `fence_callback_bridge` | `src/data_ops/mod.rs:1177` | `PMIx_Fence_nb` completion |
-| `spawn_callback_bridge` | `src/process_mgmt.rs:539` | `PMIx_Spawn` completion |
-| `connect_callback_bridge` | `src/process_mgmt.rs:826` | `PMIx_Connect` completion |
-| `disconnect_callback_bridge` | `src/process_mgmt.rs:1048` | `PMIx_Disconnect` completion |
-| `fabric_register_cb` | `src/fabric.rs:334` | `PMIx_Fabric_register` completion |
-| `fabric_update_cb` | `src/fabric.rs:462` | `PMIx_Fabric_update_nb` completion |
-| `fabric_deregister_cb` | `src/fabric.rs:561` | `PMIx_Fabric_deregister` completion |
-| `compute_distances_cb` | `src/fabric.rs:1247` | Distance computation completion |
-| `group_construct_callback_bridge` | `src/groups.rs:145` | `PMIx_Group_construct` upcall |
-| `group_invite_callback_bridge` | `src/groups.rs:352` | `PMIx_Group_invite` upcall |
-| `group_join_callback_bridge` | `src/groups.rs:560` | `PMIx_Group_join` upcall |
-| `group_leave_callback_bridge` | `src/groups.rs:715` | `PMIx_Group_leave` completion |
-| `group_destruct_callback_bridge` | `src/groups.rs:837` | `PMIx_Group_destruct` completion |
-| `allocation_callback_bridge` | `src/allocation.rs:303` | `PMIx_server_allocate` completion |
-| `job_control_callback_bridge` | `src/allocation.rs:669` | `PMIx_server_job_control` completion |
-| `session_control_callback_bridge` | `src/allocation.rs:860` | `PMIx_server_session_control` completion |
-| `monitor_callback_bridge` | `src/monitoring.rs:136` | `PMIx_server_monitor` upcall |
-| `query_callback_bridge` | `src/query_log.rs:357` | `PMIx_Query` completion |
-| `log_callback_bridge` | `src/query_log.rs:566` | `PMIx_Log` completion |
-| `credential_callback_bridge` | `src/security.rs:366` | Credential request completion |
-| `validation_callback_bridge` | `src/security.rs:700` | Validation completion |
-| `reg_callback_bridge` | `src/utility/mod.rs:1048` | IOF register completion |
-| `dereg_callback_bridge` | `src/utility/mod.rs:1259` | IOF deregister completion |
-| `push_callback_bridge` | `src/utility/mod.rs:1550` | IOF push completion |
-| `io_callback_bridge` | `src/utility/mod.rs:999` | IOF delivery |
-| `register_nspace_callback_bridge` | `src/server/mod.rs:538` | `PMIx_server_register_nspace` completion |
-| `deregister_nspace_callback_bridge` | `src/server/mod.rs:753` | `PMIx_server_deregister_nspace` completion |
-| `register_client_callback_bridge` | `src/server/mod.rs:914` | `PMIx_server_register_client` completion |
-| `deregister_client_callback_bridge` | `src/server/mod.rs:1086` | `PMIx_server_deregister_client` completion |
-| `dmodex_request_callback_bridge` | `src/server/mod.rs:1458` | `PMIx_server_dmodex_req` upcall |
-| `setup_application_callback_bridge` | `src/server/mod.rs:1661` | `PMIx_server_setup_app` upcall |
-| `setup_local_support_callback_bridge` | `src/server/mod.rs:1930` | `PMIx_server_setup_local` completion |
-| `iof_deliver_callback_bridge` | `src/server/mod.rs:2135` | IOF deliver completion |
-| `collect_inventory_callback_bridge` | `src/server/mod.rs:2391` | Inventory collection upcall |
-| `deliver_inventory_callback_bridge` | `src/server/mod.rs:2610` | Inventory delivery completion |
-| `fence_nb_callback_bridge` | `src/server/data.rs:375` | Server fence_nb upcall |
-| `connect_nb_callback_bridge` | `src/server/data.rs:508` | Server connect_nb upcall |
-| `disconnect_nb_callback_bridge` | `src/server/data.rs:646` | Server disconnect_nb upcall |
-| `register_resources_callback_bridge` | `src/server/pset.rs:266` | Register resources completion |
-| `deregister_resources_callback_bridge` | `src/server/pset.rs:464` | Deregister resources completion |
-
-### 3.3 Callback bridge summary
-
-| Category | Count | Thread |
-|----------|-------|--------|
-| Client API calls (caller → PMIx) | 62 | Caller thread (threadshifted internally by PMIx ≥ 6.1) |
-| Callback bridges (PMIx → caller) | 40 | PMIx progress thread |
+Still handle-based; same process-wide session pattern is [#49](https://github.com/SedahsDev/pmix-rs/issues/49).
 
 ---
 
-## 4. Key Rules for Callers
+## 4. Progress & pinning
 
-1. **Never share `!Send` types across threads** — use `Arc<Mutex<T>>` if you need shared access to `Context`, `Info`, `PmixOwnedValue`, etc.
-2. **Callbacks run on the PMIx progress thread** — keep them short. Do not call blocking PMIx APIs from within a callback (deadlock risk). If you must, dispatch to your own thread pool.
-3. **Single init/finalize cycle** — prefer one `init()` / `finalize()` pair per process. Multiple cycles are not guaranteed to work.
-4. **Progress engine must run** — if you provide your own progress engine instead of using the PMIx internal one, ensure it runs during API calls to avoid threadlock.
-5. **Server upcalls** — `PmixServerModule` callbacks are invoked by PMIx on its internal threads. The callback bridges handle cbdata routing, but user-provided callback logic should be non-blocking.
+| Goal | How |
+|------|-----|
+| Pin progress CPUs | `InitOptions::bind_progress_thread` |
+| Host progress | `InitOptions::external_progress(true)` + `progress()` |
+| Stop progress thread | `progress_thread_stop()` |
+
+Deadlocks: external progress without a loop; mutex held across `progress()` + callback; blocking PMIx inside a callback; `progress()` after `progress_thread_stop()`.
 
 ---
 
-## 5. Future Work
+## 5. Type inventory (summary)
 
-- [ ] Add `PhantomData<*mut u8>` to all 26 raw-handle types (enforce `!Send`/`!Sync` at compile time) — see PR #42 for the pattern
-- [ ] Add `static_assertions` compile-time tests for all public types
-- [ ] Consider `Arc<Mutex<T>>` wrapper types for common multi-threaded use patterns
-- [ ] Document thread-safety guarantees per-function in doc comments
+| Type | Send/Sync | Status |
+|------|-----------|--------|
+| `PmixClient`, `PmixClientState` | **Send + Sync** | Enforced |
+| `Proc` | Send + Sync (POD) | Intended |
+| `Info` | **!Send + !Sync** | Enforced |
+| Buffers / fabric / results | !Send target | #50 |
+| Enums / pure builders | Send + Sync | OK |
+
+Full matrix: [#66](https://github.com/SedahsDev/pmix-rs/issues/66). Completing marks: [#50](https://github.com/SedahsDev/pmix-rs/issues/50).
+
+---
+
+## 6. Caller rules
+
+1. Use **`PmixClient`** — clone for workers; `disconnect` once.  
+2. Build `Info` on the calling thread.  
+3. Callbacks = progress thread — hop before blocking PMIx.  
+4. One connect/disconnect cycle per process.  
+5. Progress must run.  
+6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.
+
+---
+
+## 7. Examples
+
+`examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs` use `PmixClient::connect_new` / `require_proc` / `disconnect`.
+
+---
+
+## 8. Roadmap
+
+| Item | Issue | Status |
+|------|------:|--------|
+| Inventory + ≥6.1 | #45 | Done |
+| InitOptions / progress stop | #46, #47 | Done |
+| PmixClient session | #48 | Done |
+| Remove Context/init | this PR | Done |
+| Server/tool sessions | #49 | Open |
+| C-owned !Send | #50 | Open (`Info` done) |
+| Callback hop / audit | #51, #67 | Open |
+| Server upcall example | #52 | Open |
+| Global FFI mutex | #53 | Deferred |
+| MT integration tests | #54 | Open |
+| static_assertions matrix | #66 | Open |

--- a/examples/client_minimal.rs
+++ b/examples/client_minimal.rs
@@ -1,24 +1,25 @@
-//! Minimal PMIx client example: init → put → commit → fence → get → finalize.
+//! Minimal PMIx client: connect → put → commit → fence → get → disconnect.
 //!
 //! ```text
 //! cargo run --example client_minimal
+//! prterun -n 1 target/debug/examples/client_minimal
 //! ```
 //!
-//! Usually needs a PMIx runtime (e.g. `prterun -n 1 target/debug/examples/client_minimal`).
-//! Without a DVM, `init` may fail — that is expected in bare `cargo run`.
+//! Without a DVM, `connect_new` may fail — that is expected in bare `cargo run`.
 
 use std::ffi::CString;
 
 fn main() {
     println!("pmix-rs client_minimal");
 
-    let ctx = match pmix::init(None) {
+    let client = match pmix::PmixClient::connect_new(None) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("pmix::init failed (need prterun/DVM?): {e:?}");
+            eprintln!("PmixClient::connect_new failed (need prterun/DVM?): {e:?}");
             return;
         }
     };
+    let proc = client.require_proc();
 
     let key = CString::new("client_minimal_key").expect("key");
     let mut value = pmix::PmixValueBuilder::new()
@@ -29,22 +30,25 @@ fn main() {
 
     if let Err(e) = pmix::put_value(pmix::PmixScope::Global.to_raw(), &key, &mut value) {
         eprintln!("put_value failed: {e:?}");
+        let _ = client.disconnect(None);
         return;
     }
     if let Err(e) = pmix::commit() {
         eprintln!("commit failed: {e:?}");
+        let _ = client.disconnect(None);
         return;
     }
-    if let Err(e) = pmix::fence(ctx.get_proc(), None) {
+    if let Err(e) = pmix::fence(&proc, None) {
         eprintln!("fence failed: {e:?}");
+        let _ = client.disconnect(None);
         return;
     }
 
-    match pmix::get_value(ctx.get_proc(), b"client_minimal_key\0", None) {
+    match pmix::get_value(&proc, b"client_minimal_key\0", None) {
         Ok(_) => println!("get_value ok"),
         Err(e) => println!("get_value: {e:?} (ok without full DVM in some envs)"),
     }
 
-    // Context drop finalizes
+    let _ = client.disconnect(None);
     println!("client_minimal done");
 }

--- a/examples/simple_fence.rs
+++ b/examples/simple_fence.rs
@@ -1,22 +1,29 @@
 //! Very simple fence example.
-//
+//!
+//! ```text
 //! cargo run --example simple_fence
+//! ```
 
 fn main() {
     println!("PMIx simple fence example");
 
-    let ctx = pmix::init(None).expect("init failed");
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("connect_new failed (need prterun/DVM?): {e:?}");
+            return;
+        }
+    };
+    let proc = client.require_proc();
 
-    // Just fence
-    let result = pmix::fence(ctx.get_proc(), None);
-    match result {
+    match pmix::fence(&proc, None) {
         Ok(()) => println!("fence succeeded"),
-        Err(e) => println!("fence status: {:?}", e),
+        Err(e) => println!("fence status: {e:?}"),
     }
 
-    // Optional: fence with empty info
     let info = pmix::info::empty();
-    let _ = pmix::fence(ctx.get_proc(), Some(info));
+    let _ = pmix::fence(&proc, Some(info));
 
+    let _ = client.disconnect(None);
     println!("Simple fence example done");
 }

--- a/examples/simple_put_get.rs
+++ b/examples/simple_put_get.rs
@@ -1,45 +1,36 @@
 //! Very simple example using put / get / commit / fence.
 //!
-//! Run with: cargo run --example simple_put_get
-//! (Usually requires a PMIx daemon via prterun or prte)
+//! ```text
+//! cargo run --example simple_put_get
+//! prterun -np 1 target/debug/examples/simple_put_get
+//! ```
 
 use std::ffi::CString;
 
 fn main() {
     println!("PMIx Rust simple put/get/commit/fence example");
 
-    // Init (Context finalizes on drop)
-    let ctx = pmix::init(None).expect("pmix::init failed");
+    let client = pmix::PmixClient::connect_new(None).expect("PmixClient::connect_new failed");
+    let proc = client.require_proc();
 
-    // Key (null terminated for get)
     let key = CString::new("simple_example_key").unwrap();
-
-    // Build a string value
     let mut value = pmix::PmixValueBuilder::new()
         .string("hello from the pmix rust example")
         .expect("string value")
         .build()
         .expect("build value");
 
-    // Put the value using Global scope
     pmix::put_value(pmix::PmixScope::Global.to_raw(), &key, &mut value).expect("put_value failed");
-
-    // Commit the puts
     pmix::commit().expect("commit failed");
+    pmix::fence(&proc, None).expect("fence failed");
 
-    // Fence for visibility
-    pmix::fence(ctx.get_proc(), None).expect("fence failed");
-
-    // Try to get it back
-    match pmix::get_value(ctx.get_proc(), b"simple_example_key\0", None) {
+    match pmix::get_value(&proc, b"simple_example_key\0", None) {
         Ok(_val) => println!("Got value successfully via get_value"),
         Err(e) => {
-            println!(
-                "get_value status (expected without full DVM in some envs): {:?}",
-                e
-            );
+            println!("get_value status (expected without full DVM in some envs): {e:?}");
         }
     }
 
+    client.disconnect(None).expect("disconnect failed");
     println!("Simple put/get/commit/fence example finished");
 }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -1547,7 +1547,7 @@ mod tests {
             || std::env::var("PMIX_RANK").is_ok()
             || std::env::var("PRTE_LAUNCHED").is_ok();
         if !_is_dvm {
-            match crate::init(None) {
+            match crate::PmixClient::connect_new(None) {
                 Ok(_) => {}
                 Err(_) => {
                     eprintln!("test_fabric_register_nb_compiles: init failed, skipping");
@@ -1572,7 +1572,7 @@ mod tests {
             || std::env::var("PMIX_RANK").is_ok()
             || std::env::var("PRTE_LAUNCHED").is_ok();
         if !_is_dvm {
-            match crate::init(None) {
+            match crate::PmixClient::connect_new(None) {
                 Ok(_) => {}
                 Err(_) => {
                     eprintln!("test_fabric_update_nb_compiles: init failed, skipping");
@@ -1594,7 +1594,7 @@ mod tests {
             || std::env::var("PMIX_RANK").is_ok()
             || std::env::var("PRTE_LAUNCHED").is_ok();
         if !_is_dvm {
-            match crate::init(None) {
+            match crate::PmixClient::connect_new(None) {
                 Ok(_) => {}
                 Err(_) => {
                     eprintln!("test_fabric_deregister_nb_compiles: init failed, skipping");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,19 +9,21 @@
 //! engine, so concurrent **calls** into C are intended to be OK while progress
 //! runs. Rust still owns session lifetime and C-handle discipline:
 //!
-//! - Prefer one process-wide [`PmixClient`] session: `Clone` is cheap (`Arc`),
-//!   and the type is **`Send + Sync`** so clones can move to worker threads.
-//! - Do **not** lock every put/get in Rust by default — OpenPMIx serializes entry.
-//!   Lock only Rust-owned shared state (the session does this for cached `Proc`).
+//! - **Only** client session API: process-wide [`PmixClient`] (`Clone + Send + Sync`).
+//!   Use [`PmixClient::connect_new`] / [`connect`](PmixClient::connect) /
+//!   [`disconnect`](PmixClient::disconnect). There is no legacy `Context` / `init`.
+//! - Do **not** lock every put/get in Rust by default — OpenPMIx ≥ 6.1 serializes entry.
+//!   Lock only Rust-owned shared state (the session caches `Proc` under a mutex).
 //! - Data ops stay as free functions ([`put_value`], [`get_value`], [`commit`],
-//!   [`fence`], …). Pass proc handles from the client; build [`Info`] per call.
-//! - [`Info`] and other raw-handle wrappers are **`!Send` + `!Sync`**
+//!   [`fence`], …). Pass [`Proc`] from the client; build [`Info`] per call.
+//! - [`Info`] and other C-owned handles are **`!Send` + `!Sync`**
 //!   (`PhantomData<*mut u8>`). Share only behind your own `Mutex` if you must.
-//! - One logical init/finalize cycle per process. [`PmixClient::disconnect`] is
-//!   explicit — **Drop does not finalize** (avoids double-finalize with clones).
-//! - Legacy [`init`] / [`Context`] share the same session state machine; `Context`
-//!   still finalizes on Drop for backward compatibility.
+//! - One logical connect/disconnect per process. **Drop does not finalize**
+//!   (clones must not each run `PMIx_Finalize`). Call [`disconnect`](PmixClient::disconnect)
+//!   or [`finalize`].
 //! - Server upcalls may run on PMIx internal threads; keep callbacks short.
+//!
+//! See [THREADING.md](../THREADING.md) in the repo for the full model.
 //!
 use std::fmt::Debug;
 pub mod allocation;
@@ -3476,9 +3478,8 @@ fn client_session() -> Arc<PmixClientInner> {
 /// # Drop / finalize rules
 ///
 /// - **Drop does not finalize.** Clones must not each run `PMIx_Finalize`.
-/// - Call [`disconnect`](Self::disconnect) once (or legacy [`finalize`]).
+/// - Call [`disconnect`](Self::disconnect) once (or free-function [`finalize`]).
 /// - Further disconnect/finalize calls are no-ops once not `Live`.
-/// - Legacy [`Context`] still finalizes on Drop and shares this state machine.
 ///
 /// # Example
 ///
@@ -3486,8 +3487,7 @@ fn client_session() -> Arc<PmixClientInner> {
 /// use pmix::{PmixClient, put_value, commit, fence, PmixScope};
 /// use std::ffi::CString;
 ///
-/// let client = PmixClient::new();
-/// client.connect(None)?;
+/// let client = PmixClient::connect_new(None)?;
 ///
 /// let worker = client.clone();
 /// std::thread::spawn(move || {
@@ -3638,12 +3638,15 @@ impl PmixClient {
             .clone()
     }
 
-    /// Borrow-style access via clone of the cached `Proc` when live.
-    ///
-    /// Named for parity with [`Context::get_proc`]; returns owned `Proc`
-    /// because the cache lives behind a mutex.
+    /// Alias for [`proc`](Self::proc).
     pub fn get_proc(&self) -> Option<Proc> {
         self.proc()
+    }
+
+    /// Process handle, or panic if not live (tests / infallible paths).
+    pub fn require_proc(&self) -> Proc {
+        self.proc()
+            .expect("pmix: PmixClient must be connected (Live) to use require_proc")
     }
 
     /// Rank from the cached process handle when live.
@@ -3656,9 +3659,15 @@ impl PmixClient {
             .map(|p| p.get_rank())
     }
 
-    /// Alias for [`rank`](Self::rank) matching [`Context::get_rank`] naming.
+    /// Alias for [`rank`](Self::rank).
     pub fn get_rank(&self) -> Option<u32> {
         self.rank()
+    }
+
+    /// Rank, or panic if not live.
+    pub fn require_rank(&self) -> u32 {
+        self.rank()
+            .expect("pmix: PmixClient must be connected (Live) to use require_rank")
     }
 
     /// `Proc` for `rank` in this client's namespace.
@@ -3682,66 +3691,6 @@ impl PmixClient {
             Err(PmixError::ErrInit)
         }
     }
-}
-
-/// Legacy RAII client context — prefer [`PmixClient`] for multi-threaded code.
-///
-/// `Context` is retained for backward compatibility. It performs finalize in
-/// [`Drop`] via [`finalize`], which is coordinated with the process-wide
-/// [`PmixClient`] state machine (double-finalize becomes a no-op).
-///
-/// `Context` itself is not the shareable session type: clone/move a
-/// [`PmixClient`] across threads instead.
-
-pub struct Context {
-    pub(crate) proc: Proc,
-}
-
-impl Context {
-    pub fn proc_with_nspace(&self, rank: u32) -> Result<Proc, NulError> {
-        let mut handle: pmix_proc_t;
-        unsafe {
-            handle = mem::zeroed();
-            PMIx_Proc_construct(&mut handle);
-        }
-        handle.rank = rank;
-        unsafe {
-            PMIx_Load_nspace(handle.nspace.as_mut_ptr(), self.proc.handle.nspace.as_ptr());
-        }
-        Ok(Proc { handle, len: 1 })
-    }
-
-    pub fn get_rank(&self) -> u32 {
-        self.proc.handle.rank
-    }
-    pub fn get_proc(&self) -> &Proc {
-        &self.proc
-    }
-}
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        // Always log finalize failures (including release builds). This runs at
-        // end-of-scope / process teardown where diagnostics matter more than
-        // avoiding a single eprintln. Never panic in Drop (double-panic → abort).
-        if let Err(status) = finalize(None) {
-            eprintln!("pmix: finalize in Context::Drop failed: status={status}");
-        }
-    }
-}
-
-/// Initialize the process-wide PMIx client session and return a legacy [`Context`].
-///
-/// Prefer [`PmixClient::connect_new`] / [`PmixClient::connect`] for multi-threaded
-/// code. This function uses the same process session state machine as
-/// [`PmixClient`]; a second init while live returns [`PmixError::ErrExists`].
-pub fn init(info: Option<Info>) -> Result<Context, PmixError> {
-    let client = PmixClient::new();
-    client.connect(info)?;
-    let proc = client
-        .proc()
-        .expect("pmix: proc must be set after successful connect");
-    Ok(Context { proc })
 }
 
 pub fn get_value(proc: &Proc, key: &[u8], info: Option<Info>) -> Result<PmixOwnedValue, PmixError> {
@@ -3918,8 +3867,9 @@ pub fn progress_thread_stop() {
 
 /// Finalize the process-wide PMIx client session (`PMIx_Finalize`).
 ///
-/// Delegates to [`PmixClient::disconnect`]. No-op if the session is not live.
-/// Prefer explicit [`PmixClient::disconnect`] when using [`PmixClient`].
+/// Equivalent to [`PmixClient::disconnect`] on the process session.
+/// No-op if the session is not live. Prefer calling
+/// [`disconnect`](PmixClient::disconnect) on your client handle when you have one.
 pub fn finalize(info: Option<Info>) -> Result<(), pmix_status_t> {
     PmixClient::new().disconnect(info)
 }
@@ -5472,6 +5422,7 @@ mod tests {
         assert!(client.proc().is_none());
         assert!(client.get_proc().is_none());
         assert!(client.rank().is_none());
+        assert!(client.get_rank().is_none());
         assert!(client.check_live().is_err());
         assert!(client.proc_with_nspace(0).is_err());
     }
@@ -5482,9 +5433,9 @@ mod tests {
         if client.is_live() {
             return;
         }
-        let before = client.state();
+        // Process-wide session may already be Dead from another test; disconnect is still Ok.
         assert!(client.disconnect(None).is_ok());
-        assert_eq!(client.state(), before);
+        assert!(!client.is_live());
     }
 
     #[test]
@@ -5493,8 +5444,7 @@ mod tests {
         if client.is_live() {
             return;
         }
-        let before = client.state();
         assert!(finalize(None).is_ok());
-        assert_eq!(PmixClient::new().state(), before);
+        assert!(!PmixClient::new().is_live());
     }
 }

--- a/tests/allocation_deep.rs
+++ b/tests/allocation_deep.rs
@@ -1208,7 +1208,7 @@ fn allocation_request_error_is_known() {
 fn allocation_request_full_lifecycle() {
     // With PMIx_Init, allocation_request should be accepted.
     // The actual result depends on the resource manager.
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let result = allocation_request(PmixAllocDirective::AllocNew, &[]);
     // assert!(result.is_ok() || result.is_err()); // RM may reject
     // pmix::finalize(None).unwrap();
@@ -1222,7 +1222,7 @@ fn allocation_request_nb_full_lifecycle() {
     impl AllocationCallback for Cb {
         fn on_complete(&self, _status: PmixStatus, _results: AllocationResults) {}
     }
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let result = allocation_request_nb(PmixAllocDirective::AllocNew, &[], Box::new(Cb));
     // assert!(result.is_ok()); // Should be accepted (callback fires later)
     // pmix::finalize(None).unwrap();
@@ -1232,7 +1232,7 @@ fn allocation_request_nb_full_lifecycle() {
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn job_control_full_lifecycle() {
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let result = job_control(&[], &[]);
     // assert!(result.is_ok() || result.is_err());
     // pmix::finalize(None).unwrap();
@@ -1246,7 +1246,7 @@ fn job_control_nb_full_lifecycle() {
     impl JobControlCallback for Cb {
         fn on_complete(&self, _status: PmixStatus, _results: JobControlResults) {}
     }
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let result = job_control_nb(&[], &[], Box::new(Cb));
     // assert!(result.is_ok());
     // pmix::finalize(None).unwrap();
@@ -1256,7 +1256,7 @@ fn job_control_nb_full_lifecycle() {
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn allocation_request_with_info() {
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let info = InfoBuilder::new().build();
     // // Note: allocation_request takes &[Info], and InfoBuilder produces a single Info.
     // // The caller would need to wrap it in a Vec to pass as slice.
@@ -1267,7 +1267,7 @@ fn allocation_request_with_info() {
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn job_control_with_info() {
-    // let _ = pmix::init(None);
+    // let _ = pmix::PmixClient::connect_new(None);
     // let directives = InfoBuilder::new().build();
     // pmix::finalize(None).unwrap();
 }

--- a/tests/daemon_helper.rs
+++ b/tests/daemon_helper.rs
@@ -317,14 +317,15 @@ pub fn assert_error(status: pmix::PmixStatus) {
     );
 }
 
-/// Ensures PMIx is initialized exactly once per test binary (DVM/prterun tests).
-/// Returns a reference to the Context.
-/// Call this instead of direct pmix::init(None) to avoid multiple init/finalize.
+/// Ensures the process-wide [`pmix::PmixClient`] is connected once per test binary (DVM/prterun).
+///
+/// Prefer this over calling `PmixClient::connect_new` in every test — PMIx allows one logical
+/// client init per process. Drop does **not** finalize; process exit tears down the DVM job.
 /// Multiple cycles are not supported.
-pub fn ensure_pmix_init() -> &'static pmix::Context {
+pub fn ensure_pmix_init() -> &'static pmix::PmixClient {
     use std::sync::OnceLock;
-    static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
-    PMIX_CTX.get_or_init(|| pmix::init(None).expect("PMIx_Init failed — run under prterun"))
+    static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
+    PMIX_CTX.get_or_init(|| pmix::PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_ops_Fence_nb.rs
+++ b/tests/data_ops_Fence_nb.rs
@@ -330,7 +330,7 @@ fn fence_nb_after_init() {
     }
 
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     let result = fence_nb(&procs, None, Box::new(NbCallback));
@@ -365,7 +365,7 @@ fn fence_nb_with_collect_data() {
     builder.collect_data();
     let info = builder.build();
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     let result = fence_nb(&procs, Some(&info), Box::new(CollectCallback));
@@ -419,7 +419,7 @@ fn fence_nb_chained_fences() {
     }
 
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     // Issue first fence.
@@ -452,7 +452,7 @@ fn fence_nb_callback_status_on_success() {
     }
 
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     let result = fence_nb(&procs, None, Box::new(StatusVerifyCallback));
@@ -475,7 +475,7 @@ fn fence_nb_full_params() {
     builder.collect_data();
     let info = builder.build();
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     let result = fence_nb(&procs, Some(&info), Box::new(FullCallback));
@@ -501,7 +501,7 @@ fn fence_nb_put_commit_fence_pattern() {
     // The C test pattern: put data, commit, then fence.
     // The fence ensures data visibility across the group.
     let _ctx = daemon_helper::ensure_pmix_init();
-    let proc = _ctx.get_proc().clone();
+    let proc = _ctx.require_proc();
     let procs = vec![proc];
 
     let mut builder = InfoBuilder::new();

--- a/tests/data_ops_Lookup.rs
+++ b/tests/data_ops_Lookup.rs
@@ -443,8 +443,8 @@ fn publish_fence_lookup_pattern() {
     assert!(publish_result.is_ok(), "publish should succeed");
 
     // Fence to ensure data is visible.
-    let proc = ctx.get_proc();
-    let fence_result = pmix::fence(proc, None);
+    let proc = ctx.require_proc();
+    let fence_result = pmix::fence(&proc, None);
     assert!(fence_result.is_ok(), "fence should succeed after publish");
 
     // Lookup the published data.

--- a/tests/data_ops_Publish.rs
+++ b/tests/data_ops_Publish.rs
@@ -289,8 +289,8 @@ fn publish_fence_pattern() {
     assert!(result.is_ok(), "publish should succeed");
 
     // Fence to ensure data is visible.
-    let proc = ctx.get_proc();
-    let fence_result = pmix::fence(proc, None);
+    let proc = ctx.require_proc();
+    let fence_result = pmix::fence(&proc, None);
     assert!(fence_result.is_ok(), "fence should succeed after publish");
 }
 

--- a/tests/data_ops_Unpublish.rs
+++ b/tests/data_ops_Unpublish.rs
@@ -397,8 +397,8 @@ fn publish_unpublish_cycle() {
     assert!(publish_result.is_ok(), "publish should succeed");
 
     // Fence to ensure data is visible.
-    let proc = ctx.get_proc();
-    let fence_result = pmix::fence(proc, None);
+    let proc = ctx.require_proc();
+    let fence_result = pmix::fence(&proc, None);
     assert!(fence_result.is_ok(), "fence after publish should succeed");
 
     // Unpublish the keys.
@@ -409,7 +409,7 @@ fn publish_unpublish_cycle() {
     );
 
     // Final fence to ensure cleanup is complete.
-    let final_fence = pmix::fence(proc, None);
+    let final_fence = pmix::fence(&proc, None);
     assert!(final_fence.is_ok(), "final fence should succeed");
 }
 

--- a/tests/data_serialization_Data_load.rs
+++ b/tests/data_serialization_Data_load.rs
@@ -27,17 +27,17 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::data_serialization::*;
-use pmix::{PmixStatus, init};
+use pmix::{PmixStatus, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // The FFI integration tests below all share this single context.
 // ─────────────────────────────────────────────────────────────────────────────
 
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_Data_pack.rs
+++ b/tests/data_serialization_Data_pack.rs
@@ -17,15 +17,15 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::data_serialization::*;
-use pmix::{PmixDataType, init};
+use pmix::{PmixDataType, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_Data_unload.rs
+++ b/tests/data_serialization_Data_unload.rs
@@ -20,16 +20,16 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::data_serialization::*;
-use pmix::{PmixStatus, init};
+use pmix::{PmixStatus, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // The FFI integration tests below all share this single context.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_Data_unpack.rs
+++ b/tests/data_serialization_Data_unpack.rs
@@ -14,15 +14,15 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::data_serialization::*;
-use pmix::{PmixDataType, init};
+use pmix::{PmixDataType, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_PmixDataBuffer.rs
+++ b/tests/data_serialization_PmixDataBuffer.rs
@@ -11,15 +11,15 @@ mod daemon_helper;
 
 use std::sync::OnceLock;
 
-use pmix::{data_serialization::*, init};
+use pmix::{data_serialization::*, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_advanced.rs
+++ b/tests/data_serialization_advanced.rs
@@ -25,15 +25,15 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::data_serialization::*;
-use pmix::{PmixDataType, PmixError, PmixStatus, init};
+use pmix::{PmixDataType, PmixError, PmixStatus, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_edge_cases.rs
+++ b/tests/data_serialization_edge_cases.rs
@@ -26,16 +26,16 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::{PmixDataType, PmixError, PmixStatus};
-use pmix::{data_serialization::*, init};
+use pmix::{data_serialization::*, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
 
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_pack_unpack_wrapper.rs
+++ b/tests/data_serialization_pack_unpack_wrapper.rs
@@ -13,15 +13,15 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::PmixDataType;
-use pmix::{data_serialization::*, init};
+use pmix::{data_serialization::*, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_proptest.rs
+++ b/tests/data_serialization_proptest.rs
@@ -10,7 +10,7 @@
 
 mod daemon_helper;
 
-use pmix::{PmixDataType, data_serialization::*, init};
+use pmix::{PmixDataType, data_serialization::*, PmixClient};
 use proptest::prelude::*;
 use std::sync::OnceLock;
 
@@ -19,10 +19,10 @@ use std::sync::OnceLock;
 // Proptest may call the test closure many times (shrinking), so we need
 // a shared Context that lives for the whole test run.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/data_serialization_roundtrip.rs
+++ b/tests/data_serialization_roundtrip.rs
@@ -20,15 +20,15 @@ mod daemon_helper;
 use std::sync::OnceLock;
 
 use pmix::{PmixDataType, PmixStatus};
-use pmix::{data_serialization::*, init};
+use pmix::{data_serialization::*, PmixClient};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Singleton PMIx init — PMIx can only be initialized once per process.
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CTX: OnceLock<pmix::Context> = OnceLock::new();
+static PMIX_CTX: OnceLock<pmix::PmixClient> = OnceLock::new();
 
-fn ensure_init() -> &'static pmix::Context {
-    PMIX_CTX.get_or_init(|| init(None).expect("PMIx_Init failed — run under prterun"))
+fn ensure_init() -> &'static pmix::PmixClient {
+    PMIX_CTX.get_or_init(|| PmixClient::connect_new(None).expect("PMIx_Init failed — run under prterun"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/fabric_ffi_via_prterun.rs
+++ b/tests/fabric_ffi_via_prterun.rs
@@ -18,7 +18,7 @@ use std::sync::OnceLock;
 
 /// Shared PMIx context initialized once when first DVM test runs.
 /// Avoids multiple init/finalize cycles that corrupt PMIx library state.
-static PMIX_CONTEXT: OnceLock<Option<pmix::Context>> = OnceLock::new();
+static PMIX_CONTEXT: OnceLock<Option<pmix::PmixClient>> = OnceLock::new();
 
 /// Initialize the shared PMIx context if we're running under prterun.
 /// Returns true if PMIx is available.

--- a/tests/groups_Group_construct.rs
+++ b/tests/groups_Group_construct.rs
@@ -568,7 +568,7 @@ fn group_construct_integration() {
     daemon_helper::ensure_pmix_init();
     // In a real integration test environment:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create Procs for the group members.
     // 3. Call group_construct("my_group", &procs, &[]) and verify Ok(_).
     // 4. Call group_leave("my_group", &[]) and verify Ok(()).
@@ -594,7 +594,7 @@ fn group_invite_join_integration() {
     daemon_helper::ensure_pmix_init();
     // In a real integration test:
     //
-    // 1. Leader calls pmix::lifecycle::init(None).expect("init");
+    // 1. Leader calls pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Leader calls group_invite("async_group", &invitees, &[])
     //    and verifies Ok(_).
     // 3. Invitees call group_join("async_group", &leader,

--- a/tests/init_via_prterun.rs
+++ b/tests/init_via_prterun.rs
@@ -1,4 +1,4 @@
-//! Tests for pmix::init() (PMIx_Init) - the DVM-launched client path.
+//! Tests for PmixClient::connect_new() (PMIx_Init) - the DVM-launched client path.
 //!
 //! PMIx_Init only works when the process is launched by the DVM (prterun/prun).
 //! It does NOT accept PMIX_SERVER_URI from the environment - that is for
@@ -7,11 +7,11 @@
 //! These tests are designed to be run in two modes:
 //!
 //! 1. Standalone (cargo test --test init_via_prterun):
-//!    - Tests that pmix::init() FAILS gracefully with PMIX_ERR_UNREACH
+//!    - Tests that PmixClient::connect_new() FAILS gracefully with PMIX_ERR_UNREACH
 //!    - Tests that pmix::initialized() returns false before init
 //!
 //! 2. Via prterun (prterun -np 1 cargo test --test init_via_prterun -- --ignored):
-//!    - Tests that pmix::init() SUCCEEDS when DVM-launched
+//!    - Tests that PmixClient::connect_new() SUCCEEDS when DVM-launched
 //!    - Tests context, proc, namespace, rank from DVM connection
 mod daemon_helper;
 
@@ -29,16 +29,16 @@ fn is_dvm_launched() -> bool {
 // Standalone tests - run normally, verify PMIx_Init fails gracefully
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// pmix::init() fails when not DVM-launched.
+/// PmixClient::connect_new() fails when not DVM-launched.
 #[test]
 fn test_init_fails_without_dvm() {
     if is_dvm_launched() {
         return;
     }
-    let result = pmix::init(None);
+    let result = pmix::PmixClient::connect_new(None);
     assert!(
         result.is_err(),
-        "pmix::init() should fail when not launched by DVM"
+        "PmixClient::connect_new() should fail when not launched by DVM"
     );
 }
 
@@ -46,29 +46,29 @@ fn test_init_fails_without_dvm() {
 // DVM-launched tests - only run when prterun launches us
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// pmix::init() succeeds when launched by prterun.
+/// PmixClient::connect_new() succeeds when launched by prterun.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_succeeds_via_prterun() {
     assert!(is_dvm_launched(), "this test must be launched by prterun");
-    let result = pmix::init(None);
+    let result = pmix::PmixClient::connect_new(None);
     assert!(
         result.is_ok(),
-        "pmix::init() should succeed when launched by prterun"
+        "PmixClient::connect_new() should succeed when launched by prterun"
     );
 }
 
-/// pmix::init() returns a valid context with rank 0.
+/// PmixClient::connect_new() returns a valid context with rank 0.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_returns_valid_context() {
     assert!(is_dvm_launched(), "this test must be launched by prterun");
     let context = daemon_helper::ensure_pmix_init();
-    let rank = context.get_rank();
+    let rank = context.require_rank();
     assert_eq!(rank, 0, "rank should be 0 for single-process job");
 }
 
-/// pmix::utility::initialized() returns true after pmix::init().
+/// pmix::utility::initialized() returns true after PmixClient::connect_new().
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_initialized_after_init() {
@@ -76,30 +76,30 @@ fn test_initialized_after_init() {
     let _context = daemon_helper::ensure_pmix_init();
     assert!(
         pmix::utility::initialized(),
-        "pmix::initialized() should return true after pmix::init()"
+        "pmix::initialized() should return true after PmixClient::connect_new()"
     );
 }
 
-/// pmix::init() with Info succeeds via prterun.
+/// PmixClient::connect_new() with Info succeeds via prterun.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_with_info_via_prterun() {
     assert!(is_dvm_launched(), "this test must be launched by prterun");
     let info = InfoBuilder::new().build();
-    let result = pmix::init(Some(info));
+    let result = pmix::PmixClient::connect_new(Some(info));
     assert!(
         result.is_ok(),
-        "pmix::init() with info should succeed via prterun"
+        "PmixClient::connect_new() with info should succeed via prterun"
     );
 }
 
-/// pmix::init() context provides valid proc namespace.
+/// PmixClient::connect_new() context provides valid proc namespace.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_context_proc_info() {
     assert!(is_dvm_launched(), "this test must be launched by prterun");
     let context = daemon_helper::ensure_pmix_init();
-    let proc = context.get_proc();
+    let proc = context.require_proc();
     // Access nspace through proc_with_nspace which returns a new Proc
     let _new_proc = context
         .proc_with_nspace(0)
@@ -107,11 +107,11 @@ fn test_context_proc_info() {
     assert_eq!(proc.get_rank(), 0, "rank should be 0");
 }
 
-/// pmix::init() -> finalize cycle works via prterun.
+/// PmixClient::connect_new() -> finalize cycle works via prterun.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_finalize_cycle() {
     assert!(is_dvm_launched(), "this test must be launched by prterun");
     let _context = daemon_helper::ensure_pmix_init();
-    // Context Drop calls finalize automatically
+    // Call disconnect/finalize explicitly — Drop does not finalize
 }

--- a/tests/lib_core_api.rs
+++ b/tests/lib_core_api.rs
@@ -155,7 +155,7 @@ fn test_tool_init_minimal() {
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_with_daemon() {
-    let result = pmix::init(None);
+    let result = pmix::PmixClient::connect_new(None);
     assert!(result.is_ok(), "init should succeed with daemon");
 }
 
@@ -163,7 +163,7 @@ fn test_init_with_daemon() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_returns_valid_context() {
     let context = daemon_helper::ensure_pmix_init();
-    let rank = context.get_rank();
+    let rank = context.require_rank();
     assert_eq!(rank, 0, "rank should be 0 for standalone client");
 }
 
@@ -171,7 +171,7 @@ fn test_init_returns_valid_context() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_context_get_proc() {
     let context = daemon_helper::ensure_pmix_init();
-    let _proc = context.get_proc();
+    let _proc = context.require_proc();
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn test_context_proc_with_nspace() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_with_info() {
     let info = InfoBuilder::new().build();
-    let result = pmix::init(Some(info));
+    let result = pmix::PmixClient::connect_new(Some(info));
     assert!(result.is_ok(), "init with info should succeed");
 }
 
@@ -213,7 +213,7 @@ fn test_init_finalize_cycle() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_fence_after_init() {
     let context = daemon_helper::ensure_pmix_init();
-    let result = pmix::fence(context.get_proc(), None);
+    let result = pmix::fence(&context.require_proc(), None);
     assert!(result.is_ok(), "fence should succeed after init");
 }
 
@@ -222,7 +222,7 @@ fn test_fence_after_init() {
 fn test_fence_with_info() {
     let context = daemon_helper::ensure_pmix_init();
     let info = InfoBuilder::new().build();
-    let result = pmix::fence(context.get_proc(), Some(info));
+    let result = pmix::fence(&context.require_proc(), Some(info));
     assert!(result.is_ok(), "fence with info should succeed");
 }
 
@@ -247,7 +247,7 @@ fn test_put_get_commit_roundtrip() {
     if put_result.is_ok() {
         let commit_result = pmix::commit();
         if commit_result.is_ok() {
-            let get_result = pmix::get_value(context.get_proc(), b"test_roundtrip_key\0", None);
+            let get_result = pmix::get_value(&context.require_proc(), b"test_roundtrip_key\0", None);
             drop(get_result);
         }
     }
@@ -257,7 +257,7 @@ fn test_put_get_commit_roundtrip() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_get_value_nonexistent() {
     let context = daemon_helper::ensure_pmix_init();
-    let result = pmix::get_value(context.get_proc(), b"nonexistent_key_xyz\0", None);
+    let result = pmix::get_value(&context.require_proc(), b"nonexistent_key_xyz\0", None);
     assert!(result.is_err(), "get_value for nonexistent key should fail");
 }
 

--- a/tests/lib_core_lifecycle.rs
+++ b/tests/lib_core_lifecycle.rs
@@ -1,8 +1,8 @@
-//! Integration tests for PMIx core lifecycle: `pmix::init`, `pmix::finalize`,
+//! Integration tests for PMIx core lifecycle: `PmixClient::connect_new`, `pmix::finalize`,
 //! `pmix::utility::initialized`, and `pmix::get_version`.
 //!
 //! All tests in this file run standalone without a PMIx daemon (prterun/DVM).
-//! This means `pmix::init()` will always return an error (typically `ErrUnreach`
+//! This means `PmixClient::connect_new()` will always return an error (typically `ErrUnreach`
 //! since no server is available), and `pmix::finalize()` may succeed even without
 //! prior init (PMIx_Finalize is idempotent).
 //!
@@ -10,7 +10,7 @@
 //! `PMIx_Get_attribute_name` — they crash with SIGSEGV without `PMIx_Init`.
 
 use pmix::utility::initialized;
-use pmix::{InfoBuilder, PmixError, PmixStatus, finalize, get_version, init};
+use pmix::{InfoBuilder, PmixClient, PmixError, PmixStatus, finalize, get_version};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // get_version — safe, no init needed
@@ -209,32 +209,32 @@ fn initialized_returns_consistent_value() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// init() error paths — no DVM available
+// PmixClient::connect_new() error paths — no DVM available
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// `init(None)` without DVM returns `Err`.
+/// `PmixClient::connect_new(None)` without DVM returns `Err`.
 #[test]
 fn init_without_dvm_returns_err() {
     assert!(
-        init(None).is_err(),
-        "init(None) without DVM should return Err"
+        PmixClient::connect_new(None).is_err(),
+        "PmixClient::connect_new(None) without DVM should return Err"
     );
 }
 
-/// `init(Some(info))` without DVM returns `Err`.
+/// `PmixClient::connect_new(Some(info))` without DVM returns `Err`.
 #[test]
 fn init_with_info_without_dvm_returns_err() {
     let info = InfoBuilder::new().build();
     assert!(
-        init(Some(info)).is_err(),
-        "init(Some(info)) without DVM should return Err"
+        PmixClient::connect_new(Some(info)).is_err(),
+        "PmixClient::connect_new(Some(info)) without DVM should return Err"
     );
 }
 
-/// `init(None)` error is a known PMIx error (not a random code).
+/// `PmixClient::connect_new(None)` error is a known PMIx error (not a random code).
 #[test]
 fn init_without_dvm_error_is_known() {
-    match init(None) {
+    match PmixClient::connect_new(None) {
         Err(e) => {
             let status = PmixStatus::from_raw(e.to_raw());
             assert!(
@@ -243,17 +243,17 @@ fn init_without_dvm_error_is_known() {
                 status
             );
         }
-        Ok(_) => panic!("init(None) should fail without DVM"),
+        Ok(_) => panic!("PmixClient::connect_new(None) should fail without DVM"),
     }
 }
 
 /// `init` does not panic on error — it returns a proper `Err`.
 #[test]
 fn init_does_not_panic_on_error() {
-    let result = std::panic::catch_unwind(|| init(None));
+    let result = std::panic::catch_unwind(|| PmixClient::connect_new(None));
     assert!(
         result.is_ok(),
-        "init(None) should not panic, it should return Err"
+        "PmixClient::connect_new(None) should not panic, it should return Err"
     );
 }
 
@@ -262,7 +262,7 @@ fn init_does_not_panic_on_error() {
 fn init_with_empty_info_returns_err() {
     let info = InfoBuilder::new().build();
     assert!(
-        init(Some(info)).is_err(),
+        PmixClient::connect_new(Some(info)).is_err(),
         "init with empty InfoBuilder should fail without DVM"
     );
 }
@@ -274,7 +274,7 @@ fn init_with_collect_data_info_returns_err() {
     builder.collect_data();
     let info = builder.build();
     assert!(
-        init(Some(info)).is_err(),
+        PmixClient::connect_new(Some(info)).is_err(),
         "init with collect_data info should fail without DVM"
     );
 }
@@ -283,8 +283,8 @@ fn init_with_collect_data_info_returns_err() {
 #[test]
 #[ignore = "flaky — second init may succeed after first partially initializes PMIx"]
 fn double_init_returns_same_error_type() {
-    let result1 = init(None);
-    let result2 = init(None);
+    let result1 = PmixClient::connect_new(None);
+    let result2 = PmixClient::connect_new(None);
 
     assert!(result1.is_err(), "first init should fail");
     assert!(result2.is_err(), "second init should fail");
@@ -301,16 +301,16 @@ fn double_init_returns_same_error_type() {
     }
 }
 
-/// `init` returns `Result<Context, PmixError>` (compile-time type check).
+/// `init` returns `Result<PmixClient, PmixError>` (compile-time type check).
 #[test]
 fn init_return_type_is_result_context_pmixerror() {
-    let _result: Result<pmix::Context, PmixError> = init(None);
+    let _result: Result<pmix::PmixClient, PmixError> = PmixClient::connect_new(None);
 }
 
 /// `init` error value is negative (error codes are negative in PMIx).
 #[test]
 fn init_error_value_is_negative() {
-    match init(None) {
+    match PmixClient::connect_new(None) {
         Err(e) => {
             let raw = e.to_raw();
             assert!(
@@ -326,7 +326,7 @@ fn init_error_value_is_negative() {
 /// Error from init is a known PmixError variant (not unknown/user-defined).
 #[test]
 fn init_error_is_known_pmixerror() {
-    match init(None) {
+    match PmixClient::connect_new(None) {
         Err(e) => {
             let status = PmixStatus::from_raw(e.to_raw());
             assert!(
@@ -342,7 +342,7 @@ fn init_error_is_known_pmixerror() {
 /// `init` error is an error (not success) — raw value is negative.
 #[test]
 fn init_error_is_error_not_success() {
-    match init(None) {
+    match PmixClient::connect_new(None) {
         Err(e) => {
             assert!(
                 e.is_error(),
@@ -425,14 +425,14 @@ fn finalize_result_is_valid() {
 #[test]
 fn init_finalize_init_cycle() {
     // First init — should fail
-    let init1 = init(None);
+    let init1 = PmixClient::connect_new(None);
     assert!(init1.is_err(), "first init should fail without DVM");
 
     // Finalize — may succeed or fail, but should not crash
     let _fin1 = finalize(None);
 
     // Second init — should still fail
-    let init2 = init(None);
+    let init2 = PmixClient::connect_new(None);
     assert!(init2.is_err(), "second init should also fail without DVM");
 }
 
@@ -440,8 +440,8 @@ fn init_finalize_init_cycle() {
 #[test]
 #[ignore = "flaky — second init may succeed after first partially initializes PMIx"]
 fn double_init_then_finalize() {
-    let init1 = init(None);
-    let init2 = init(None);
+    let init1 = PmixClient::connect_new(None);
+    let init2 = PmixClient::connect_new(None);
     let _fin = finalize(None);
 
     assert!(init1.is_err(), "first init should fail");
@@ -452,7 +452,7 @@ fn double_init_then_finalize() {
 #[test]
 fn finalize_init_finalize() {
     let _fin1 = finalize(None);
-    let init1 = init(None);
+    let init1 = PmixClient::connect_new(None);
     let _fin2 = finalize(None);
 
     assert!(init1.is_err(), "init should fail without DVM");
@@ -462,7 +462,7 @@ fn finalize_init_finalize() {
 #[test]
 fn initialized_consistent_after_failed_lifecycle() {
     let before = initialized();
-    let _ = init(None);
+    let _ = PmixClient::connect_new(None);
     let _ = finalize(None);
     let after = initialized();
     // initialized() should be stable (consistent) across these operations
@@ -477,7 +477,7 @@ fn init_with_info_then_finalize_with_info() {
     let info1 = InfoBuilder::new().build();
     let info2 = InfoBuilder::new().build();
 
-    let init_result = init(Some(info1));
+    let init_result = PmixClient::connect_new(Some(info1));
     assert!(
         init_result.is_err(),
         "init with info should fail without DVM"
@@ -537,7 +537,7 @@ fn errunreach_is_error() {
 ///
 /// NOTE: We do NOT assert that all threads return the same value. `initialized()`
 /// reads PMIx's internal global state, which can change during parallel test execution
-/// when other tests call `init()` or `finalize()`. The key safety property is that
+/// when other tests call `PmixClient::connect_new()` or `finalize()`. The key safety property is that
 /// concurrent reads don't crash or panic — not that they return identical values.
 #[test]
 fn concurrent_initialized_safe() {
@@ -650,7 +650,7 @@ fn safe_functions_work_before_any_lifecycle() {
 /// `get_version` works after failed init.
 #[test]
 fn get_version_works_after_failed_init() {
-    let _ = init(None);
+    let _ = PmixClient::connect_new(None);
     assert!(
         !get_version().is_empty(),
         "get_version should work after failed init"
@@ -660,7 +660,7 @@ fn get_version_works_after_failed_init() {
 /// `initialized()` works after failed init and failed finalize.
 #[test]
 fn initialized_works_after_failed_lifecycle() {
-    let _ = init(None);
+    let _ = PmixClient::connect_new(None);
     let _ = finalize(None);
     // Just calling it — should not crash
     let _ = initialized();

--- a/tests/monitoring_via_prterun.rs
+++ b/tests/monitoring_via_prterun.rs
@@ -11,7 +11,7 @@ mod daemon_helper;
 
 use pmix::PmixStatus;
 use std::sync::OnceLock;
-static PMIX_CONTEXT: OnceLock<Option<pmix::Context>> = OnceLock::new();
+static PMIX_CONTEXT: OnceLock<Option<pmix::PmixClient>> = OnceLock::new();
 
 fn ensure_pmix_init() -> bool {
     if !is_dvm_launched() {

--- a/tests/process_mgmt_Abort.rs
+++ b/tests/process_mgmt_Abort.rs
@@ -213,7 +213,7 @@ fn abort_integration() {
     // The safe approach is to skip this in unit test mode.
     // In a real integration test environment, we would:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Register an event handler for abort notifications.
     // 3. If rank 0, call abort(PmixStatus::Known(PmixError::ErrOutOfResource),
     //    Some("Eat rocks"), Some(&[my_proc])).

--- a/tests/process_mgmt_Connect.rs
+++ b/tests/process_mgmt_Connect.rs
@@ -274,7 +274,7 @@ fn connect_integration() {
     // This would require PMIx_Init which needs a daemon.
     // In a real integration test environment, we would:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create a Proc with our own namespace and WILDCARD rank.
     // 3. Call connect(&[proc], &[]) and verify Ok(()).
     // 4. Call disconnect(&[proc], &[]) and verify Ok(()).
@@ -298,7 +298,7 @@ fn connect_nb_integration() {
     daemon_helper::ensure_pmix_init();
     // In a real integration test:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create a Proc with our own namespace and WILDCARD rank.
     // 3. Use a Arc<Mutex<...>> or AtomicBool shared with the callback
     //    to detect when connect_nb completes.

--- a/tests/process_mgmt_Disconnect.rs
+++ b/tests/process_mgmt_Disconnect.rs
@@ -324,7 +324,7 @@ fn disconnect_integration() {
     // This would require PMIx_Init which needs a daemon.
     // In a real integration test environment, we would:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create a Proc with our own namespace and WILDCARD rank.
     // 3. Call connect(&[proc], &[]) and verify Ok(()).
     // 4. Call disconnect(&[proc], &[]) and verify Ok(()).
@@ -350,7 +350,7 @@ fn disconnect_nb_integration() {
     daemon_helper::ensure_pmix_init();
     // In a real integration test:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create a Proc with our own namespace and WILDCARD rank.
     // 3. Connect first (required before disconnect).
     // 4. Use a Arc<Mutex<...>> or AtomicBool shared with the callback
@@ -377,7 +377,7 @@ fn disconnect_without_prior_connect_returns_error() {
     daemon_helper::ensure_pmix_init();
     // In a real integration test:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Create a Proc with our own namespace.
     // 3. Call disconnect(&[proc], &[]) WITHOUT calling connect first.
     // 4. Verify it returns an error (PMIX_ERR_INVALID_OPERATION or similar).

--- a/tests/process_mgmt_Spawn.rs
+++ b/tests/process_mgmt_Spawn.rs
@@ -365,7 +365,7 @@ fn spawn_integration() {
     // This would require PMIx_Init which needs a daemon.
     // In a real integration test environment:
     //
-    // 1. Call pmix::lifecycle::init(None).expect("init");
+    // 1. Call pmix::lifecycle::PmixClient::connect_new(None).expect("init");
     // 2. Build PmixApp with cmd = "./simpclient", maxprocs = 2
     // 3. Call spawn(&[], &[app])
     // 4. Verify returned namespace is non-empty

--- a/tests/security_via_prterun.rs
+++ b/tests/security_via_prterun.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared PMIx context for all DVM tests
 // ─────────────────────────────────────────────────────────────────────────────
-static PMIX_CONTEXT: OnceLock<Option<pmix::Context>> = OnceLock::new();
+static PMIX_CONTEXT: OnceLock<Option<pmix::PmixClient>> = OnceLock::new();
 
 fn ensure_pmix_init() -> bool {
     if !is_dvm_launched() {

--- a/tests/tool_via_prterun.rs
+++ b/tests/tool_via_prterun.rs
@@ -17,7 +17,7 @@
 mod daemon_helper;
 
 use std::sync::OnceLock;
-static PMIX_CONTEXT: OnceLock<Option<pmix::Context>> = OnceLock::new();
+static PMIX_CONTEXT: OnceLock<Option<pmix::PmixClient>> = OnceLock::new();
 
 fn ensure_pmix_init() -> bool {
     if !is_dvm_launched() {
@@ -78,12 +78,12 @@ fn test_dvm_launch_detected() {
     assert!(is_dvm_launched());
 }
 
-/// Context provides valid proc info via DVM.
+/// PmixClient provides valid proc info via DVM.
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_context_via_dvm() {
     let context = daemon_helper::ensure_pmix_init();
-    let proc = context.get_proc();
+    let proc = context.require_proc();
     assert_eq!(proc.get_rank(), 0);
 }
 

--- a/tests/utility_generate_regex.rs
+++ b/tests/utility_generate_regex.rs
@@ -151,7 +151,7 @@ fn test_generate_regex_error_display() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_sequential_nodes() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes = "odin001,odin002,odin003,odin010,odin011,odin075";
@@ -179,7 +179,7 @@ fn test_generate_regex_sequential_nodes() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_three_nodes() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes = "test000,test001,test002";
@@ -199,7 +199,7 @@ fn test_generate_regex_three_nodes() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_short_nodes() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes = "c712f6n01,c712f6n02,c712f6n03";
@@ -216,7 +216,7 @@ fn test_generate_regex_short_nodes() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_deterministic() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes = "odin001,odin002,odin003,odin010,odin011,odin075";
@@ -233,7 +233,7 @@ fn test_generate_regex_deterministic() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_many_nodes() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes: String = (0..100)
@@ -259,7 +259,7 @@ fn test_generate_regex_many_nodes() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_single_host() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let result = generate_regex("localhost");
@@ -281,7 +281,7 @@ fn test_generate_regex_single_host() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_output_format() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let test_cases = vec![
@@ -306,7 +306,7 @@ fn test_generate_regex_output_format() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_no_leak_smoke() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     for i in 0..50 {
@@ -325,7 +325,7 @@ fn test_generate_regex_no_leak_smoke() {
 #[test]
 #[ignore = "requires PMIx_server_init"]
 fn test_generate_regex_mixed_names() {
-    if !require_server_init() {
+    if !skip_without_server() {
         return;
     }
     let nodes = "compute-0,compute-1,gpu-node-0,gpu-node-1";


### PR DESCRIPTION
## Summary

**Breaking.** No external users — drop legacy dual client path.

### Removed
- `pub struct Context` (+ Drop-finalize)
- `pub fn init(...)`

### Client API now
```rust
let client = pmix::PmixClient::connect_new(None)?;
let proc = client.require_proc();
// put_value / get_value / fence(&proc, ...)
client.disconnect(None)?;
// or: pmix::finalize(None)
```

- Process-wide `Arc` session, `Clone + Send + Sync`
- **Drop does not finalize**
- `require_proc` / `require_rank` for infallible test/app paths
- Free-fn `finalize` = session disconnect alias

### Also
- Examples + integration tests + `daemon_helper::ensure_pmix_init` migrated
- README + THREADING.md greenfield model
- Closes #65 (examples migration)
- Supersedes dual-path notes on #48 / #64

### Verify
- [x] `cargo test --lib` → 1741 passed
- [x] `cargo test --tests --no-run`
- [x] `cargo build --examples`