### PR TITLE
feat(threading): enforce !Send/!Sync on C-owned handles

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -1,10 +1,11 @@
 # Threading Model & Send/Sync Inventory
 
 **Date:** 2026-07-27  
-**Issues:** [#64](https://github.com/SedahsDev/pmix-rs/issues/64), [#45](https://github.com/SedahsDev/pmix-rs/issues/45)  
-**Related:** [#49](https://github.com/SedahsDev/pmix-rs/issues/49)–[#52](https://github.com/SedahsDev/pmix-rs/issues/52), [#54](https://github.com/SedahsDev/pmix-rs/issues/54), [#66](https://github.com/SedahsDev/pmix-rs/issues/66)–[#67](https://github.com/SedahsDev/pmix-rs/issues/67)
+**Issues:** [#64](https://github.com/SedahsDev/pmix-rs/issues/64), [#45](https://github.com/SedahsDev/pmix-rs/issues/45), [#50](https://github.com/SedahsDev/pmix-rs/issues/50)  
+**Related:** [#51](https://github.com/SedahsDev/pmix-rs/issues/51)–[#52](https://github.com/SedahsDev/pmix-rs/issues/52), [#54](https://github.com/SedahsDev/pmix-rs/issues/54), [#66](https://github.com/SedahsDev/pmix-rs/issues/66)–[#67](https://github.com/SedahsDev/pmix-rs/issues/67)
 
-Crate-root docs in `src/lib.rs` (`//! # Concurrency model`) match this document.
+Crate-root docs in `src/lib.rs` (`//! # Concurrency model`) match this document.  
+Compile-time matrix: `src/threading_assert.rs`.
 
 ---
 
@@ -15,7 +16,7 @@ Crate-root docs in `src/lib.rs` (`//! # Concurrency model`) match this document.
 | **Session** | Process-wide `OnceLock<Arc<Inner>>`. Handle is **`Clone + Send + Sync`**. **No** `PhantomData<*mut u8>` on the session Inner. |
 | **Client API** | **`PmixClient` only** — no legacy `Context` / `init()`. Explicit `connect` / `disconnect`. **Drop never finalizes.** |
 | **C API entry** | Trust OpenPMIx **≥ 6.1** threadshift. No global op mutex by default. |
-| **C-owned handles** | `Info`, buffers, fabric, … → **`!Send + !Sync`**. Prefer build-per-call. |
+| **C-owned handles** | `Info`, buffers, fabric, results → **`!Send + !Sync`** (`PhantomData<*mut u8>`). Prefer build-per-call. |
 | **Data ops** | Free functions (`put_value`, `get_value`, `commit`, `fence`, `data_ops::*`, …). |
 | **Callbacks / upcalls** | PMIx **progress thread**. No blocking PMIx in-handler (#51, #52, #67). |
 
@@ -29,17 +30,14 @@ Threadshift on C entry. Progress must run (internal thread or `external_progress
 
 ---
 
-## 3. `PmixClient` (only client session)
+## 3. Sessions
 
-| Property | Behavior |
-|----------|----------|
-| Storage | `OnceLock<Arc<PmixClientInner>>` |
-| Auto-traits | **`Clone + Send + Sync`** (asserted) |
-| State | `Uninitialized → Live → Finalizing → Dead` |
-| Connect | `PmixClient::connect_new(info)` or `new()` + `connect` |
-| Disconnect | `client.disconnect(info)` or free-fn `finalize(info)` |
-| Drop | **No** finalize |
-| Identity | `proc()` / `require_proc()` / `rank()` / `require_rank()` |
+| Type | Auto-traits | Drop finalize? |
+|------|-------------|----------------|
+| `PmixClient` | `Clone + Send + Sync` | No |
+| `PmixServer` | `Clone + Send + Sync` | No |
+| `PmixTool` | `Clone + Send + Sync` | No |
+| `Proc` | `Clone + Send + Sync` (POD) | n/a |
 
 ```rust
 let client = pmix::PmixClient::connect_new(None)?;
@@ -48,16 +46,7 @@ std::thread::spawn(move || { let _ = w.rank(); });
 client.disconnect(None)?;
 ```
 
-### Server / tool
-
-| Type | Notes |
-|------|--------|
-| [`PmixServer`](src/server/session.rs) | Process-wide Arc session, `Clone + Send + Sync`, Drop does **not** finalize |
-| [`PmixTool`](src/tool.rs) | Same pattern for tool library lifecycle |
-| `PmixToolHandle` | Identity token (nspace+rank) from attach/connect-to-server — **not** the session |
-| `tool::PmixServerHandle` | Server identity from attach — **not** `server::PmixServer` |
-
-`server_init` / `tool_init` free functions delegate to the session types.
+`PmixToolHandle` / `tool::PmixServerHandle` are **identity tokens** (nspace+rank), not process sessions.
 
 ---
 
@@ -73,26 +62,39 @@ Deadlocks: external progress without a loop; mutex held across `progress()` + ca
 
 ---
 
-## 5. Type inventory (summary)
+## 5. Type inventory
 
-| Type | Send/Sync | Status |
-|------|-----------|--------|
-| `PmixClient`, `PmixClientState` | **Send + Sync** | Enforced |
-| `Proc` | Send + Sync (POD) | Intended |
-| `Info` | **!Send + !Sync** | Enforced |
-| Buffers / fabric / results | !Send target | #50 |
-| Enums / pure builders | Send + Sync | OK |
+### 5.1 Sessions / POD — `Send + Sync` (enforced in `threading_assert.rs`)
 
-Full matrix: [#66](https://github.com/SedahsDev/pmix-rs/issues/66). Completing marks: [#50](https://github.com/SedahsDev/pmix-rs/issues/50).
+`PmixClient`, `PmixClientState`, `PmixServer`, `PmixServerState`, `PmixTool`, `PmixToolState`, `Proc`
+
+### 5.2 C-owned — `!Send + !Sync` (enforced)
+
+| Type | Module |
+|------|--------|
+| `Info`, `InfoBuilder`, `PmixOwnedValue` | `lib` |
+| `PmixDataBuffer`, `PmixByteObject` | `data_serialization` |
+| `PmixFabric`, `PmixTopology`, `PmixCpuset`, `DeviceDistances` | `fabric` |
+| `QueryResults`, `PmixQuery` | `query_log` |
+| `AllocationResults`, `JobControlResults`, `SessionControlResults` | `allocation` |
+| `MonitorResults` | `monitoring` |
+| `ValidationResults` | `security` |
+| `CollectInventoryResults` | `server` |
+
+**Share model:** build ephemeral handles **per call** on the calling thread. Optional app-side `Arc<Mutex<T>>` if you must share (no library `into_shared` helper — YAGNI).
+
+### 5.3 Pure Rust / remaining
+
+`PmixCredential` holds a Rust `Vec<u8>` (opaque bytes) — stays `Send + Sync`. Enums and pure builders are `Send + Sync`.
 
 ---
 
 ## 6. Caller rules
 
-1. Use **`PmixClient`** — clone for workers; `disconnect` once.  
-2. Build `Info` on the calling thread.  
+1. Use session types (`PmixClient` / `PmixServer` / `PmixTool`) — clone for workers; `disconnect` once.  
+2. Build `Info` and other C-owned handles on the calling thread.  
 3. Callbacks = progress thread — hop before blocking PMIx.  
-4. One connect/disconnect cycle per process.  
+4. One connect/disconnect cycle per process (per role).  
 5. Progress must run.  
 6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.
 
@@ -100,7 +102,7 @@ Full matrix: [#66](https://github.com/SedahsDev/pmix-rs/issues/66). Completing m
 
 ## 7. Examples
 
-`examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs` use `PmixClient::connect_new` / `require_proc` / `disconnect`.
+`examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs`, `server_minimal.rs`, `tool_attach.rs`.
 
 ---
 
@@ -111,11 +113,11 @@ Full matrix: [#66](https://github.com/SedahsDev/pmix-rs/issues/66). Completing m
 | Inventory + ≥6.1 | #45 | Done |
 | InitOptions / progress stop | #46, #47 | Done |
 | PmixClient session | #48 | Done |
-| Remove Context/init | this PR | Done |
-| Server/tool sessions | #49 | Done (this PR) |
-| C-owned !Send | #50 | Open (`Info` done) |
+| Remove Context/init | #69 | Done |
+| Server/tool sessions | #49 | Done |
+| C-owned !Send + assert matrix | #50 | Done (`threading_assert.rs`) |
 | Callback hop / audit | #51, #67 | Open |
 | Server upcall example | #52 | Open |
 | Global FFI mutex | #53 | Deferred |
 | MT integration tests | #54 | Open |
-| static_assertions matrix | #66 | Open |
+| Extra static_assertions | #66 | Mostly superseded by #50 |

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -158,6 +158,8 @@ impl std::fmt::Display for PmixAllocDirective {
 pub struct AllocationResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl AllocationResults {
@@ -265,7 +267,9 @@ pub fn allocation_request(
     Ok(AllocationResults {
         handle: results,
         len: nresults,
-    })
+    
+            _not_thread_safe: std::marker::PhantomData,
+        })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -337,7 +341,9 @@ extern "C" fn allocation_callback_bridge(
     let results = AllocationResults {
         handle: info,
         len: ninfo,
-    };
+    
+            _not_thread_safe: std::marker::PhantomData,
+        };
     cb.on_complete(pmix_status, results);
     // release_fn is unused — we manage our own memory via AllocationResults Drop.
     let _ = release_fn;
@@ -510,6 +516,8 @@ impl std::fmt::Display for PmixJobCtrlAction {
 pub struct JobControlResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl JobControlResults {
@@ -530,6 +538,8 @@ impl JobControlResults {
         Self {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 }
@@ -631,7 +641,9 @@ pub fn job_control(targets: &[Proc], directives: &[Info]) -> Result<JobControlRe
     Ok(JobControlResults {
         handle: results,
         len: nresults,
-    })
+    
+            _not_thread_safe: std::marker::PhantomData,
+        })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -703,7 +715,9 @@ extern "C" fn job_control_callback_bridge(
     let results = JobControlResults {
         handle: info,
         len: ninfo,
-    };
+    
+            _not_thread_safe: std::marker::PhantomData,
+        };
     cb.on_complete(pmix_status, results);
     // release_fn is unused — we manage our own memory via JobControlResults Drop.
     let _ = release_fn;
@@ -819,6 +833,8 @@ pub fn job_control_nb(
 pub struct SessionControlResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl SessionControlResults {
@@ -891,7 +907,9 @@ extern "C" fn session_control_callback_bridge(
     let results = SessionControlResults {
         handle: info,
         len: ninfo,
-    };
+    
+            _not_thread_safe: std::marker::PhantomData,
+        };
     cb.on_complete(pmix_status, results);
     let _ = release_fn;
 }
@@ -982,7 +1000,9 @@ pub fn session_control(
                 Ok(Some(SessionControlResults {
                     handle: results,
                     len: nresults,
-                }))
+                
+            _not_thread_safe: std::marker::PhantomData,
+        }))
             } else {
                 Err(pmix_status)
             }
@@ -1120,6 +1140,8 @@ mod tests {
         let results = AllocationResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -1130,6 +1152,8 @@ mod tests {
         let results = AllocationResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         let s = format!("{:?}", results);
         assert!(s.contains("AllocationResults"));
@@ -1335,6 +1359,8 @@ mod tests {
         let results = SessionControlResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -1345,6 +1371,8 @@ mod tests {
         let results = SessionControlResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         let s = format!("{:?}", results);
         assert!(s.contains("SessionControlResults"));
@@ -1453,6 +1481,8 @@ mod tests {
         let results = AllocationResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         drop(results); // Should not panic or segfault
     }
@@ -1470,6 +1500,8 @@ mod tests {
         let results = SessionControlResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         drop(results); // Should not panic or segfault
     }

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -260,7 +260,9 @@ extern "C" fn get_value_callback_bridge(
         let val = unsafe { ptr::read(kv) };
         // Clear the pointer so PMIx doesn't double-free.
         unsafe { ptr::write(kv, std::mem::zeroed()) };
-        Some(PmixOwnedValue { inner: val })
+        Some(PmixOwnedValue { inner: val, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
     } else {
         None
     };
@@ -464,7 +466,9 @@ pub fn get(proc: &Proc, key: &str, info: Option<&Info>) -> Result<PmixOwnedValue
             // which will free it on drop.
             ptr::read(value)
         };
-        Ok(PmixOwnedValue { inner: owned })
+        Ok(PmixOwnedValue { inner: owned, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
     } else {
         Err(pmix_status)
     }
@@ -625,7 +629,9 @@ pub fn lookup(
         let value = if pdata.value.type_ != pmix_undef {
             // Take ownership of the value.
             let val = unsafe { ptr::read(&pdata.value) };
-            Some(PmixOwnedValue { inner: val })
+            Some(PmixOwnedValue { inner: val, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
         } else {
             None
         };
@@ -738,7 +744,9 @@ extern "C" fn lookup_callback_bridge(
                 let pmix_undef: ffi::pmix_data_type_t = ffi::PMIX_UNDEF as u16;
                 let value = if pdata_ref.value.type_ != pmix_undef {
                     let val = ptr::read(&pdata_ref.value);
-                    Some(PmixOwnedValue { inner: val })
+                    Some(PmixOwnedValue { inner: val, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
                 } else {
                     None
                 };

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -1607,6 +1607,8 @@ use super::*;
         // This verifies the Drop implementation doesn't panic on zeroed data
         let val = PmixOwnedValue {
             inner: unsafe { std::mem::zeroed() },
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         // Drop happens at end of scope — should not panic
         drop(val);

--- a/src/data_serialization.rs
+++ b/src/data_serialization.rs
@@ -94,6 +94,8 @@ impl<'a> PmixProcRef<'a> {
 #[derive(Debug)]
 pub struct PmixByteObject {
     inner: ffi::pmix_byte_object_t,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 // Not Send/Sync by default — the underlying buffer is managed by the PMIx C library
@@ -106,6 +108,8 @@ impl PmixByteObject {
                 bytes: ptr::null_mut(),
                 size: 0,
             },
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -163,6 +167,8 @@ impl From<Vec<u8>> for PmixByteObject {
                 bytes: c_ptr as *mut std::os::raw::c_char,
                 size,
             },
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 }
@@ -200,6 +206,8 @@ impl Drop for PmixByteObject {
 /// ```
 pub struct PmixDataBuffer {
     ptr: *mut ffi::pmix_data_buffer_t,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 // The PMIx data buffer is not safe to share across threads.
@@ -239,6 +247,8 @@ impl PmixDataBuffer {
     pub fn null() -> Self {
         Self {
             ptr: ptr::null_mut(),
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -250,7 +260,9 @@ impl PmixDataBuffer {
     /// or null. The resulting `PmixDataBuffer` takes ownership and will call
     /// `PMIx_Data_buffer_release` on drop.
     pub unsafe fn from_raw(ptr: *mut ffi::pmix_data_buffer_t) -> Self {
-        Self { ptr }
+        Self { ptr, 
+            _not_thread_safe: std::marker::PhantomData,
+        }
     }
 }
 
@@ -310,7 +322,9 @@ pub fn data_buffer_create() -> Result<PmixDataBuffer, PmixStatus> {
     if ptr.is_null() {
         return Err(PmixStatus::from_raw(-1)); // PMIX_ERROR
     }
-    Ok(PmixDataBuffer { ptr })
+    Ok(PmixDataBuffer { ptr, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
 }
 
 /// Release a PMIx data buffer.

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -94,6 +94,8 @@ pub struct PmixFabric {
     registered: bool,
     /// Raw C struct for FFI calls.
     raw: MaybeUninit<ffi::pmix_fabric_t>,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl std::fmt::Debug for PmixFabric {
@@ -130,6 +132,8 @@ impl PmixFabric {
             module: ptr::null_mut(),
             registered: false,
             raw: MaybeUninit::uninit(),
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     }
 
@@ -142,6 +146,8 @@ impl PmixFabric {
             module: ptr::null_mut(),
             registered: false,
             raw: MaybeUninit::uninit(),
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -624,6 +630,8 @@ pub struct PmixTopology {
     loaded: bool,
     /// Raw C struct for FFI calls.
     raw: std::mem::MaybeUninit<ffi::pmix_topology_t>,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl PmixTopology {
@@ -641,6 +649,8 @@ impl PmixTopology {
             topology: ptr::null_mut(),
             loaded: false,
             raw: std::mem::MaybeUninit::uninit(),
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     }
 
@@ -651,6 +661,8 @@ impl PmixTopology {
             topology: ptr::null_mut(),
             loaded: false,
             raw: std::mem::MaybeUninit::uninit(),
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -737,6 +749,8 @@ pub struct PmixCpuset {
     raw: std::mem::MaybeUninit<ffi::pmix_cpuset_t>,
     /// Whether this cpuset has been constructed.
     constructed: bool,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl PmixCpuset {
@@ -747,6 +761,8 @@ impl PmixCpuset {
         let mut this = Self {
             raw: std::mem::MaybeUninit::uninit(),
             constructed: false,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         let raw_ptr = this.raw.as_mut_ptr();
         // SAFETY: PMIx_Cpuset_construct initializes a pmix_cpuset_t.
@@ -775,6 +791,8 @@ impl PmixCpuset {
         Self {
             raw: std::mem::MaybeUninit::uninit(),
             constructed: true,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -925,6 +943,8 @@ pub struct DeviceDistances {
     raw_ptr: *mut ffi::pmix_device_distance_t,
     /// Number of elements in the raw array.
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl DeviceDistances {
@@ -952,6 +972,8 @@ impl DeviceDistances {
             distances,
             raw_ptr: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 }
@@ -1197,7 +1219,9 @@ pub fn compute_distances(
         distances,
         raw_ptr: raw_distances,
         len: ndist,
-    })
+    
+            _not_thread_safe: std::marker::PhantomData,
+        })
 }
 
 /// Non-blocking variant of [`compute_distances`].
@@ -1265,13 +1289,17 @@ pub fn compute_distances_nb(
                 distances: rust_distances,
                 raw_ptr: dist,
                 len: ndist,
-            }
+            
+            _not_thread_safe: std::marker::PhantomData,
+        }
         } else {
             DeviceDistances {
                 distances: Vec::new(),
                 raw_ptr: ptr::null_mut(),
                 len: 0,
-            }
+            
+            _not_thread_safe: std::marker::PhantomData,
+        }
         };
 
         // Call the release function if provided.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod security;
 pub mod server;
 pub mod tool;
 pub mod utility;
+#[cfg(test)]
+mod threading_assert;
 
 
 /// Dispatch a PMIx FFI call to the mock implementation when the `mock_ffi`
@@ -2660,6 +2662,8 @@ impl PmixValueBuilder {
     pub fn build(self) -> Result<PmixOwnedValue, ValueError> {
         Ok(PmixOwnedValue {
             inner: self.build_raw()?,
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     }
 
@@ -2870,6 +2874,8 @@ pub fn free_value(v: &mut pmix_value_t) {
 /// ownership to a C API that calls `PMIX_VALUE_RELEASE` itself.
 pub struct PmixOwnedValue {
     inner: pmix_value_t,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl PmixOwnedValue {
@@ -3011,6 +3017,8 @@ pub struct InfoBuilder {
     infos: Vec<InfoEntry>,
     /// String-key entries for keys that exceed the 13-byte limit.
     string_infos: Vec<InfoEntryString>,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl InfoBuilder {
@@ -3739,6 +3747,8 @@ pub fn get_value(proc: &Proc, key: &[u8], info: Option<Info>) -> Result<PmixOwne
     if status.is_success() {
         Ok(PmixOwnedValue {
             inner: unsafe { *value },
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     } else {
         if let Some(known) = status.known() {

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -64,6 +64,8 @@ use crate::{Info, PmixError, PmixStatus};
 pub struct MonitorResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl MonitorResults {
@@ -85,6 +87,8 @@ impl MonitorResults {
         Self {
             handle: std::ptr::null_mut(),
             len,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 }
@@ -156,7 +160,9 @@ unsafe extern "C" fn monitor_callback_bridge(
                 Some(MonitorResults {
                     handle: info,
                     len: ninfo,
-                })
+                
+            _not_thread_safe: std::marker::PhantomData,
+        })
             } else {
                 None
             };
@@ -265,6 +271,8 @@ pub fn process_monitor(
         Ok(MonitorResults {
             handle: results,
             len: nresults,
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     } else {
         Err(pmix_status)

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -69,6 +69,8 @@ pub struct PmixQuery {
     /// Freed manually in Drop since PMIx_Query_release would double-free the
     /// individual CString-allocated strings.
     keys_array: *mut *mut c_char,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl std::fmt::Debug for PmixQuery {
@@ -164,6 +166,8 @@ impl PmixQuery {
             handle: query_ptr,
             _keys: c_keys,
             keys_array,
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     }
 
@@ -250,6 +254,8 @@ impl Drop for PmixQuery {
 pub struct QueryResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl std::fmt::Debug for QueryResults {
@@ -349,6 +355,8 @@ pub fn query_info(queries: &[PmixQuery]) -> Result<QueryResults, PmixStatus> {
         Ok(QueryResults {
             handle: results,
             len: nresults,
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     } else {
         // On error, PMIx may have still allocated a results array — free it.
@@ -446,7 +454,9 @@ extern "C" fn query_callback_bridge(
     let results = QueryResults {
         handle: info,
         len: ninfo,
-    };
+    
+            _not_thread_safe: std::marker::PhantomData,
+        };
     cb.on_complete(pmix_status, results);
     // release_fn is unused — we manage our own memory via QueryResults Drop.
     let _ = release_fn;
@@ -915,6 +925,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -925,6 +937,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 3,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(!results.is_empty());
         assert_eq!(results.len(), 3);
@@ -935,6 +949,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 5,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         let debug_str = format!("{:?}", results);
         assert!(debug_str.contains("QueryResults"));
@@ -946,6 +962,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         drop(results);
     }
@@ -955,6 +973,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 5,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         drop(results);
     }
@@ -1368,6 +1388,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         cb.on_complete(PmixStatus::Known(PmixError::Success), results);
         assert_eq!(count.load(Ordering::SeqCst), 1);
@@ -1520,6 +1542,8 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: usize::MAX,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(!results.is_empty());
         assert_eq!(results.len(), usize::MAX);

--- a/src/security.rs
+++ b/src/security.rs
@@ -537,6 +537,8 @@ pub fn get_credential_nb(
 pub struct ValidationResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl ValidationResults {
@@ -548,6 +550,8 @@ impl ValidationResults {
         Self {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 
@@ -646,6 +650,8 @@ pub fn validate_credential(
         Ok(ValidationResults {
             handle: results,
             len: nresults,
+        
+            _not_thread_safe: std::marker::PhantomData,
         })
     } else {
         // On error, free any results that may have been allocated.
@@ -757,11 +763,15 @@ extern "C" fn validation_callback_bridge(
         ValidationResults {
             handle: info,
             len: ninfo,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     } else {
         ValidationResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         }
     };
 

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -173,7 +173,9 @@ pub fn server_lookup(
             let val = unsafe { ptr::read(&pdata.value) };
             // Destruct the pdata.
             unsafe { ffi::PMIx_Pdata_destruct(&mut pdata) };
-            Ok(PmixOwnedValue { inner: val })
+            Ok(PmixOwnedValue { inner: val, 
+            _not_thread_safe: std::marker::PhantomData,
+        })
         } else {
             unsafe { ffi::PMIx_Pdata_destruct(&mut pdata) };
             Err(PmixStatus::Known(PmixError::ErrNotFound))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2236,6 +2236,8 @@ pub trait CollectInventoryCallback: Send + 'static {
 pub struct CollectInventoryResults {
     handle: *mut ffi::pmix_info_t,
     len: usize,
+    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
 impl CollectInventoryResults {
@@ -2318,7 +2320,9 @@ pub(crate) extern "C" fn collect_inventory_callback_bridge(
     let inventory = CollectInventoryResults {
         handle: info,
         len: ninfo,
-    };
+    
+            _not_thread_safe: std::marker::PhantomData,
+        };
     cb.on_complete(pmix_status, inventory);
     // release_fn is unused — we manage our own memory via CollectInventoryResults Drop.
     let _ = release_fn;

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -405,6 +405,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: std::ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -989,6 +991,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -1115,6 +1119,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert_eq!(results.len(), 0);
         assert!(results.is_empty());
@@ -1125,6 +1131,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         let debug_str = format!("{:?}", results);
         assert!(debug_str.contains("CollectInventoryResults"));
@@ -1137,6 +1145,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: 0x1 as *mut ffi::pmix_info_t, // dummy non-null
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
         assert_eq!(results.len(), 0);
@@ -1148,6 +1158,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         drop(results); // should be a no-op
     }
@@ -1616,6 +1628,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
+        
+            _not_thread_safe: std::marker::PhantomData,
         };
         boxed.on_complete(PmixStatus::from_raw(0), results);
         assert!(called.load(Ordering::SeqCst));

--- a/src/threading_assert.rs
+++ b/src/threading_assert.rs
@@ -1,0 +1,69 @@
+//! Compile-time `Send`/`Sync` matrix for public session vs C-owned handle types.
+//!
+//! See [THREADING.md](../THREADING.md) and issue #50.
+
+#[cfg(test)]
+mod asserts {
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    // ── Sessions: must stay shareable ─────────────────────────────────────
+    use crate::{PmixClient, PmixClientState, Proc};
+    use crate::server::{PmixServer, PmixServerState};
+    use crate::tool::{PmixTool, PmixToolState};
+
+    assert_impl_all!(PmixClient: Clone, Send, Sync);
+    assert_impl_all!(PmixClientState: Send, Sync);
+    assert_impl_all!(PmixServer: Clone, Send, Sync);
+    assert_impl_all!(PmixServerState: Send, Sync);
+    assert_impl_all!(PmixTool: Clone, Send, Sync);
+    assert_impl_all!(PmixToolState: Send, Sync);
+    // POD process identity — free-threaded by design
+    assert_impl_all!(Proc: Clone, Send, Sync);
+
+    // ── C-owned / exclusive handles: must NOT be free-threaded ────────────
+    use crate::Info;
+    use crate::InfoBuilder;
+    use crate::PmixOwnedValue;
+    use crate::allocation::{AllocationResults, JobControlResults, SessionControlResults};
+    use crate::data_serialization::{PmixByteObject, PmixDataBuffer};
+    use crate::fabric::{DeviceDistances, PmixCpuset, PmixFabric, PmixTopology};
+    use crate::monitoring::MonitorResults;
+    use crate::query_log::{PmixQuery, QueryResults};
+    use crate::security::ValidationResults;
+    use crate::server::CollectInventoryResults;
+
+    assert_not_impl_any!(Info: Send);
+    assert_not_impl_any!(Info: Sync);
+    assert_not_impl_any!(InfoBuilder: Send);
+    assert_not_impl_any!(InfoBuilder: Sync);
+    assert_not_impl_any!(PmixOwnedValue: Send);
+    assert_not_impl_any!(PmixOwnedValue: Sync);
+    assert_not_impl_any!(PmixDataBuffer: Send);
+    assert_not_impl_any!(PmixDataBuffer: Sync);
+    assert_not_impl_any!(PmixByteObject: Send);
+    assert_not_impl_any!(PmixByteObject: Sync);
+    assert_not_impl_any!(PmixFabric: Send);
+    assert_not_impl_any!(PmixFabric: Sync);
+    assert_not_impl_any!(PmixTopology: Send);
+    assert_not_impl_any!(PmixTopology: Sync);
+    assert_not_impl_any!(PmixCpuset: Send);
+    assert_not_impl_any!(PmixCpuset: Sync);
+    assert_not_impl_any!(DeviceDistances: Send);
+    assert_not_impl_any!(DeviceDistances: Sync);
+    assert_not_impl_any!(QueryResults: Send);
+    assert_not_impl_any!(QueryResults: Sync);
+    assert_not_impl_any!(PmixQuery: Send);
+    assert_not_impl_any!(PmixQuery: Sync);
+    assert_not_impl_any!(AllocationResults: Send);
+    assert_not_impl_any!(AllocationResults: Sync);
+    assert_not_impl_any!(JobControlResults: Send);
+    assert_not_impl_any!(JobControlResults: Sync);
+    assert_not_impl_any!(SessionControlResults: Send);
+    assert_not_impl_any!(SessionControlResults: Sync);
+    assert_not_impl_any!(MonitorResults: Send);
+    assert_not_impl_any!(MonitorResults: Sync);
+    assert_not_impl_any!(ValidationResults: Send);
+    assert_not_impl_any!(ValidationResults: Sync);
+    assert_not_impl_any!(CollectInventoryResults: Send);
+    assert_not_impl_any!(CollectInventoryResults: Sync);
+}


### PR DESCRIPTION
## Summary

Closes #50. Largely covers #66.

### C-owned handles now `!Send + !Sync`
`PhantomData<*mut u8>` on:

- `InfoBuilder`, `PmixOwnedValue` (Info already done)
- `PmixDataBuffer`, `PmixByteObject`
- `PmixFabric`, `PmixTopology`, `PmixCpuset`, `DeviceDistances`
- `QueryResults`, `PmixQuery`
- `AllocationResults`, `JobControlResults`, `SessionControlResults`
- `MonitorResults`, `ValidationResults`, `CollectInventoryResults`

### Compile-time matrix
`src/threading_assert.rs`:
- Sessions + `Proc` → `Send + Sync`
- C-owned list → `!Send + !Sync`

### Non-goals (issue text)
- **No** `into_shared` helper (YAGNI — prefer per-call ephemeral handles)
- **No** PhantomData on session Inners

### Docs
THREADING.md inventory + roadmap updated.

### Verify
- [x] `cargo test --lib` → 1747 passed