### PR TITLE
threading: callback hop-off-progress helpers + bridge policy (#51)

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -105,6 +105,23 @@ Deadlocks: external progress without a loop; mutex held across `progress()` + ca
 7. Bridges never hold a registry `Mutex` across user callback execution
    (regression-tested in `events`).
 
+### 6.1 Forbidden on the progress thread (concrete)
+
+```rust,ignore
+// ❌ NEVER — blocks progress on a PMIx round-trip
+let _ = pmix::data_ops::get(&proc, "pmix.job.size", None);
+
+// ❌ NEVER — waits for a condition only progress can satisfy
+while !ready.load(Ordering::SeqCst) { /* spin / park */ }
+
+// ❌ NEVER — holds a registry lock across application callback code
+let mut guard = EVENT_HANDLERS.lock().unwrap();
+if let Some(cb) = guard.get_mut(&id) { cb(); } // user code under lock
+```
+
+Hop first (`spawn_from_callback` / `CallbackChannel`), then do the blocking
+work on an application thread. Full policy: `src/threading.rs`.
+
 ---
 
 ## 7. Examples

--- a/THREADING.md
+++ b/THREADING.md
@@ -5,7 +5,8 @@
 **Related:** [#51](https://github.com/SedahsDev/pmix-rs/issues/51)–[#52](https://github.com/SedahsDev/pmix-rs/issues/52), [#54](https://github.com/SedahsDev/pmix-rs/issues/54), [#66](https://github.com/SedahsDev/pmix-rs/issues/66)–[#67](https://github.com/SedahsDev/pmix-rs/issues/67)
 
 Crate-root docs in `src/lib.rs` (`//! # Concurrency model`) match this document.  
-Compile-time matrix: `src/threading_assert.rs`.
+Compile-time matrix: `src/threading_assert.rs`.  
+Callback hop-off helpers + bridge policy: `src/threading.rs`.
 
 ---
 
@@ -93,16 +94,24 @@ Deadlocks: external progress without a loop; mutex held across `progress()` + ca
 
 1. Use session types (`PmixClient` / `PmixServer` / `PmixTool`) — clone for workers; `disconnect` once.  
 2. Build `Info` and other C-owned handles on the calling thread.  
-3. Callbacks = progress thread — hop before blocking PMIx.  
+3. Callbacks = progress thread — hop before blocking PMIx. Use
+   `threading::spawn_from_callback` (fire-and-forget thread) or
+   `threading::CallbackChannel` (app-thread receiver) — see
+   `examples/callback_hop.rs`. Never join/wait in-handler; convert C-owned
+   (`!Send`) values to Rust-owned data (e.g. `bytes_copy()`) before hopping.  
 4. One connect/disconnect cycle per process (per role).  
 5. Progress must run.  
-6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.
+6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.  
+7. Bridges never hold a registry `Mutex` across user callback execution
+   (regression-tested in `events`).
 
 ---
 
 ## 7. Examples
 
-`examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs`, `server_minimal.rs`, `tool_attach.rs`.
+`examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs`,
+`server_minimal.rs`, `tool_attach.rs`, `callback_hop.rs` (get_nb + events
+callback hop-off via `threading` helpers).
 
 ---
 
@@ -116,7 +125,7 @@ Deadlocks: external progress without a loop; mutex held across `progress()` + ca
 | Remove Context/init | #69 | Done |
 | Server/tool sessions | #49 | Done |
 | C-owned !Send + assert matrix | #50 | Done (`threading_assert.rs`) |
-| Callback hop / audit | #51, #67 | Open |
+| Callback hop / audit | #51, #67 | #51 Done (`threading` module + events registry); #67 Open |
 | Server upcall example | #52 | Open |
 | Global FFI mutex | #53 | Deferred |
 | MT integration tests | #54 | Open |

--- a/examples/callback_hop.rs
+++ b/examples/callback_hop.rs
@@ -127,7 +127,7 @@ fn main() {
 /// OpenPMIx requires every handler to complete the event chain by calling
 /// `cbfunc(..., cbdata)`. `progress_local_event_hdlr` thread-shifts, so the
 /// completion may safely run from the hopped-off application thread.
-unsafe extern "C" fn on_event(
+unsafe fn on_event(
     id: pmix::events::EventHandlerRef,
     status: i32,
     _source: *const c_void,

--- a/examples/callback_hop.rs
+++ b/examples/callback_hop.rs
@@ -1,0 +1,159 @@
+//! Callback hop-off-progress example (issue #51).
+//!
+//! Demonstrates the two shared helpers from [`pmix::threading`] with **one
+//! `data_ops` non-blocking path** (`get_nb`) and **one events path**
+//! (`register_event_handler` + `notify_event`):
+//!
+//! * [`CallbackChannel`](pmix::threading::CallbackChannel) — the application
+//!   thread keeps the receiver; the `get_nb` completion callback (which PMIx
+//!   invokes on the **progress thread**) pushes Rust-owned data through a
+//!   cloned sender and returns immediately.
+//! * [`spawn_from_callback`](pmix::threading::spawn_from_callback) — the event
+//!   handler (also on the progress thread) hops blocking work onto a fresh
+//!   application thread.
+//! * [`ProgressContext`](pmix::threading::ProgressContext) — a zero-sized
+//!   marker that documents "we are on the progress thread" and the forbidden
+//!   APIs at the point of use.
+//!
+//! # Running
+//!
+//! The example compiles and runs standalone (it exits gracefully when no DVM
+//! is present). Under a process manager it exercises real callbacks:
+//!
+//! ```text
+//! prterun --np 2 ./target/debug/examples/callback_hop
+//! ```
+
+use std::os::raw::c_void;
+use std::sync::mpsc;
+
+fn main() {
+    println!("pmix-rs: callback hop-off-progress example (issue #51)");
+    println!("Run under a DVM to see real callbacks, e.g.");
+    println!("  prterun --np 2 ./target/debug/examples/callback_hop");
+
+    // Without a DVM there is no PMIx server to connect to — exit gracefully
+    // like the other role examples in this crate.
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("connect_new failed (need prterun/DVM?): {e:?}");
+            return;
+        }
+    };
+    let proc = client.require_proc();
+    println!("connected: rank {}", proc.get_rank());
+
+    // ── 1. Events path ─────────────────────────────────────────────────────
+    // Empty `codes` = handle all events. The handler runs on the PMIx
+    // progress thread, so it hops off before doing any work.
+    let info = pmix::info::empty();
+    let handler_ref = match pmix::events::register_event_handler(&[], &info, Some(on_event), None) {
+        Ok(r) => r,
+        Err(e) => {
+            println!("register_event_handler failed (no DVM?): {e:?}");
+            0
+        }
+    };
+
+    // ── 2. data_ops non-blocking path ──────────────────────────────────────
+    // Application thread owns the channel; the callback gets a cloned sender.
+    let hop = pmix::threading::CallbackChannel::<(i32, Option<Vec<u8>>)>::new();
+    let tx = hop.sender();
+    match pmix::data_ops::get_nb(&proc, "pmix.job.size", None, Box::new(HopCallback { tx })) {
+        Ok(()) => println!("get_nb accepted — completion will arrive on the progress thread"),
+        Err(e) => println!("get_nb submit failed (no DVM?): {e:?}"),
+    }
+
+    // ── 3. Deliver an event so the handler fires (needs a DVM) ─────────────
+    let event = pmix::PmixStatus::Known(pmix::PmixError::EventJobEnd);
+    match pmix::events::notify_event(event, &proc, pmix::PmixDataRange::Session, &info) {
+        Ok(()) => println!("notify_event accepted — handler will fire on the progress thread"),
+        Err(e) => println!("notify_event failed (no DVM?): {e:?}"),
+    }
+
+    // ── 4. Application thread: drain the hop channel ───────────────────────
+    // This thread is where blocking PMIx calls are legal (the callback that
+    // pushed into the channel must never block on progress).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        match hop.recv_timeout(std::time::Duration::from_millis(250)) {
+            Ok((status, payload)) => {
+                let text = payload
+                    .as_deref()
+                    .map(|b| String::from_utf8_lossy(b).into_owned())
+                    .unwrap_or_else(|| "<no value>".to_string());
+                println!("[app thread] get_nb completed: status={status} value={text:?}");
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) if std::time::Instant::now() < deadline => {
+                // Standalone runs never produce the completion; keep waiting
+                // briefly so a real DVM run has time to deliver it.
+            }
+            Err(_) => {
+                println!("[app thread] no get_nb completion within 5s (standalone run?)");
+                break;
+            }
+        }
+    }
+
+    // ── 5. Cleanup ─────────────────────────────────────────────────────────
+    if handler_ref != 0 {
+        match pmix::events::deregister_event_handler(handler_ref, None) {
+            Ok(()) => println!("deregistered event handler {handler_ref}"),
+            Err(e) => println!("deregister_event_handler: {e:?}"),
+        }
+    }
+    let _ = client.disconnect(None);
+    println!("callback_hop example done");
+}
+
+/// Event handler — runs on the PMIx **progress thread**.
+///
+/// Note the [`ProgressContext`](pmix::threading::ProgressContext) marker: it
+/// documents that blocking PMIx calls are forbidden here, and the work is
+/// hopped onto a fresh application thread via
+/// [`spawn_from_callback`](pmix::threading::spawn_from_callback).
+unsafe extern "C" fn on_event(
+    id: pmix::events::EventHandlerRef,
+    status: i32,
+    _source: *const c_void,
+    _info: *mut c_void,
+    _ninfo: usize,
+    _results: *mut c_void,
+    _nresults: usize,
+    _cbfunc: pmix::events::pmix_event_notification_cbfunc_fn_t,
+    _cbdata: *mut c_void,
+) {
+    // We are on the progress thread — this marker is documentation, and any
+    // blocking PMIx call here would deadlock progress.
+    let _ctx = pmix::threading::ProgressContext;
+
+    // Hop off: spawn an application thread for the actual handling. We never
+    // join it here (that could block progress and deadlock the process).
+    let _ = pmix::threading::spawn_from_callback(move || {
+        println!("[app thread] event {id} fired with status {status} — blocking work is safe here");
+    });
+}
+
+/// `get_nb` completion callback — also invoked on the PMIx progress thread.
+///
+/// The [`PmixOwnedValue`](pmix::PmixOwnedValue) handed to us is a C-owned
+/// handle (`!Send`), so it is converted to Rust-owned bytes with
+/// [`bytes_copy`](pmix::PmixOwnedValue::bytes_copy) **before** crossing the
+/// channel. Only the cheap, non-blocking `send` happens on the progress
+/// thread; the application thread does any blocking work.
+struct HopCallback {
+    tx: mpsc::Sender<(i32, Option<Vec<u8>>)>,
+}
+
+impl pmix::data_ops::GetValueCallback for HopCallback {
+    fn on_result(self: Box<Self>, status: pmix::PmixStatus, value: Option<pmix::PmixOwnedValue>) {
+        let _ctx = pmix::threading::ProgressContext;
+
+        // Convert the C-owned (!Send) value into Rust-owned bytes so it can
+        // cross the channel, then hop — never block here.
+        let payload = value.map(|v| v.bytes_copy());
+        let _ = self.tx.send((status.to_raw(), payload));
+    }
+}

--- a/examples/callback_hop.rs
+++ b/examples/callback_hop.rs
@@ -10,7 +10,7 @@
 //!   cloned sender and returns immediately.
 //! * [`spawn_from_callback`](pmix::threading::spawn_from_callback) — the event
 //!   handler (also on the progress thread) hops blocking work onto a fresh
-//!   application thread.
+//!   application thread, then completes the OpenPMIx event chain via `cbfunc`.
 //! * [`ProgressContext`](pmix::threading::ProgressContext) — a zero-sized
 //!   marker that documents "we are on the progress thread" and the forbidden
 //!   APIs at the point of use.
@@ -25,6 +25,7 @@
 //! ```
 
 use std::os::raw::c_void;
+use std::ptr;
 use std::sync::mpsc;
 
 fn main() {
@@ -47,12 +48,18 @@ fn main() {
     // ── 1. Events path ─────────────────────────────────────────────────────
     // Empty `codes` = handle all events. The handler runs on the PMIx
     // progress thread, so it hops off before doing any work.
+    //
+    // Track success via `Result` — OpenPMIx assigns handler indices from 0, so
+    // `Ok(0)` is a legitimate first registration, not a failure sentinel.
     let info = pmix::info::empty();
     let handler_ref = match pmix::events::register_event_handler(&[], &info, Some(on_event), None) {
-        Ok(r) => r,
+        Ok(r) => {
+            println!("registered event handler {r}");
+            Some(r)
+        }
         Err(e) => {
             println!("register_event_handler failed (no DVM?): {e:?}");
-            0
+            None
         }
     };
 
@@ -66,6 +73,8 @@ fn main() {
     }
 
     // ── 3. Deliver an event so the handler fires (needs a DVM) ─────────────
+    // Blocking notify_event waits on the event chain; the handler must call
+    // its completion cbfunc (see on_event) or this never returns under a DVM.
     let event = pmix::PmixStatus::Known(pmix::PmixError::EventJobEnd);
     match pmix::events::notify_event(event, &proc, pmix::PmixDataRange::Session, &info) {
         Ok(()) => println!("notify_event accepted — handler will fire on the progress thread"),
@@ -98,7 +107,7 @@ fn main() {
     }
 
     // ── 5. Cleanup ─────────────────────────────────────────────────────────
-    if handler_ref != 0 {
+    if let Some(handler_ref) = handler_ref {
         match pmix::events::deregister_event_handler(handler_ref, None) {
             Ok(()) => println!("deregistered event handler {handler_ref}"),
             Err(e) => println!("deregister_event_handler: {e:?}"),
@@ -114,6 +123,10 @@ fn main() {
 /// documents that blocking PMIx calls are forbidden here, and the work is
 /// hopped onto a fresh application thread via
 /// [`spawn_from_callback`](pmix::threading::spawn_from_callback).
+///
+/// OpenPMIx requires every handler to complete the event chain by calling
+/// `cbfunc(..., cbdata)`. `progress_local_event_hdlr` thread-shifts, so the
+/// completion may safely run from the hopped-off application thread.
 unsafe extern "C" fn on_event(
     id: pmix::events::EventHandlerRef,
     status: i32,
@@ -122,8 +135,8 @@ unsafe extern "C" fn on_event(
     _ninfo: usize,
     _results: *mut c_void,
     _nresults: usize,
-    _cbfunc: pmix::events::pmix_event_notification_cbfunc_fn_t,
-    _cbdata: *mut c_void,
+    cbfunc: pmix::events::pmix_event_notification_cbfunc_fn_t,
+    cbdata: *mut c_void,
 ) {
     // We are on the progress thread — this marker is documentation, and any
     // blocking PMIx call here would deadlock progress.
@@ -131,8 +144,30 @@ unsafe extern "C" fn on_event(
 
     // Hop off: spawn an application thread for the actual handling. We never
     // join it here (that could block progress and deadlock the process).
+    // Complete the OpenPMIx event chain from the app thread after the work.
+    //
+    // Raw `*mut c_void` is `!Send`; carry the chain address as `usize` across
+    // the hop. Function pointers are already `Send`. Calling `cbfunc` from the
+    // app thread is the intended hop-off pattern (`progress_local_event_hdlr`
+    // does PMIX_THREADSHIFT internally).
+    let chain_addr = cbdata as usize;
     let _ = pmix::threading::spawn_from_callback(move || {
         println!("[app thread] event {id} fired with status {status} — blocking work is safe here");
+        if let Some(cbfunc) = cbfunc {
+            // SAFETY: complete the event chain; return OpenPMIx's chain pointer
+            // verbatim (never NULL). Address was received from OpenPMIx and is
+            // valid until the chain completes.
+            unsafe {
+                cbfunc(
+                    status,
+                    ptr::null_mut(),
+                    0,
+                    None,
+                    ptr::null_mut(),
+                    chain_addr as *mut c_void,
+                );
+            }
+        }
     });
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -22,6 +22,17 @@
 //! call is blocking and returns the handler reference ID directly in the
 //! return status (positive = success, negative = error).
 //!
+//! # Threading
+//!
+//! Event handlers are delivered on the PMIx **progress thread**, like all
+//! `_nb` completions. The notification bridge follows the policy in
+//! [`crate::threading`]: the user's `NotificationFn` is stored in a registry
+//! keyed by the handler reference ID (never a raw pointer in `cbdata`), and
+//! the registry lock is **not** held while the user callback runs. Handlers
+//! must not call blocking PMIx APIs; hop off with
+//! [`spawn_from_callback`](crate::threading::spawn_from_callback) or a
+//! [`CallbackChannel`](crate::threading::CallbackChannel) first.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -42,9 +53,11 @@
 //! deregister_event_handler(handler_ref, None).expect("deregister failed");
 //! ```
 
-use crate::{Info, PmixDataRange, PmixError, PmixStatus, Proc, ffi};
+use crate::{ffi, Info, PmixDataRange, PmixError, PmixStatus, Proc};
+use std::collections::HashMap;
 use std::os::raw::c_void;
 use std::ptr;
+use std::sync::{LazyLock, Mutex};
 
 /// PMIx event notification completion callback type (re-exported for external use).
 ///
@@ -131,8 +144,22 @@ pub type HandlerRegCbFn =
 pub type OpCbFn = Option<unsafe extern "C" fn(status: i32, cbdata: *mut c_void)>;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Internal bridge: convert our public NotificationFn to the FFI type
+// Internal bridge: ref-keyed handler registry
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Global registry mapping handler reference IDs to boxed user notification
+/// functions.
+///
+/// PMIx retains an event handler — and its `cbdata` — for the lifetime of the
+/// registration, so the user's [`NotificationFn`] must outlive it. We store
+/// the function here, keyed by the reference ID that PMIx passes to the
+/// notification bridge as its first argument, and free it at deregistration.
+/// This follows the bridge policy in [`crate::threading`]: the registry lock
+/// is held only to copy the function pointer out, never across the user call,
+/// and no callback data rides in a raw `cbdata` pointer.
+type HandlerRegistry = HashMap<EventHandlerRef, Box<NotificationFn>>;
+static HANDLER_REGISTRY: LazyLock<Mutex<HandlerRegistry>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Convert a user-provided `NotificationFn` into the FFI `pmix_notification_fn_t`.
 ///
@@ -140,6 +167,11 @@ pub type OpCbFn = Option<unsafe extern "C" fn(status: i32, cbdata: *mut c_void)>
 /// `source`, `info`, and `results` parameters so that callers outside the crate
 /// don't need access to the private `ffi` module. This bridge casts those back
 /// to the real FFI types before calling the user's function.
+///
+/// Runs on the PMIx **progress thread**. The user function is resolved from
+/// [`HANDLER_REGISTRY`] under a scoped lock that is released before the user
+/// callback executes; the callback must not call blocking PMIx APIs (see
+/// [`crate::threading`]).
 unsafe extern "C" fn notification_bridge(
     evhdlr_registration_id: EventHandlerRef,
     status: i32,
@@ -149,13 +181,23 @@ unsafe extern "C" fn notification_bridge(
     results: *mut ffi::pmix_info_t,
     nresults: usize,
     cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-    cbdata: *mut c_void,
+    _cbdata: *mut c_void,
 ) {
+    // Copy the user fn pointer out of the registry WITHOUT holding the lock
+    // across the user call (bridge policy). Function pointers are `Copy`, so
+    // a short scoped critical section is all we need.
+    let user_fn = {
+        let registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+        registry
+            .get(&evhdlr_registration_id)
+            .and_then(|b| *b.as_ref())
+    };
+
     // SAFETY: We cast the FFI pointers back to c_void and call the user's
     // callback. The user callback receives opaque pointers and is not expected
     // to dereference them without casting back.
-    unsafe {
-        if let Some(user_fn) = *(cbdata as *mut NotificationFn) {
+    if let Some(user_fn) = user_fn {
+        unsafe {
             user_fn(
                 evhdlr_registration_id,
                 status,
@@ -171,18 +213,43 @@ unsafe extern "C" fn notification_bridge(
     }
 }
 
-/// Wrap a user `NotificationFn` into the FFI type, storing the user function
-/// in a heap-allocated box that we pass as `cbdata` to the bridge.
-fn wrap_notification_fn(user_fn: NotificationFn) -> (ffi::pmix_notification_fn_t, *mut c_void) {
-    if user_fn.is_some() {
-        // Allocate the user function on the heap so the bridge can access it.
-        let boxed = Box::new(user_fn);
-        (
-            Some(notification_bridge),
-            Box::into_raw(boxed) as *mut c_void,
-        )
-    } else {
-        (None, std::ptr::null_mut())
+/// State carried by [`register_event_handler_nb`]'s completion bridge: the
+/// boxed user notification fn plus the user's own completion callback and
+/// opaque data, forwarded verbatim once the reference ID is known.
+struct HandlerRegState {
+    user_fn: Box<NotificationFn>,
+    user_cbfunc: HandlerRegCbFn,
+    user_cbdata: *mut c_void,
+}
+
+/// C bridge for the registration-completion callback of
+/// [`register_event_handler_nb`].
+///
+/// For non-blocking registration the reference ID is only known here, so the
+/// boxed user notification fn is parked in [`HANDLER_REGISTRY`] at this point
+/// (freed on error instead, so it never leaks). The user's own `cbfunc` is
+/// then forwarded verbatim with the original `cbdata`.
+extern "C" fn handler_reg_cb_bridge(status: i32, refid: EventHandlerRef, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+
+    // SAFETY: cbdata is the `Box<HandlerRegState>` we passed to
+    // PMIx_Register_event_handler. PMIx invokes the registration completion
+    // callback exactly once per registration request.
+    let state = unsafe { Box::from_raw(cbdata as *mut HandlerRegState) };
+
+    if PmixStatus::from_raw(status).is_success() {
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(refid, state.user_fn);
+    }
+
+    if let Some(user_cbfunc) = state.user_cbfunc {
+        // SAFETY: user-supplied completion callback with user-supplied opaque
+        // cbdata; both are forwarded verbatim from the registration call.
+        unsafe { user_cbfunc(status, refid, state.user_cbdata) };
     }
 }
 
@@ -201,7 +268,9 @@ fn wrap_notification_fn(user_fn: NotificationFn) -> (ffi::pmix_notification_fn_t
 /// * `codes` — array of event codes to handle (empty = all events).
 /// * `info` — optional info directives (e.g., range, scope).
 /// * `evhdlr` — the notification callback function.
-/// * `cbfunc` — `None` for blocking mode; `Some(...)` for non-blocking.
+/// * `cbfunc` — `None` for blocking mode; `Some(...)` for non-blocking
+///   (in which case the reference ID is delivered to `cbfunc` and the return
+///   value is not meaningful — prefer [`register_event_handler_nb`]).
 ///
 /// # Returns
 /// * `Ok(handler_ref)` — the handler reference ID (positive integer).
@@ -242,42 +311,36 @@ pub fn register_event_handler(
         (ptr::null(), 0)
     };
 
-    let (ffi_evhdlr, evhdlr_cbdata) = wrap_notification_fn(evhdlr);
-
     // SAFETY: FFI call into PMIx library. The codes slice and info handle
-    // remain valid for the duration of this call. PMIx does not retain these
-    // pointers after the call returns (blocking mode) or after cbfunc fires
-    // (non-blocking mode).
+    // remain valid for the duration of this call. The user's notification fn
+    // is kept alive by HANDLER_REGISTRY (keyed by the reference ID PMIx
+    // returns) and freed at deregistration — no callback data rides in cbdata,
+    // so NULL is passed and nothing is freed after this call returns.
     let raw_status = unsafe {
         ffi::PMIx_Register_event_handler(
             codes_ptr,
             ncodes,
             info_ptr as *mut ffi::pmix_info_t,
             ninfo,
-            ffi_evhdlr,
+            Some(notification_bridge),
             cbfunc,
-            evhdlr_cbdata,
+            ptr::null_mut(),
         )
     };
 
-    // Clean up the boxed notification fn if we allocated one.
-    // In blocking mode, the registration is complete, so we can free it.
-    // In non-blocking mode, the bridge holds a reference — but for blocking
-    // mode (cbfunc is None), PMIx doesn't retain our bridge pointer, so
-    // we need to clean up after the call returns.
-    if !evhdlr_cbdata.is_null() {
-        unsafe {
-            // Recover the boxed NotificationFn and drop it.
-            // Note: in non-blocking mode this is a use-after-free bug because
-            // the bridge still needs it. For now, only blocking mode is safe.
-            // Users should prefer blocking mode or manage lifetime manually.
-            let _ = Box::from_raw(evhdlr_cbdata as *mut NotificationFn);
-        }
-    }
-
     let status = PmixStatus::from_raw(raw_status);
     if status.is_success() {
-        Ok(raw_status as EventHandlerRef)
+        let handler_ref = raw_status as EventHandlerRef;
+        if evhdlr.is_some() {
+            // Park the user fn for the lifetime of the registration. PMIx may
+            // deliver an event to the bridge the moment registration returns,
+            // so insert before returning to the caller.
+            HANDLER_REGISTRY
+                .lock()
+                .expect("mutex poisoned (events.rs)")
+                .insert(handler_ref, Box::new(evhdlr));
+        }
+        Ok(handler_ref)
     } else {
         Err(status)
     }
@@ -321,21 +384,32 @@ pub fn register_event_handler_nb(
         (ptr::null(), 0)
     };
 
-    let (ffi_evhdlr, _evhdlr_cbdata) = wrap_notification_fn(evhdlr);
+    // In non-blocking mode the reference ID is only delivered via cbfunc, so
+    // the user fn is boxed into a registration state; the completion bridge
+    // parks it in HANDLER_REGISTRY (freed on error) and then forwards to the
+    // user's cbfunc. The notification bridge resolves the fn by ref ID, so no
+    // callback data is needed in the registration cbdata — except the state
+    // box itself, which PMIx passes back to our completion bridge.
+    let state = Box::new(HandlerRegState {
+        user_fn: Box::new(evhdlr),
+        user_cbfunc: cbfunc,
+        user_cbdata: cbdata,
+    });
 
     // SAFETY: FFI call into PMIx library. The codes slice lives for the
-    // duration of this call. In non-blocking mode, PMIx retains the
-    // evhdlr callback; it must be a static function or otherwise live
-    // for the lifetime of the handler.
+    // duration of this call. The boxed HandlerRegState is reclaimed by
+    // handler_reg_cb_bridge exactly once; on synchronous failure it is
+    // intentionally leaked (PMIx may still invoke the completion callback
+    // with an error status, so freeing it here could double-free).
     let raw_status = unsafe {
         ffi::PMIx_Register_event_handler(
             codes_ptr,
             ncodes,
             info_ptr as *mut ffi::pmix_info_t,
             ninfo,
-            ffi_evhdlr,
-            cbfunc,
-            cbdata,
+            Some(notification_bridge),
+            Some(handler_reg_cb_bridge),
+            Box::into_raw(state) as *mut c_void,
         )
     };
 
@@ -376,6 +450,15 @@ pub fn deregister_event_handler(
     evhdlr_ref: EventHandlerRef,
     cbfunc: OpCbFn,
 ) -> Result<(), PmixStatus> {
+    // Free the boxed user fn BEFORE the C call so the notification bridge can
+    // no longer fire into freed memory, even if an event is already in flight
+    // on the progress thread. If the C deregistration then fails, the handler
+    // stays registered but its events are silently dropped (no UAF).
+    HANDLER_REGISTRY
+        .lock()
+        .expect("mutex poisoned (events.rs)")
+        .remove(&evhdlr_ref);
+
     // SAFETY: FFI call into PMIx library. evhdlr_ref is an opaque usize
     // returned by the library itself, so it is valid to pass back.
     let raw_status =
@@ -534,6 +617,7 @@ pub fn notify_event_nb(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
 
     // ─── Type alias tests ───────────────────────────────────────────────────
 
@@ -573,18 +657,118 @@ mod tests {
         assert!(fn_.is_none());
     }
 
-    // ─── wrap_notification_fn tests ─────────────────────────────────────────
+    // ─── Handler registry + notification bridge tests ──────────────────────
 
-    #[test]
-    fn test_wrap_notification_fn_none() {
-        let (ffi_fn, cbdata) = wrap_notification_fn(None);
-        assert!(ffi_fn.is_none());
-        assert!(cbdata.is_null());
+    use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
+
+    /// A no-op user notification handler for bridge tests.
+    unsafe extern "C" fn test_handler(
+        _id: EventHandlerRef,
+        _status: i32,
+        _source: *const std::os::raw::c_void,
+        _info: *mut std::os::raw::c_void,
+        _ninfo: usize,
+        _results: *mut std::os::raw::c_void,
+        _nresults: usize,
+        _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
+        _cbdata: *mut std::os::raw::c_void,
+    ) {
     }
 
     #[test]
-    fn test_wrap_notification_fn_some() {
-        extern "C" fn dummy_handler(
+    fn test_handler_registry_insert_lookup_remove() {
+        let ref_id: EventHandlerRef = 424242;
+        {
+            let mut registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+            registry.insert(ref_id, Box::new(Some(test_handler)));
+            let found = registry.get(&ref_id).and_then(|b| *b.as_ref());
+            assert!(found.is_some(), "user fn should be findable by ref id");
+            registry.remove(&ref_id);
+            assert!(registry.get(&ref_id).is_none());
+        }
+    }
+
+    #[test]
+    fn test_notification_bridge_invokes_user_fn() {
+        static CALLED: AtomicBool = AtomicBool::new(false);
+
+        unsafe extern "C" fn recording_handler(
+            _id: EventHandlerRef,
+            status: i32,
+            _source: *const std::os::raw::c_void,
+            _info: *mut std::os::raw::c_void,
+            _ninfo: usize,
+            _results: *mut std::os::raw::c_void,
+            _nresults: usize,
+            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
+            _cbdata: *mut std::os::raw::c_void,
+        ) {
+            assert_eq!(status, 7, "handler should receive the event status");
+            CALLED.store(true, Ordering::SeqCst);
+        }
+
+        let ref_id: EventHandlerRef = 424243;
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(ref_id, Box::new(Some(recording_handler)));
+
+        unsafe {
+            notification_bridge(
+                ref_id,
+                7,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                None,
+                std::ptr::null_mut(),
+            );
+        }
+
+        assert!(
+            CALLED.load(Ordering::SeqCst),
+            "bridge must invoke the user fn"
+        );
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .remove(&ref_id);
+    }
+
+    #[test]
+    fn test_notification_bridge_unknown_ref_is_noop() {
+        // No registry entry — the bridge must skip silently (this also covers
+        // the window before a registration completes).
+        unsafe {
+            notification_bridge(
+                999_999_999,
+                0,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                None,
+                std::ptr::null_mut(),
+            );
+        }
+    }
+
+    /// Deadlock regression (issue #51): the notification bridge must NOT hold
+    /// the registry lock while the user callback runs.
+    ///
+    /// A user handler that blocks is invoked from a stand-in progress thread;
+    /// while it is blocked, this test must still be able to acquire the
+    /// registry lock. If the lock were held across the user call, the
+    /// `try_lock` below would fail and the test would fail.
+    #[test]
+    fn test_notification_bridge_no_lock_across_user_code() {
+        static ENTER_TX: Mutex<Option<mpsc::Sender<()>>> = Mutex::new(None);
+        static RELEASE_RX: Mutex<Option<mpsc::Receiver<()>>> = Mutex::new(None);
+
+        unsafe extern "C" fn blocking_handler(
             _id: EventHandlerRef,
             _status: i32,
             _source: *const std::os::raw::c_void,
@@ -595,14 +779,167 @@ mod tests {
             _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
             _cbdata: *mut std::os::raw::c_void,
         ) {
+            if let Some(tx) = ENTER_TX
+                .lock()
+                .expect("mutex poisoned (events.rs)")
+                .as_ref()
+            {
+                let _ = tx.send(());
+            }
+            if let Some(rx) = RELEASE_RX
+                .lock()
+                .expect("mutex poisoned (events.rs)")
+                .as_ref()
+            {
+                let _ = rx.recv_timeout(std::time::Duration::from_secs(5));
+            }
         }
-        let (ffi_fn, cbdata) = wrap_notification_fn(Some(dummy_handler));
-        assert!(ffi_fn.is_some());
-        assert!(!cbdata.is_null());
-        // Clean up the allocated box
-        unsafe {
-            let _ = Box::from_raw(cbdata as *mut NotificationFn);
+
+        let (enter_tx, enter_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        *ENTER_TX.lock().expect("mutex poisoned (events.rs)") = Some(enter_tx);
+        *RELEASE_RX.lock().expect("mutex poisoned (events.rs)") = Some(release_rx);
+
+        let ref_id: EventHandlerRef = 424244;
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(ref_id, Box::new(Some(blocking_handler)));
+
+        // Stand-in "progress thread": delivers the event, blocking inside the
+        // user handler until released.
+        let progress_thread = std::thread::spawn(move || unsafe {
+            notification_bridge(
+                ref_id,
+                0,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                None,
+                std::ptr::null_mut(),
+            );
+        });
+
+        // Wait until the user handler is executing…
+        enter_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("handler should have entered");
+        // …and prove the registry lock is free: try_lock must succeed.
+        // (If the bridge held the lock across the user call, this would be
+        // `Err(TryLockError::WouldBlock)`.)
+        let guard = HANDLER_REGISTRY
+            .try_lock()
+            .expect("registry lock must not be held across user callback code");
+        drop(guard);
+
+        // Release the handler and let the progress thread finish.
+        let _ = release_tx.send(());
+        progress_thread
+            .join()
+            .expect("progress thread should finish");
+
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .remove(&ref_id);
+    }
+
+    #[test]
+    fn test_handler_reg_cb_bridge_parks_fn_on_success() {
+        static REG_REFID: AtomicUsize = AtomicUsize::new(0);
+
+        unsafe extern "C" fn reg_cb(
+            _status: i32,
+            refid: EventHandlerRef,
+            _cbdata: *mut std::os::raw::c_void,
+        ) {
+            REG_REFID.store(refid, Ordering::SeqCst);
         }
+
+        let ref_id: EventHandlerRef = 424245;
+        let state = Box::new(HandlerRegState {
+            user_fn: Box::new(Some(test_handler)),
+            user_cbfunc: Some(reg_cb),
+            user_cbdata: std::ptr::null_mut(),
+        });
+
+        handler_reg_cb_bridge(
+            0, /* PMIX_SUCCESS */
+            ref_id,
+            Box::into_raw(state) as *mut c_void,
+        );
+
+        // The user fn is now parked in the registry under the delivered ref id,
+        // and the user's completion callback was forwarded the ref id.
+        assert_eq!(REG_REFID.load(Ordering::SeqCst), ref_id);
+        let parked = {
+            let registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+            registry.get(&ref_id).and_then(|b| *b.as_ref())
+        };
+        assert!(
+            parked.is_some(),
+            "user fn should be parked on successful registration"
+        );
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .remove(&ref_id);
+    }
+
+    #[test]
+    fn test_handler_reg_cb_bridge_error_frees_state() {
+        static REG_STATUS: AtomicI32 = AtomicI32::new(0);
+
+        unsafe extern "C" fn reg_cb(
+            status: i32,
+            _refid: EventHandlerRef,
+            _cbdata: *mut std::os::raw::c_void,
+        ) {
+            REG_STATUS.store(status, Ordering::SeqCst);
+        }
+
+        let ref_id: EventHandlerRef = 424246;
+        let state = Box::new(HandlerRegState {
+            user_fn: Box::new(Some(test_handler)),
+            user_cbfunc: Some(reg_cb),
+            user_cbdata: std::ptr::null_mut(),
+        });
+
+        handler_reg_cb_bridge(
+            -39, /* PMIX_ERR_INIT */
+            ref_id,
+            Box::into_raw(state) as *mut c_void,
+        );
+
+        // Failure: nothing parked (box freed instead), user cbfunc still
+        // forwarded the error status verbatim.
+        assert_eq!(REG_STATUS.load(Ordering::SeqCst), -39);
+        let registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+        assert!(
+            registry.get(&ref_id).is_none(),
+            "no fn parked on failed registration"
+        );
+    }
+
+    #[test]
+    fn test_deregister_removes_registry_entry() {
+        let ref_id: EventHandlerRef = 424247;
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(ref_id, Box::new(Some(test_handler)));
+
+        // Without PMIx init the C call fails, but the registry entry is freed
+        // first — no handler can fire into freed memory after this returns.
+        let _ = deregister_event_handler(ref_id, None);
+
+        let registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+        assert!(
+            registry.get(&ref_id).is_none(),
+            "deregistration must free the user fn"
+        );
     }
 
     // ─── PmixDataRange tests ────────────────────────────────────────────────
@@ -1136,108 +1473,10 @@ mod tests {
         }
     }
 
-    // ─── wrap_notification_fn with Some ─────────────────────────────────────
-
-    #[test]
-    fn test_wrap_notification_fn_some_returns_bridge() {
-        extern "C" fn dummy(
-            _id: EventHandlerRef,
-            _status: i32,
-            _source: *const c_void,
-            _info: *mut c_void,
-            _ninfo: usize,
-            _results: *mut c_void,
-            _nresults: usize,
-            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-            _cbdata: *mut c_void,
-        ) {
-        }
-        let (ffi_fn, cbdata) = wrap_notification_fn(Some(dummy));
-        assert!(ffi_fn.is_some());
-        assert!(!cbdata.is_null());
-        // Clean up
-        unsafe {
-            let _ = Box::from_raw(cbdata as *mut NotificationFn);
-        }
-    }
-
-    #[test]
-    fn test_wrap_notification_fn_none_returns_null() {
-        let (ffi_fn, cbdata) = wrap_notification_fn(None);
-        assert!(ffi_fn.is_none());
-        assert!(cbdata.is_null());
-    }
-
-    // ─── notification_bridge tests ──────────────────────────────────────────
-
-    #[test]
-    fn test_notification_bridge_with_null_cbdata() {
-        // When cbdata is null, notification_bridge should not crash
-        // It checks if let Some(user_fn) = *(cbdata as *mut NotificationFn)
-        // With a null pointer, this would dereference null — but since
-        // we're testing, we use a valid pointer to None
-        let boxed_fn: Box<NotificationFn> = Box::new(None);
-        let raw = Box::into_raw(boxed_fn) as *mut c_void;
-        unsafe {
-            notification_bridge(
-                42,
-                0,
-                std::ptr::null(),
-                std::ptr::null_mut(),
-                0,
-                std::ptr::null_mut(),
-                0,
-                None,
-                raw,
-            );
-        }
-        // Clean up — the boxed NotificationFn with None value
-        unsafe {
-            let _ = Box::from_raw(raw as *mut NotificationFn);
-        }
-    }
-
-    #[test]
-    fn test_notification_bridge_invokes_user_fn() {
-        use std::sync::Arc;
-        let called = Arc::new(std::sync::Mutex::new(false));
-        let _called_clone = called.clone();
-
-        extern "C" fn dummy(
-            _id: EventHandlerRef,
-            _status: i32,
-            _source: *const c_void,
-            _info: *mut c_void,
-            _ninfo: usize,
-            _results: *mut c_void,
-            _nresults: usize,
-            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-            _cbdata: *mut c_void,
-        ) {
-        }
-
-        // Create a boxed NotificationFn with Some(dummy)
-        let boxed_fn: Box<NotificationFn> = Box::new(Some(dummy));
-        let raw = Box::into_raw(boxed_fn) as *mut c_void;
-
-        unsafe {
-            notification_bridge(
-                42,
-                0,
-                std::ptr::null(),
-                std::ptr::null_mut(),
-                0,
-                std::ptr::null_mut(),
-                0,
-                None,
-                raw,
-            );
-        }
-        // Clean up
-        unsafe {
-            let _ = Box::from_raw(raw as *mut NotificationFn);
-        }
-    }
+    // ─── Notification bridge (registry-based) tests live at the top of this
+    // module (see `test_notification_bridge_*`). The old boxed-cbdata
+    // mechanism they replaced is gone; handlers are stored in
+    // HANDLER_REGISTRY keyed by the reference ID.
 
     // ─── PmixDataRange variant tests ────────────────────────────────────────
 
@@ -2210,59 +2449,6 @@ mod tests {
     fn test_data_range_from_raw_one() {
         let range = PmixDataRange::from_raw(1);
         assert_eq!(range.to_raw(), 1);
-    }
-
-    // ─── wrap_notification_fn: multiple calls produce independent boxes ────
-
-    #[test]
-    fn test_wrap_notification_fn_multiple_calls_independent() {
-        extern "C" fn dummy1(
-            _id: EventHandlerRef,
-            _status: i32,
-            _source: *const c_void,
-            _info: *mut c_void,
-            _ninfo: usize,
-            _results: *mut c_void,
-            _nresults: usize,
-            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-            _cbdata: *mut c_void,
-        ) {
-        }
-        extern "C" fn dummy2(
-            _id: EventHandlerRef,
-            _status: i32,
-            _source: *const c_void,
-            _info: *mut c_void,
-            _ninfo: usize,
-            _results: *mut c_void,
-            _nresults: usize,
-            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-            _cbdata: *mut c_void,
-        ) {
-        }
-        let (ffi1, data1) = wrap_notification_fn(Some(dummy1));
-        let (ffi2, data2) = wrap_notification_fn(Some(dummy2));
-        assert!(ffi1.is_some());
-        assert!(ffi2.is_some());
-        assert!(!data1.is_null());
-        assert!(!data2.is_null());
-        // Both should point to the same bridge function
-        assert!(ffi1.is_some() && ffi2.is_some());
-        // Clean up both boxes
-        unsafe {
-            let _ = Box::from_raw(data1 as *mut NotificationFn);
-            let _ = Box::from_raw(data2 as *mut NotificationFn);
-        }
-    }
-
-    #[test]
-    fn test_wrap_notification_fn_none_multiple_calls() {
-        let (ffi1, data1) = wrap_notification_fn(None);
-        let (ffi2, data2) = wrap_notification_fn(None);
-        assert!(ffi1.is_none());
-        assert!(ffi2.is_none());
-        assert!(data1.is_null());
-        assert!(data2.is_null());
     }
 
     // ─── register_event_handler_nb with user cbdata ────────────────────────

--- a/src/events.rs
+++ b/src/events.rs
@@ -119,8 +119,17 @@ pub type EventHandlerRef = usize;
 ///     void *cbdata
 /// );
 /// ```
+///
+/// # ABI
+///
+/// This is a **Rust-ABI** `unsafe fn`, not `extern "C"`. Only
+/// [`notification_bridge`] is registered with OpenPMIx; it is the sole
+/// C→Rust FFI boundary. Keeping the user handler off the C ABI means a
+/// panic inside the handler can be caught (`catch_unwind`) instead of
+/// aborting via `nounwind` — required so the bridge can still complete the
+/// OpenPMIx event chain.
 pub type NotificationFn = Option<
-    unsafe extern "C" fn(
+    unsafe fn(
         evhdlr_registration_id: EventHandlerRef,
         status: i32,
         source: *const c_void,
@@ -169,13 +178,57 @@ pub type OpCbFn = Option<unsafe extern "C" fn(status: i32, cbdata: *mut c_void)>
 /// PMIx retains an event handler — and its `cbdata` — for the lifetime of the
 /// registration, so the user's [`NotificationFn`] must outlive it. We store
 /// the function here, keyed by the reference ID that PMIx passes to the
-/// notification bridge as its first argument, and free it at deregistration.
+/// notification bridge as its first argument, and free it at deregistration
+/// (or session finalize via [`clear_handler_registry`]).
+///
 /// This follows the bridge policy in [`crate::threading`]: the registry lock
 /// is held only to copy the function pointer out, never across the user call,
 /// and no callback data rides in a raw `cbdata` pointer.
+///
+/// # Invariant
+///
+/// Entries are plain [`NotificationFn`] values (`Option` of a function pointer).
+/// Function pointers are `Copy`, so copying the fn out under the lock and later
+/// dropping the `Box` is not a use-after-free. That analysis would not hold if
+/// this type ever became a capturing closure / trait object.
 type HandlerRegistry = HashMap<EventHandlerRef, Box<NotificationFn>>;
 static HANDLER_REGISTRY: LazyLock<Mutex<HandlerRegistry>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Drop every parked notification handler.
+///
+/// Called from client / tool / server session finalize paths so registrations
+/// that were never explicitly deregistered do not leak `Box<NotificationFn>`
+/// for the rest of the process lifetime. Safe under the crate's no-reinit
+/// policy: after finalize, no further event deliveries are expected.
+pub(crate) fn clear_handler_registry() {
+    HANDLER_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Complete an OpenPMIx local event-handler chain (pass-through / recovery).
+///
+/// # Safety
+///
+/// `cbfunc` / `cbdata` / `results` must be the values OpenPMIx supplied to the
+/// notification handler (or nulls). Double-completion of the same chain is
+/// undefined at the C layer — call at most once per delivery.
+unsafe fn complete_event_chain(
+    status: i32,
+    results: *mut ffi::pmix_info_t,
+    nresults: usize,
+    cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
+    cbdata: *mut c_void,
+) {
+    if let Some(cbfunc) = cbfunc {
+        // SAFETY: caller upholds OpenPMIx chain-completion contract.
+        unsafe {
+            cbfunc(status, results, nresults, None, ptr::null_mut(), cbdata);
+        }
+    }
+}
 
 /// Convert a user-provided `NotificationFn` into the FFI `pmix_notification_fn_t`.
 ///
@@ -203,6 +256,11 @@ static HANDLER_REGISTRY: LazyLock<Mutex<HandlerRegistry>> =
 /// insert) this bridge still calls `cbfunc` as a pass-through so the chain
 /// stays alive. The chain pointer is always forwarded verbatim — never
 /// replaced with `NULL`.
+///
+/// User-handler panics are caught: unwinding across the C→Rust FFI boundary
+/// is undefined behaviour, and a panic that skips `cbfunc` would stall the
+/// chain. The bridge completes the chain, logs, and **contains** the panic
+/// (does not `resume_unwind` into OpenPMIx).
 unsafe extern "C" fn notification_bridge(
     evhdlr_registration_id: EventHandlerRef,
     status: i32,
@@ -218,7 +276,7 @@ unsafe extern "C" fn notification_bridge(
     // across the user call (bridge policy). Function pointers are `Copy`, so
     // a short scoped critical section is all we need.
     let user_fn = {
-        let registry = HANDLER_REGISTRY.lock().expect("mutex poisoned (events.rs)");
+        let registry = HANDLER_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
         registry
             .get(&evhdlr_registration_id)
             .and_then(|b| *b.as_ref())
@@ -228,7 +286,11 @@ unsafe extern "C" fn notification_bridge(
         // SAFETY: cast FFI pointers to c_void for the user-facing NotificationFn
         // ABI. Forward OpenPMIx's chain pointer (`cbdata`) and completion
         // `cbfunc` verbatim — the handler must return them via cbfunc.
-        unsafe {
+        //
+        // catch_unwind: this bridge is an `extern "C"` entry called from
+        // OpenPMIx. A panic must not unwind into C, and must not leave the
+        // event chain incomplete.
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             user_fn(
                 evhdlr_registration_id,
                 status,
@@ -240,14 +302,31 @@ unsafe extern "C" fn notification_bridge(
                 cbfunc,
                 cbdata,
             );
+        }))
+        .is_err();
+
+        if panicked {
+            eprintln!(
+                "pmix::events: notification handler panicked on the progress thread; \
+                 completing the OpenPMIx event chain and containing the panic \
+                 (must not unwind across FFI)"
+            );
+            // Best-effort chain recovery. If the handler already completed the
+            // chain before panicking, this is a second completion (undefined at
+            // the C layer); that is still preferable to permanently stalling
+            // every subsequent notify when the handler panics first.
+            // SAFETY: same OpenPMIx-supplied cbfunc/cbdata/results as this delivery.
+            unsafe {
+                complete_event_chain(status, results, nresults, cbfunc, cbdata);
+            }
         }
-    } else if let Some(cbfunc) = cbfunc {
+    } else {
         // Registry miss / no user handler: pass-through completion keeps the
         // OpenPMIx event chain alive. Do not drop `cbfunc` here.
         // SAFETY: OpenPMIx-supplied completion with its chain pointer; status
         // and results are forwarded as received.
         unsafe {
-            cbfunc(status, results, nresults, None, ptr::null_mut(), cbdata);
+            complete_event_chain(status, results, nresults, cbfunc, cbdata);
         }
     }
 }
@@ -315,6 +394,17 @@ extern "C" fn handler_reg_cb_bridge(status: i32, refid: EventHandlerRef, cbdata:
 /// * `Ok(handler_ref)` — the handler reference ID (a non-negative integer;
 ///   **`0` is a valid first ref id** in OpenPMIx, not a failure sentinel).
 /// * `Err(PmixStatus)` — registration failed (e.g., `PMIX_ERR_INIT`).
+///
+/// # Registration-window delivery
+///
+/// The C-side handler is live as soon as `PMIx_Register_event_handler`
+/// returns, but the reference ID is only known **after** that return, so
+/// the Rust registry insert cannot run earlier. An event delivered in that
+/// gap is **pass-through-completed without invoking `evhdlr`** (dropped at
+/// the Rust layer; the OpenPMIx chain still advances). Loss-sensitive
+/// notifications (e.g. `PMIX_EVENT_JOB_END`) can therefore miss a delivery
+/// that races registration — re-check state after register returns, or
+/// tolerate a possible drop in that window.
 ///
 /// # C API
 /// ```c
@@ -755,7 +845,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 
     /// A no-op user notification handler for bridge tests.
-    unsafe extern "C" fn test_handler(
+    unsafe fn test_handler(
         _id: EventHandlerRef,
         _status: i32,
         _source: *const std::os::raw::c_void,
@@ -786,7 +876,7 @@ mod tests {
         static CALLED: AtomicBool = AtomicBool::new(false);
         static SAW_CBDATA: AtomicUsize = AtomicUsize::new(0);
 
-        unsafe extern "C" fn recording_handler(
+        unsafe fn recording_handler(
             _id: EventHandlerRef,
             status: i32,
             _source: *const std::os::raw::c_void,
@@ -909,6 +999,106 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_notification_bridge_user_panic_completes_chain_and_is_contained() {
+        // A panicking user handler must not unwind into OpenPMIx (UB) and must
+        // still complete the event chain so blocking notify_event cannot hang.
+        static CBFUNC_CALLED: AtomicBool = AtomicBool::new(false);
+        static CBFUNC_STATUS: AtomicI32 = AtomicI32::new(i32::MIN);
+        static CBFUNC_CBDATA: AtomicUsize = AtomicUsize::new(0);
+
+        unsafe fn panicking_handler(
+            _id: EventHandlerRef,
+            _status: i32,
+            _source: *const std::os::raw::c_void,
+            _info: *mut std::os::raw::c_void,
+            _ninfo: usize,
+            _results: *mut std::os::raw::c_void,
+            _nresults: usize,
+            _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
+            _cbdata: *mut std::os::raw::c_void,
+        ) {
+            panic!("user notification handler panicked on purpose");
+        }
+
+        unsafe extern "C" fn recording_cbfunc(
+            status: i32,
+            _results: *mut ffi::pmix_info_t,
+            _nresults: usize,
+            _cbfunc: ffi::pmix_op_cbfunc_t,
+            _thiscbdata: *mut c_void,
+            notification_cbdata: *mut c_void,
+        ) {
+            CBFUNC_STATUS.store(status, Ordering::SeqCst);
+            CBFUNC_CBDATA.store(notification_cbdata as usize, Ordering::SeqCst);
+            CBFUNC_CALLED.store(true, Ordering::SeqCst);
+        }
+
+        let ref_id: EventHandlerRef = 424_250;
+        let chain_token = 0xE_u8;
+        let chain_ptr = &chain_token as *const u8 as *mut c_void;
+
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(ref_id, Box::new(Some(panicking_handler)));
+
+        // Must return normally (panic contained) — would abort the test thread
+        // if resume_unwind crossed the bridge.
+        unsafe {
+            notification_bridge(
+                ref_id,
+                11,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                Some(recording_cbfunc),
+                chain_ptr,
+            );
+        }
+
+        assert!(
+            CBFUNC_CALLED.load(Ordering::SeqCst),
+            "hit-path panic must still complete the OpenPMIx event chain"
+        );
+        assert_eq!(CBFUNC_STATUS.load(Ordering::SeqCst), 11);
+        assert_eq!(
+            CBFUNC_CBDATA.load(Ordering::SeqCst),
+            chain_ptr as usize,
+            "panic recovery must forward chain cbdata verbatim"
+        );
+
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .remove(&ref_id);
+    }
+
+    #[test]
+    fn test_clear_handler_registry_drops_parked_fns() {
+        let ref_id: EventHandlerRef = 424_251;
+        HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .insert(ref_id, Box::new(Some(test_handler)));
+        assert!(HANDLER_REGISTRY
+            .lock()
+            .expect("mutex poisoned (events.rs)")
+            .contains_key(&ref_id));
+
+        clear_handler_registry();
+
+        assert!(
+            HANDLER_REGISTRY
+                .lock()
+                .expect("mutex poisoned (events.rs)")
+                .is_empty(),
+            "finalize cleanup must drop every parked NotificationFn"
+        );
+    }
+
     /// Deadlock / lock-order regression (issue #51): the event-handler registry
     /// lock must **not** be held while the user callback runs.
     ///
@@ -921,7 +1111,7 @@ mod tests {
         static ENTER_TX: Mutex<Option<mpsc::Sender<()>>> = Mutex::new(None);
         static RELEASE_RX: Mutex<Option<mpsc::Receiver<()>>> = Mutex::new(None);
 
-        unsafe extern "C" fn blocking_handler(
+        unsafe fn blocking_handler(
             _id: EventHandlerRef,
             _status: i32,
             _source: *const std::os::raw::c_void,
@@ -1219,7 +1409,7 @@ mod tests {
 
     #[test]
     fn test_notification_fn_is_option() {
-        // Verify NotificationFn is Option<extern "C" fn(...)>
+        // Verify NotificationFn is Option<unsafe fn(...)>
         let fn_: NotificationFn = None;
         assert!(fn_.is_none());
         assert_eq!(fn_.as_ref(), None);
@@ -1298,7 +1488,7 @@ mod tests {
 
     #[test]
     fn test_register_event_handler_with_notification_fn() {
-        extern "C" fn dummy_handler(
+        fn dummy_handler(
             _id: EventHandlerRef,
             _status: i32,
             _source: *const std::os::raw::c_void,
@@ -1788,7 +1978,7 @@ mod tests {
 
     #[test]
     fn test_register_event_handler_nb_with_notification_fn() {
-        extern "C" fn dummy_handler(
+        fn dummy_handler(
             _id: EventHandlerRef,
             _status: i32,
             _source: *const c_void,
@@ -2785,7 +2975,7 @@ mod tests {
 
     #[test]
     fn test_notification_bridge_with_some_user_fn() {
-        extern "C" fn dummy(
+        fn dummy(
             _id: EventHandlerRef,
             _status: i32,
             _source: *const c_void,

--- a/src/events.rs
+++ b/src/events.rs
@@ -89,7 +89,23 @@ pub type EventHandlerRef = usize;
 /// * `results` — results from handlers that ran before this one.
 /// * `nresults` — number of results entries.
 /// * `cbfunc` — completion callback to call when this handler is done.
-/// * `cbdata` — user data to pass through to `cbfunc`.
+/// * `cbdata` — **OpenPMIx event-chain pointer**. Must be returned **verbatim**
+///   through `cbfunc` (as `notification_cbdata`). OpenPMIx's
+///   `progress_local_event_hdlr` casts it to the chain object with no NULL
+///   check — discarding it or substituting `NULL` stalls or crashes the
+///   event engine. Call `cbfunc` from the progress thread or from a hopped-off
+///   application thread (`progress_local_event_hdlr` thread-shifts).
+///
+/// # Contract
+///
+/// Handlers **must** complete the event chain. Typical completion:
+///
+/// ```text
+/// cbfunc(status, results, nresults, None, null_mut(), cbdata)
+/// ```
+///
+/// Omitting the call permanently stalls the chain (blocking `notify_event`
+/// never returns; subsequent deliveries hang).
 ///
 /// # C API
 /// ```c
@@ -172,6 +188,21 @@ static HANDLER_REGISTRY: LazyLock<Mutex<HandlerRegistry>> =
 /// [`HANDLER_REGISTRY`] under a scoped lock that is released before the user
 /// callback executes; the callback must not call blocking PMIx APIs (see
 /// [`crate::threading`]).
+///
+/// # Event-chain completion
+///
+/// OpenPMIx invokes the registered handler with
+/// `cbfunc = progress_local_event_hdlr` and `cbdata = (void*)chain`. The
+/// handler **must** call `cbfunc(..., cbdata)` or the chain never advances
+/// (`cycle_events` / `final_cbfunc` never run). A blocking `notify_event`
+/// waits on that completion, so a missed `cbfunc` is a permanent hang — not
+/// a silent drop.
+///
+/// On registry miss (no user fn, `evhdlr = None`, deregistration race, or
+/// the brief window after blocking registration returns but before the
+/// insert) this bridge still calls `cbfunc` as a pass-through so the chain
+/// stays alive. The chain pointer is always forwarded verbatim — never
+/// replaced with `NULL`.
 unsafe extern "C" fn notification_bridge(
     evhdlr_registration_id: EventHandlerRef,
     status: i32,
@@ -181,7 +212,7 @@ unsafe extern "C" fn notification_bridge(
     results: *mut ffi::pmix_info_t,
     nresults: usize,
     cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-    _cbdata: *mut c_void,
+    cbdata: *mut c_void,
 ) {
     // Copy the user fn pointer out of the registry WITHOUT holding the lock
     // across the user call (bridge policy). Function pointers are `Copy`, so
@@ -193,10 +224,10 @@ unsafe extern "C" fn notification_bridge(
             .and_then(|b| *b.as_ref())
     };
 
-    // SAFETY: We cast the FFI pointers back to c_void and call the user's
-    // callback. The user callback receives opaque pointers and is not expected
-    // to dereference them without casting back.
     if let Some(user_fn) = user_fn {
+        // SAFETY: cast FFI pointers to c_void for the user-facing NotificationFn
+        // ABI. Forward OpenPMIx's chain pointer (`cbdata`) and completion
+        // `cbfunc` verbatim — the handler must return them via cbfunc.
         unsafe {
             user_fn(
                 evhdlr_registration_id,
@@ -207,8 +238,16 @@ unsafe extern "C" fn notification_bridge(
                 results as *mut c_void,
                 nresults,
                 cbfunc,
-                std::ptr::null_mut(),
+                cbdata,
             );
+        }
+    } else if let Some(cbfunc) = cbfunc {
+        // Registry miss / no user handler: pass-through completion keeps the
+        // OpenPMIx event chain alive. Do not drop `cbfunc` here.
+        // SAFETY: OpenPMIx-supplied completion with its chain pointer; status
+        // and results are forwarded as received.
+        unsafe {
+            cbfunc(status, results, nresults, None, ptr::null_mut(), cbdata);
         }
     }
 }
@@ -268,12 +307,13 @@ extern "C" fn handler_reg_cb_bridge(status: i32, refid: EventHandlerRef, cbdata:
 /// * `codes` — array of event codes to handle (empty = all events).
 /// * `info` — optional info directives (e.g., range, scope).
 /// * `evhdlr` — the notification callback function.
-/// * `cbfunc` — `None` for blocking mode; `Some(...)` for non-blocking
-///   (in which case the reference ID is delivered to `cbfunc` and the return
-///   value is not meaningful — prefer [`register_event_handler_nb`]).
+/// * `cbfunc` — must be `None` (blocking). Non-blocking registration with a
+///   completion callback is [`register_event_handler_nb`] only; passing
+///   `Some` here returns `PMIX_ERR_BAD_PARAM`.
 ///
 /// # Returns
-/// * `Ok(handler_ref)` — the handler reference ID (positive integer).
+/// * `Ok(handler_ref)` — the handler reference ID (a non-negative integer;
+///   **`0` is a valid first ref id** in OpenPMIx, not a failure sentinel).
 /// * `Err(PmixStatus)` — registration failed (e.g., `PMIX_ERR_INIT`).
 ///
 /// # C API
@@ -290,13 +330,21 @@ extern "C" fn handler_reg_cb_bridge(status: i32, refid: EventHandlerRef, cbdata:
 /// # Errors
 /// * `PMIX_ERR_INIT` — PMIx has not been initialized.
 /// * `PMIX_ERR_EVENT_REGISTRATION` — handler registration failed.
-/// * `PMIX_ERR_BAD_PARAM` — invalid parameters.
+/// * `PMIX_ERR_BAD_PARAM` — invalid parameters (including non-`None` `cbfunc`).
 pub fn register_event_handler(
     codes: &[PmixStatus],
     info: &Info,
     evhdlr: NotificationFn,
     cbfunc: HandlerRegCbFn,
 ) -> Result<EventHandlerRef, PmixStatus> {
+    // Blocking API only. A non-null cbfunc would make OpenPMIx treat this as
+    // non-blocking (refid delivered only via callback) while this wrapper
+    // still treats the return status as the refid — that combination is
+    // incorrect. Route async registrations through register_event_handler_nb.
+    if cbfunc.is_some() {
+        return Err(PmixStatus::Known(PmixError::ErrBadParam));
+    }
+
     let (codes_ptr, ncodes) = if codes.is_empty() {
         (ptr::null_mut(), 0)
     } else {
@@ -323,7 +371,7 @@ pub fn register_event_handler(
             info_ptr as *mut ffi::pmix_info_t,
             ninfo,
             Some(notification_bridge),
-            cbfunc,
+            None,
             ptr::null_mut(),
         )
     };
@@ -332,9 +380,13 @@ pub fn register_event_handler(
     if status.is_success() {
         let handler_ref = raw_status as EventHandlerRef;
         if evhdlr.is_some() {
-            // Park the user fn for the lifetime of the registration. PMIx may
-            // deliver an event to the bridge the moment registration returns,
-            // so insert before returning to the caller.
+            // Park the user fn for the lifetime of the registration.
+            //
+            // Race window: the C-side handler is live as soon as
+            // PMIx_Register_event_handler returns, but the refid is only known
+            // *after* that return, so the insert cannot move earlier. An event
+            // delivered in this gap hits a registry miss in notification_bridge,
+            // which pass-through-completes the chain (dropped delivery, no hang).
             HANDLER_REGISTRY
                 .lock()
                 .expect("mutex poisoned (events.rs)")
@@ -395,12 +447,17 @@ pub fn register_event_handler_nb(
         user_cbfunc: cbfunc,
         user_cbdata: cbdata,
     });
+    let state_ptr = Box::into_raw(state);
 
     // SAFETY: FFI call into PMIx library. The codes slice lives for the
-    // duration of this call. The boxed HandlerRegState is reclaimed by
-    // handler_reg_cb_bridge exactly once; on synchronous failure it is
-    // intentionally leaked (PMIx may still invoke the completion callback
-    // with an error status, so freeing it here could double-free).
+    // duration of this call. On the async path the boxed HandlerRegState is
+    // reclaimed exactly once by handler_reg_cb_bridge.
+    //
+    // Synchronous failure paths in OpenPMIx (`!initialized`, progress thread
+    // stopped, OOM on the registration object) return *before* thread-shifting
+    // and **never** invoke the registration completion callback — so the box
+    // must be freed here. Only free on Err: a successful accept transfers
+    // ownership to the completion bridge.
     let raw_status = unsafe {
         ffi::PMIx_Register_event_handler(
             codes_ptr,
@@ -409,7 +466,7 @@ pub fn register_event_handler_nb(
             ninfo,
             Some(notification_bridge),
             Some(handler_reg_cb_bridge),
-            Box::into_raw(state) as *mut c_void,
+            state_ptr as *mut c_void,
         )
     };
 
@@ -417,6 +474,12 @@ pub fn register_event_handler_nb(
     if status.is_success() {
         Ok(())
     } else {
+        // SAFETY: synchronous failure ⇒ completion bridge will not run; we
+        // still own the box and must free it to avoid a permanent leak of the
+        // boxed NotificationFn and user cbdata.
+        unsafe {
+            drop(Box::from_raw(state_ptr));
+        }
         Err(status)
     }
 }
@@ -452,8 +515,7 @@ pub fn deregister_event_handler(
 ) -> Result<(), PmixStatus> {
     // Free the boxed user fn BEFORE the C call so the notification bridge can
     // no longer fire into freed memory, even if an event is already in flight
-    // on the progress thread. If the C deregistration then fails, the handler
-    // stays registered but its events are silently dropped (no UAF).
+    // on the progress thread.
     //
     // Ordering (registry remove, then PMIx_Deregister_event_handler):
     // - OpenPMIx documents that once `PMIx_Deregister_event_handler` returns
@@ -465,9 +527,10 @@ pub fn deregister_event_handler(
     // - The inverse order (C deregister, then remove) would leave a window
     //   where the bridge can still resolve the user fn while another thread
     //   is about to free it.
-    // - Trade-off on C failure: the C handler may remain registered, but
-    //   `notification_bridge` becomes a no-op for that ref (unknown id). That
-    //   is preferable to use-after-free.
+    // - Trade-off on C failure / in-flight delivery: the C handler may remain
+    //   registered briefly, but `notification_bridge` hits a registry miss and
+    //   **pass-through-completes** the OpenPMIx event chain (no hang, no UAF).
+    //   The delivery is dropped at the Rust layer rather than forwarded.
     HANDLER_REGISTRY
         .lock()
         .expect("mutex poisoned (events.rs)")
@@ -585,7 +648,11 @@ pub fn notify_event(
     };
 
     let st = PmixStatus::from_raw(raw_status);
-    if st.is_success() { Ok(()) } else { Err(st) }
+    if st.is_success() {
+        Ok(())
+    } else {
+        Err(st)
+    }
 }
 
 /// Non-blocking variant of [`notify_event`].
@@ -633,7 +700,11 @@ pub fn notify_event_nb(
     };
 
     let st = PmixStatus::from_raw(raw_status);
-    if st.is_success() { Ok(()) } else { Err(st) }
+    if st.is_success() {
+        Ok(())
+    } else {
+        Err(st)
+    }
 }
 
 #[cfg(test)]
@@ -713,6 +784,7 @@ mod tests {
     #[test]
     fn test_notification_bridge_invokes_user_fn() {
         static CALLED: AtomicBool = AtomicBool::new(false);
+        static SAW_CBDATA: AtomicUsize = AtomicUsize::new(0);
 
         unsafe extern "C" fn recording_handler(
             _id: EventHandlerRef,
@@ -723,13 +795,18 @@ mod tests {
             _results: *mut std::os::raw::c_void,
             _nresults: usize,
             _cbfunc: ffi::pmix_event_notification_cbfunc_fn_t,
-            _cbdata: *mut std::os::raw::c_void,
+            cbdata: *mut std::os::raw::c_void,
         ) {
             assert_eq!(status, 7, "handler should receive the event status");
+            SAW_CBDATA.store(cbdata as usize, Ordering::SeqCst);
             CALLED.store(true, Ordering::SeqCst);
         }
 
         let ref_id: EventHandlerRef = 424243;
+        // Non-null sentinel standing in for OpenPMIx's event-chain pointer.
+        let chain_token = 0xC_u8;
+        let chain_ptr = &chain_token as *const u8 as *mut c_void;
+
         HANDLER_REGISTRY
             .lock()
             .expect("mutex poisoned (events.rs)")
@@ -745,13 +822,18 @@ mod tests {
                 std::ptr::null_mut(),
                 0,
                 None,
-                std::ptr::null_mut(),
+                chain_ptr,
             );
         }
 
         assert!(
             CALLED.load(Ordering::SeqCst),
             "bridge must invoke the user fn"
+        );
+        assert_eq!(
+            SAW_CBDATA.load(Ordering::SeqCst),
+            chain_ptr as usize,
+            "bridge must forward OpenPMIx chain cbdata verbatim (not NULL)"
         );
         HANDLER_REGISTRY
             .lock()
@@ -760,12 +842,61 @@ mod tests {
     }
 
     #[test]
-    fn test_notification_bridge_unknown_ref_is_noop() {
-        // No registry entry — the bridge must skip silently (this also covers
-        // the window before a registration completes).
+    fn test_notification_bridge_unknown_ref_invokes_cbfunc() {
+        // Registry miss must still complete the OpenPMIx event chain — a
+        // silent return stalls blocking notify_event forever.
+        static CBFUNC_CALLED: AtomicBool = AtomicBool::new(false);
+        static CBFUNC_STATUS: AtomicI32 = AtomicI32::new(i32::MIN);
+        static CBFUNC_CBDATA: AtomicUsize = AtomicUsize::new(0);
+
+        unsafe extern "C" fn recording_cbfunc(
+            status: i32,
+            _results: *mut ffi::pmix_info_t,
+            _nresults: usize,
+            _cbfunc: ffi::pmix_op_cbfunc_t,
+            _thiscbdata: *mut c_void,
+            notification_cbdata: *mut c_void,
+        ) {
+            CBFUNC_STATUS.store(status, Ordering::SeqCst);
+            CBFUNC_CBDATA.store(notification_cbdata as usize, Ordering::SeqCst);
+            CBFUNC_CALLED.store(true, Ordering::SeqCst);
+        }
+
+        let chain_token = 0xD_u8;
+        let chain_ptr = &chain_token as *const u8 as *mut c_void;
+
         unsafe {
             notification_bridge(
                 999_999_999,
+                42,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                Some(recording_cbfunc),
+                chain_ptr,
+            );
+        }
+
+        assert!(
+            CBFUNC_CALLED.load(Ordering::SeqCst),
+            "miss path must invoke completion cbfunc"
+        );
+        assert_eq!(CBFUNC_STATUS.load(Ordering::SeqCst), 42);
+        assert_eq!(
+            CBFUNC_CBDATA.load(Ordering::SeqCst),
+            chain_ptr as usize,
+            "miss path must forward chain cbdata verbatim"
+        );
+    }
+
+    #[test]
+    fn test_notification_bridge_unknown_ref_null_cbfunc_is_safe() {
+        // No registry entry and no completion callback — must not panic.
+        unsafe {
+            notification_bridge(
+                999_999_998,
                 0,
                 std::ptr::null(),
                 std::ptr::null_mut(),
@@ -1033,7 +1164,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let (info_ptr, ninfo) = if info.len > 0 {
             (info.handle as *const ffi::pmix_info_t, info.len)
@@ -1131,7 +1262,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&[], &info, None, None);
         // Without PMIx init, this returns an error (not BAD_PARAM)
@@ -1153,7 +1284,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -1183,7 +1314,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, Some(dummy_handler), None);
         match result {
@@ -1204,7 +1335,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler_nb(
             &codes,
@@ -1228,7 +1359,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result =
             register_event_handler_nb(&[], &info, None, Some(dummy_reg_cb), std::ptr::null_mut());
@@ -1307,7 +1438,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrJobAborted),
@@ -1330,7 +1461,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         for range_raw in [0u8, 1, 2, 3] {
             let range = PmixDataRange::from_raw(range_raw);
@@ -1361,7 +1492,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrNotSupported),
@@ -1387,7 +1518,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event_nb(
             PmixStatus::Known(PmixError::ErrJobAborted),
@@ -1469,7 +1600,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
 
@@ -1558,7 +1689,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let ranges = [
             PmixDataRange::Undef,
@@ -1596,7 +1727,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let ranges = [
             PmixDataRange::Undef,
@@ -1641,7 +1772,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -1674,7 +1805,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler_nb(
             &codes,
@@ -1749,7 +1880,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let (info_ptr, ninfo) = if info.len > 0 {
             (info.handle as *const ffi::pmix_info_t, info.len)
@@ -1788,7 +1919,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event_nb(
             PmixStatus::Known(PmixError::ErrJobAborted),
@@ -1816,7 +1947,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler_nb(
             &codes,
@@ -1841,7 +1972,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
         for _ in 0..5 {
@@ -1880,7 +2011,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         for _ in 0..5 {
             let result = notify_event(
@@ -1908,17 +2039,16 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
-        // Register with callback (non-blocking style, though we test synchronously)
+        // Register with callback on the blocking API must reject with BAD_PARAM
+        // (non-blocking registration is register_event_handler_nb only).
         let result = register_event_handler(&codes, &info, None, Some(dummy_reg_cb));
-        match result {
-            Ok(_) => {}
-            Err(e) => {
-                let raw = e.to_raw();
-                assert!(raw < 0, "Expected error without DVM, got {}", raw);
-            }
-        }
+        assert_eq!(
+            result,
+            Err(PmixStatus::Known(PmixError::ErrBadParam)),
+            "blocking register_event_handler must reject non-None cbfunc"
+        );
     }
 
     #[test]
@@ -1927,7 +2057,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -1949,7 +2079,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -1976,7 +2106,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2003,7 +2133,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2030,7 +2160,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2057,7 +2187,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2084,7 +2214,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2111,7 +2241,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2140,7 +2270,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2157,7 +2287,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2174,7 +2304,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2191,7 +2321,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2208,7 +2338,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2225,7 +2355,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2244,7 +2374,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2266,7 +2396,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrNotSupported),
@@ -2288,7 +2418,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrBadParam),
@@ -2310,7 +2440,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event(
             PmixStatus::Known(PmixError::ErrInit),
@@ -2335,7 +2465,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event_nb(
             PmixStatus::Known(PmixError::ErrTimeout),
@@ -2360,7 +2490,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = notify_event_nb(
             PmixStatus::Known(PmixError::ErrLostConnection),
@@ -2482,7 +2612,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         // Pass a non-null cbdata pointer (user data)
         let user_data: u32 = 42;
@@ -2531,7 +2661,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let user_data: u64 = 0xDEADBEEF;
         let result = notify_event_nb(
@@ -2559,7 +2689,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2576,7 +2706,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2593,7 +2723,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {
@@ -2610,7 +2740,7 @@ mod tests {
         let info = Info {
             handle: std::ptr::null_mut(),
             len: 0,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         };
         let result = register_event_handler(&codes, &info, None, None);
         match result {

--- a/src/events.rs
+++ b/src/events.rs
@@ -454,6 +454,20 @@ pub fn deregister_event_handler(
     // no longer fire into freed memory, even if an event is already in flight
     // on the progress thread. If the C deregistration then fails, the handler
     // stays registered but its events are silently dropped (no UAF).
+    //
+    // Ordering (registry remove, then PMIx_Deregister_event_handler):
+    // - OpenPMIx documents that once `PMIx_Deregister_event_handler` returns
+    //   successfully, no further notification callbacks will be delivered for
+    //   that ref. Removing first closes the Rust side before that guarantee
+    //   kicks in, so a progress-thread delivery already past the C check but
+    //   not yet into `notification_bridge` cannot observe a live registry
+    //   entry whose Box is about to be dropped.
+    // - The inverse order (C deregister, then remove) would leave a window
+    //   where the bridge can still resolve the user fn while another thread
+    //   is about to free it.
+    // - Trade-off on C failure: the C handler may remain registered, but
+    //   `notification_bridge` becomes a no-op for that ref (unknown id). That
+    //   is preferable to use-after-free.
     HANDLER_REGISTRY
         .lock()
         .expect("mutex poisoned (events.rs)")
@@ -490,6 +504,14 @@ pub fn deregister_event_handler_nb(
     cbfunc: OpCbFn,
     cbdata: *mut c_void,
 ) -> Result<(), PmixStatus> {
+    // Same registry-first ordering as the blocking path: drop the user fn
+    // before asking OpenPMIx to stop delivering events for this ref. See the
+    // comment on [`deregister_event_handler`].
+    HANDLER_REGISTRY
+        .lock()
+        .expect("mutex poisoned (events.rs)")
+        .remove(&evhdlr_ref);
+
     // SAFETY: FFI call into PMIx library. Same safety considerations as
     // the blocking variant.
     let raw_status = unsafe { ffi::PMIx_Deregister_event_handler(evhdlr_ref, cbfunc, cbdata) };
@@ -756,15 +778,15 @@ mod tests {
         }
     }
 
-    /// Deadlock regression (issue #51): the notification bridge must NOT hold
-    /// the registry lock while the user callback runs.
+    /// Deadlock / lock-order regression (issue #51): the event-handler registry
+    /// lock must **not** be held while the user callback runs.
     ///
     /// A user handler that blocks is invoked from a stand-in progress thread;
     /// while it is blocked, this test must still be able to acquire the
     /// registry lock. If the lock were held across the user call, the
     /// `try_lock` below would fail and the test would fail.
     #[test]
-    fn test_notification_bridge_no_lock_across_user_code() {
+    fn test_event_handler_lock_not_held_during_user_callback() {
         static ENTER_TX: Mutex<Option<mpsc::Sender<()>>> = Mutex::new(None);
         static RELEASE_RX: Mutex<Option<mpsc::Receiver<()>>> = Mutex::new(None);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,11 @@
 //!   (clones must not each run `PMIx_Finalize`). Call [`disconnect`](PmixClient::disconnect)
 //!   or [`finalize`].
 //! - Server upcalls may run on PMIx internal threads; keep callbacks short.
+//! - `_nb` completions and events are delivered on the **progress thread**.
+//!   Hop off before any blocking work with the [`threading`] helpers
+//!   (`spawn_from_callback`, `CallbackChannel`); never call blocking PMIx
+//!   APIs from inside a callback. See `examples/callback_hop.rs` and
+//!   [THREADING.md](../THREADING.md).
 //!
 //! See [THREADING.md](../THREADING.md) in the repo for the full model.
 //!
@@ -44,6 +49,7 @@ pub mod process_mgmt;
 pub mod query_log;
 pub mod security;
 pub mod server;
+pub mod threading;
 pub mod tool;
 pub mod utility;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3632,6 +3632,11 @@ impl PmixClient {
             None => unsafe { PMIx_Finalize(ptr::null_mut(), 0) },
         };
 
+        // Drop parked event handlers that were never deregistered. After
+        // PMIx_Finalize, OpenPMIx will not deliver further notifications for
+        // this session (crate no-reinit policy).
+        events::clear_handler_registry();
+
         self.inner
             .state
             .store(PmixClientState::Dead as u8, Ordering::Release);

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -206,6 +206,9 @@ impl PmixServer {
             real = unsafe { ffi::PMIx_server_finalize() },
         );
 
+        // Drop parked event handlers that were never deregistered.
+        crate::events::clear_handler_registry();
+
         self.inner
             .state
             .store(PmixServerState::Dead as u8, Ordering::Release);

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -91,6 +91,20 @@ use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, Sender, TryRe
 /// * [`progress`](crate::progress) (re-entering the event engine).
 /// * Waiting on another thread (joining a handle, blocking on a lock that an
 ///   application thread holds while it calls PMIx).
+/// * Holding a crate registry `Mutex` across user code (bridges must drop the
+///   lock before invoking application callbacks).
+///
+/// ```rust,ignore
+/// // ❌ NEVER — blocks the progress thread on a PMIx round-trip
+/// let _ = pmix::data_ops::get(&proc, "pmix.job.size", None);
+///
+/// // ❌ NEVER — waits for a condition that only progress can satisfy
+/// while !ready.load(Ordering::SeqCst) { /* spin / park */ }
+///
+/// // ❌ NEVER — holds a registry lock across application callback code
+/// let mut guard = EVENT_HANDLERS.lock().unwrap();
+/// if let Some(cb) = guard.get_mut(&id) { cb(); } // user code under lock
+/// ```
 ///
 /// Use [`spawn_from_callback`] or a [`CallbackChannel`] to hop off first.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
@@ -113,6 +127,11 @@ pub struct ProgressContext;
 ///   callback frame; move Rust-owned data (or clones) into the closure.
 /// * If spawning fails (thread limits / resource exhaustion), the error is
 ///   returned — log it and continue; never panic from a PMIx callback.
+/// * A panic inside `f` is **isolated to the hop thread** (it does not abort
+///   the process by itself). This helper logs a branded diagnostic on stderr
+///   and then resumes unwinding so a joined handle still reports
+///   [`JoinHandle::join`](std::thread::JoinHandle::join) `Err`. Prefer not
+///   panicking in hop work in long-running HPC jobs — treat panics as bugs.
 ///
 /// # Example
 ///
@@ -130,7 +149,19 @@ where
 {
     std::thread::Builder::new()
         .name("pmix-callback-hop".to_string())
-        .spawn(f)
+        .spawn(move || {
+            // Isolate panics to this hop thread. Log a clear diagnostic for
+            // operators (fire-and-forget callers never join), then resume so
+            // `JoinHandle::join` still surfaces the payload instead of a
+            // silent `Ok(())`.
+            if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+                eprintln!(
+                    "pmix: thread 'pmix-callback-hop' panicked while running \
+                     work hopped off the PMIx progress thread"
+                );
+                std::panic::resume_unwind(payload);
+            }
+        })
 }
 
 /// Channel pair for hopping callback payloads off the progress thread.
@@ -193,6 +224,12 @@ impl<T> CallbackChannel<T> {
     }
 
     /// Non-blocking poll for a payload.
+    ///
+    /// Returns [`TryRecvError::Empty`] when no message is ready yet, and
+    /// [`TryRecvError::Disconnected`] when every sender has been dropped
+    /// (no further messages will arrive). Callers should treat both as
+    /// non-fatal — never unwrap this on the application thread without
+    /// deciding how end-of-stream is handled.
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         self.rx.try_recv()
     }
@@ -253,6 +290,25 @@ mod tests {
     }
 
     #[test]
+    fn spawn_from_callback_panic_is_surfaced_on_join() {
+        // Hop-thread panics must not be swallowed into a silent Ok(()) —
+        // callers that join still observe the failure.
+        let handle = spawn_from_callback(|| panic!("hop-work boom")).expect("spawn");
+        let join_err = handle
+            .join()
+            .expect_err("panic in hop work must surface on JoinHandle::join");
+        let msg = join_err
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| join_err.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic payload>");
+        assert!(
+            msg.contains("hop-work boom"),
+            "unexpected panic payload: {msg}"
+        );
+    }
+
+    #[test]
     fn callback_channel_send_recv_across_threads() {
         let hop = CallbackChannel::<String>::new();
         let tx = hop.sender();
@@ -269,6 +325,17 @@ mod tests {
     fn callback_channel_try_recv_empty() {
         let hop = CallbackChannel::<u8>::new();
         assert!(matches!(hop.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn callback_channel_try_recv_disconnected_when_senders_dropped() {
+        // Keep the Result API (Empty vs Disconnected) so callers can tell a
+        // quiet progress thread from end-of-stream after every sender dies.
+        let hop = CallbackChannel::<u8>::new();
+        let tx = hop.sender();
+        let rx = hop.into_receiver(); // drops the channel's owned sender
+        drop(tx); // last sender gone → Disconnected, not Empty
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
     }
 
     #[test]

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,0 +1,336 @@
+//! # Progress-thread callbacks: hop-off helpers and bridge policy
+//!
+//! OpenPMIx delivers `_nb` completions and events on the **progress thread**
+//! (the thread that runs the PMIx event engine), never on the thread that
+//! issued the call. That means every callback this crate hands to PMIx —
+//! `data_ops` non-blocking completions, event notifications, and server
+//! upcalls — runs on a thread the application does not control.
+//!
+//! This module provides the shared helpers for **hopping off** the progress
+//! thread before doing anything that could block, plus the **bridge policy**
+//! that every callback bridge in this crate follows.
+//!
+//! # Bridge policy
+//!
+//! 1. **Never call blocking PMIx APIs from the handler.** A blocking call
+//!    (`get`, `fence`, `publish`, `lookup`, `unpublish`, `spawn`,
+//!    `register_event_handler`, `notify_event`, `disconnect`, …) from inside
+//!    a callback waits for the progress thread — which is the thread the
+//!    callback is running on. That is a self-deadlock. Hop to an application
+//!    thread first (see the template below).
+//! 2. **Non-blocking calls from the handler are allowed only if you do not
+//!    wait for their completion in-handler.** Issuing an `_nb` call and
+//!    returning is fine; blocking on its callback is not.
+//! 3. **Bridges stay minimal and never hold a registry `Mutex` across user
+//!    callback execution.** Registry lookups are scoped to the shortest
+//!    possible critical section; the user's code runs after the lock is
+//!    dropped. (Regression-tested in `events`.)
+//! 4. **cbdata** is an opaque request ID encoded with
+//!    [`crate::cbdata::encode_req_id`] / [`crate::cbdata::decode_req_id`],
+//!    never a raw pointer to a callback.
+//!
+//! # Hop-off template
+//!
+//! The two primitives cover the two ways a handler can get work off the
+//! progress thread:
+//!
+//! * [`spawn_from_callback`] — fire-and-forget: start a fresh application
+//!   thread for blocking work and return immediately.
+//! * [`CallbackChannel`] — request/response: the application thread owns the
+//!   channel (receiver side) and processes messages the handler sends.
+//!
+//! ```no_run
+//! use pmix::threading::{CallbackChannel, ProgressContext, spawn_from_callback};
+//!
+//! // App thread: create the hop channel and hand a clone-able sender to the
+//! // callback. The receiver stays on the app thread.
+//! let hop = CallbackChannel::<(i32, Vec<u8>)>::new();
+//! let tx = hop.sender();
+//!
+//! // Inside a PMIx callback (progress thread):
+//! let _ctx = ProgressContext;                 // documents: we are on progress
+//! let _ = tx.send((0, b"payload".to_vec()));  // cheap, non-blocking
+//! let _ = spawn_from_callback(move || {       // or: fresh thread for blocking work
+//!     // blocking PMIx calls are legal here
+//! });
+//!
+//! // Back on the app thread:
+//! let (status, data) = hop.recv().expect("callback never fired");
+//! # let _ = (status, data);
+//! ```
+//!
+//! **C-owned handles are `!Send`.** A value like [`PmixOwnedValue`]
+//! (crate::PmixOwnedValue) cannot cross the channel; convert it to
+//! Rust-owned data first (e.g. [`bytes_copy`](crate::PmixOwnedValue::bytes_copy))
+//! and send the copy.
+//!
+//! See also `examples/callback_hop.rs` for a complete `get_nb` + events
+//! demonstration, and [THREADING.md](../THREADING.md).
+
+use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, Sender, TryRecvError};
+
+/// Zero-sized marker for code that runs on the PMIx **progress thread**.
+///
+/// `ProgressContext` is a documentation marker: it carries no data and has no
+/// runtime effect. A callback implementation can take one (or name the type in
+/// a comment) so that the forbidden-API list lives next to the code that must
+/// respect it.
+///
+/// # Forbidden while on the progress thread
+///
+/// Anything that blocks on PMIx progress — in this crate:
+///
+/// * Blocking data ops: [`get`](crate::data_ops::get),
+///   [`lookup`](crate::data_ops::lookup), [`publish`](crate::data_ops::publish),
+///   [`unpublish`](crate::data_ops::unpublish),
+///   [`fence`](crate::fence).
+/// * Blocking events: [`register_event_handler`](crate::events::register_event_handler),
+///   [`notify_event`](crate::events::notify_event).
+/// * Session lifecycle: [`disconnect`](crate::PmixClient::disconnect),
+///   [`finalize`](crate::finalize).
+/// * [`progress`](crate::progress) (re-entering the event engine).
+/// * Waiting on another thread (joining a handle, blocking on a lock that an
+///   application thread holds while it calls PMIx).
+///
+/// Use [`spawn_from_callback`] or a [`CallbackChannel`] to hop off first.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct ProgressContext;
+
+/// Spawn an application thread from inside a PMIx callback.
+///
+/// The callback runs on the PMIx progress thread; any work that could block
+/// (including blocking PMIx calls) must be moved to an application thread.
+/// This helper spawns a fresh, named thread to run `f` and returns a
+/// [`JoinHandle`](std::thread::JoinHandle) the caller may store or detach.
+///
+/// # Rules
+///
+/// * **Do not join or otherwise wait on the returned handle from inside the
+///   callback.** The spawned thread may need progress to complete (e.g. a
+///   blocking PMIx call); waiting for it would deadlock the progress thread.
+///   Return from the handler and join from an application thread instead.
+/// * The callback must not rely on any PMIx C-owned handle outliving the
+///   callback frame; move Rust-owned data (or clones) into the closure.
+/// * If spawning fails (thread limits / resource exhaustion), the error is
+///   returned — log it and continue; never panic from a PMIx callback.
+///
+/// # Example
+///
+/// ```no_run
+/// use pmix::threading::spawn_from_callback;
+///
+/// let _ = spawn_from_callback(move || {
+///     // Blocking work — safe on this application thread.
+///     std::thread::sleep(std::time::Duration::from_millis(10));
+/// });
+/// ```
+pub fn spawn_from_callback<F>(f: F) -> std::io::Result<std::thread::JoinHandle<()>>
+where
+    F: FnOnce() + Send + 'static,
+{
+    std::thread::Builder::new()
+        .name("pmix-callback-hop".to_string())
+        .spawn(f)
+}
+
+/// Channel pair for hopping callback payloads off the progress thread.
+///
+/// Wraps a [`std::sync::mpsc`] channel with the intended usage spelled out:
+/// the **application thread** creates the channel and keeps the receiver;
+/// the **callback** (progress thread) gets a cloned [`Sender`] via
+/// [`sender`](CallbackChannel::sender) and pushes Rust-owned payloads into it
+/// before returning. The application thread then does the blocking work.
+///
+/// The sender is `Send + Sync + Clone`, so it can be moved into any of this
+/// crate's `Send` callback traits ([`GetValueCallback`](crate::data_ops::GetValueCallback),
+/// [`FenceCallback`](crate::data_ops::FenceCallback), …) or into a
+/// [`NotificationFn`](crate::events::NotificationFn) closure.
+///
+/// Payloads must be `Send` (and typically Rust-owned — see the module docs
+/// on C-owned handles).
+///
+/// # Example
+///
+/// ```no_run
+/// use pmix::threading::CallbackChannel;
+///
+/// let hop = CallbackChannel::<u64>::new();
+/// let tx = hop.sender();
+/// // hand `tx` to a callback running on the progress thread…
+/// std::thread::spawn(move || { let _ = tx.send(7); });
+/// // …and process on the application thread:
+/// assert_eq!(hop.recv().unwrap(), 7);
+/// ```
+pub struct CallbackChannel<T> {
+    tx: Sender<T>,
+    rx: Receiver<T>,
+}
+
+impl<T> CallbackChannel<T> {
+    /// Create a new hop channel. Keep the returned value on the application
+    /// thread and distribute [`sender`](CallbackChannel::sender) clones to
+    /// callbacks.
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self { tx, rx }
+    }
+
+    /// A clone-able sender to move into a callback (runs on the progress
+    /// thread). `send` on an unbounded channel never blocks the handler.
+    pub fn sender(&self) -> Sender<T> {
+        self.tx.clone()
+    }
+
+    /// Block the application thread until a payload arrives.
+    pub fn recv(&self) -> Result<T, RecvError> {
+        self.rx.recv()
+    }
+
+    /// Block up to `timeout` for a payload (prefer this in examples and tests
+    /// so a never-firing callback cannot hang the process forever).
+    pub fn recv_timeout(&self, timeout: std::time::Duration) -> Result<T, RecvTimeoutError> {
+        self.rx.recv_timeout(timeout)
+    }
+
+    /// Non-blocking poll for a payload.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    /// Iterate over incoming payloads (blocks the application thread).
+    pub fn iter(&self) -> mpsc::Iter<'_, T> {
+        self.rx.iter()
+    }
+
+    /// Consume the channel and take ownership of the receiver (for moving it
+    /// into a dedicated worker thread).
+    pub fn into_receiver(self) -> Receiver<T> {
+        self.rx
+    }
+}
+
+impl<T> Default for CallbackChannel<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[test]
+    fn progress_context_is_zero_sized() {
+        assert_eq!(std::mem::size_of::<ProgressContext>(), 0);
+        let _ctx = ProgressContext; // constructible without ceremony
+    }
+
+    #[test]
+    fn spawn_from_callback_runs_on_a_different_thread() {
+        let caller = std::thread::current().id();
+        let (tx, rx) = mpsc::channel();
+        let handle = spawn_from_callback(move || {
+            let _ = tx.send(std::thread::current().id());
+        })
+        .expect("spawn should succeed");
+        let spawned = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("callback ran");
+        assert_ne!(
+            caller, spawned,
+            "closure must run on a fresh application thread"
+        );
+        handle.join().expect("join");
+    }
+
+    #[test]
+    fn spawn_from_callback_failure_returns_error() {
+        // Spawning with an exhausted OS limit is not reliably triggerable in
+        // tests; verify only that the signature reports io::Result.
+        let _: std::io::Result<std::thread::JoinHandle<()>> = spawn_from_callback(|| {});
+    }
+
+    #[test]
+    fn callback_channel_send_recv_across_threads() {
+        let hop = CallbackChannel::<String>::new();
+        let tx = hop.sender();
+        std::thread::spawn(move || {
+            let _ = tx.send("hopped off the progress thread".to_string());
+        });
+        let got = hop
+            .recv_timeout(Duration::from_secs(5))
+            .expect("payload should arrive");
+        assert_eq!(got, "hopped off the progress thread");
+    }
+
+    #[test]
+    fn callback_channel_try_recv_empty() {
+        let hop = CallbackChannel::<u8>::new();
+        assert!(matches!(hop.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn callback_channel_sender_is_cloneable_and_send_sync() {
+        let hop = CallbackChannel::<u8>::new();
+        let tx1 = hop.sender();
+        let tx2 = hop.sender();
+        std::thread::spawn(move || {
+            let _ = tx1.send(1);
+            let _ = tx2.send(2);
+        });
+        let mut got = Vec::new();
+        while got.len() < 2 {
+            match hop.recv_timeout(Duration::from_secs(5)) {
+                Ok(v) => got.push(v),
+                Err(_) => break,
+            }
+        }
+        got.sort_unstable();
+        assert_eq!(got, vec![1, 2]);
+    }
+
+    #[test]
+    fn callback_channel_into_receiver_moves_to_worker() {
+        let hop = CallbackChannel::<u8>::new();
+        let tx = hop.sender();
+        let rx = hop.into_receiver();
+        let worker = std::thread::spawn(move || rx.recv_timeout(Duration::from_secs(5)));
+        let _ = tx.send(42);
+        assert_eq!(worker.join().expect("worker").expect("value"), 42);
+    }
+
+    /// End-to-end hop template: a "progress thread" (a spawned thread standing
+    /// in for the PMIx event engine) pushes a payload through the channel and
+    /// spawns blocking work; the application thread receives both and joins.
+    #[test]
+    fn hop_template_end_to_end() {
+        let hop = CallbackChannel::<u32>::new();
+        let tx = hop.sender();
+        let blocking_done = std::sync::Arc::new(AtomicUsize::new(0));
+        let blocking_done2 = std::sync::Arc::clone(&blocking_done);
+
+        // The callback side — must return quickly, never block.
+        let callback_side = std::thread::spawn(move || {
+            let _ctx = ProgressContext; // runs "on the progress thread"
+            let _ = tx.send(99);
+            let _ = spawn_from_callback(move || {
+                blocking_done2.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        // The application side — receives and then does blocking work.
+        assert_eq!(
+            hop.recv_timeout(Duration::from_secs(5)).expect("payload"),
+            99
+        );
+        callback_side.join().expect("callback returns promptly");
+        // The spawned blocking work completes on its own thread.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while blocking_done.load(Ordering::SeqCst) == 0 && std::time::Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(blocking_done.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -127,9 +127,12 @@ pub struct ProgressContext;
 ///   callback frame; move Rust-owned data (or clones) into the closure.
 /// * If spawning fails (thread limits / resource exhaustion), the error is
 ///   returned — log it and continue; never panic from a PMIx callback.
-/// * A panic inside `f` is **isolated to the hop thread** (it does not abort
-///   the process by itself). This helper logs a branded diagnostic on stderr
-///   and then resumes unwinding so a joined handle still reports
+/// * A panic inside `f` is confined to the hop thread under the default
+///   `panic = "unwind"` profile: it does **not** abort the process by itself
+///   (the default panic hook does not call `exit()` for non-main threads).
+///   Under `panic = "abort"` the process aborts regardless of this helper.
+///   This helper logs a branded diagnostic on stderr for fire-and-forget
+///   callers, then resumes unwinding so a joined handle still reports
 ///   [`JoinHandle::join`](std::thread::JoinHandle::join) `Err`. Prefer not
 ///   panicking in hop work in long-running HPC jobs — treat panics as bugs.
 ///
@@ -150,10 +153,11 @@ where
     std::thread::Builder::new()
         .name("pmix-callback-hop".to_string())
         .spawn(move || {
-            // Isolate panics to this hop thread. Log a clear diagnostic for
-            // operators (fire-and-forget callers never join), then resume so
-            // `JoinHandle::join` still surfaces the payload instead of a
-            // silent `Ok(())`.
+            // Log a clear diagnostic for operators (fire-and-forget callers
+            // never join), then resume so `JoinHandle::join` still surfaces
+            // the payload instead of a silent `Ok(())`. This is not true
+            // isolation under `panic = "abort"`, and resume_unwind still
+            // panics the hop thread (by design, for joiners).
             if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
                 eprintln!(
                     "pmix: thread 'pmix-callback-hop' panicked while running \

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -256,6 +256,9 @@ impl PmixTool {
 
         let status = unsafe { ffi::PMIx_tool_finalize() };
 
+        // Drop parked event handlers that were never deregistered.
+        crate::events::clear_handler_registry();
+
         self.inner
             .state
             .store(PmixToolState::Dead as u8, Ordering::Release);

--- a/tests/events_Register_event_handler.rs
+++ b/tests/events_Register_event_handler.rs
@@ -22,7 +22,7 @@ fn event_handler_ref_is_usize() {
     assert_eq!(_ref_id, 42);
 }
 
-/// `NotificationFn` is `Option<unsafe extern "C" fn(...)>`.
+/// `NotificationFn` is `Option<unsafe fn(...)>`.
 #[test]
 fn notification_fn_type_is_option() {
     // Verify the type alias compiles and can be None.

--- a/tests/events_unit.rs
+++ b/tests/events_unit.rs
@@ -46,7 +46,7 @@ fn test_notification_fn_none_is_none() {
 
 #[test]
 fn test_notification_fn_some_is_some() {
-    extern "C" fn dummy(
+    fn dummy(
         _: EventHandlerRef,
         _: i32,
         _: *const std::os::raw::c_void,
@@ -173,7 +173,7 @@ fn test_register_event_handler_multiple_codes() {
 
 #[test]
 fn test_register_event_handler_with_notification_fn() {
-    extern "C" fn dummy_handler(
+    fn dummy_handler(
         _: EventHandlerRef,
         _: i32,
         _: *const std::os::raw::c_void,
@@ -257,7 +257,7 @@ fn test_register_event_handler_nb_empty_codes() {
 #[test]
 fn test_register_event_handler_nb_with_notification_fn() {
     extern "C" fn dummy_reg_cb(_: i32, _: EventHandlerRef, _: *mut std::os::raw::c_void) {}
-    extern "C" fn dummy_handler(
+    fn dummy_handler(
         _: EventHandlerRef,
         _: i32,
         _: *const std::os::raw::c_void,


### PR DESCRIPTION
## Summary

Implements #51 (Phase 4a — callbacks). OpenPMIx delivers `_nb` completions and events on the **progress thread**, never the caller. This PR ships the shared hop-off helpers, a documented bridge policy, and brings the last out-of-policy bridge (`events`) in line.

### 1. Shared helper — `src/threading.rs` (new `pub mod threading`)
- `ProgressContext` — ZST marker documenting the APIs forbidden on the progress thread (blocking data ops, blocking events, session lifecycle, `progress()`).
- `spawn_from_callback(f)` — fire-and-forget application thread for blocking work from inside a callback.
- `CallbackChannel<T>` — app-thread receiver + clone-able sender for callbacks; documents the `!Send` C-owned value → Rust-owned (`bytes_copy()`) conversion.
- Module docs include the full hop-off template and the 4-point bridge policy (no blocking PMIx in-handler, no waiting in-handler, no registry `Mutex` across user code, `cbdata::encode/decode_req_id`).

### 2. `events` bridge rework (the remaining out-of-policy bridge)
The old bridge boxed the user `NotificationFn` into `cbdata` and **freed it immediately after registration** — a use-after-free, since PMIx retains the handler (and its cbdata) for the lifetime of the registration. Replaced with:
- `HANDLER_REGISTRY`: ref-ID-keyed `Box<NotificationFn>`, freed at deregistration.
- `notification_bridge` resolves the user fn under a scoped lock, released **before** the user callback runs.
- `register_event_handler_nb` parks the fn when the ref ID arrives via the completion bridge (previously leaked); error path frees it.
- `deregister_event_handler` removes the entry before the C call (no fire-into-freed-memory window).

### 3. Docs + example
- `examples/callback_hop.rs`: uses the helpers with **one data_ops nb path** (`get_nb`) **and one events path** (`register_event_handler` + `notify_event`) — the issue's acceptance criterion. Runs standalone with a graceful no-DVM exit.
- `THREADING.md` + crate-root concurrency docs cross-link the module; roadmap marks #51 Done.

### 4. Audit (deliverable 4)
Checked every `extern "C"` bridge: `data_ops`, `query_log`, `security`, `monitoring` already follow the policy (lock scoped to registry removal, user code outside the lock). `events` was the exception and is now fixed, with a **deadlock regression test** (`test_notification_bridge_no_lock_across_user_code`) proving the lock is not held across user callback execution.

## Test plan
- `cargo build --examples` ✅
- `cargo test --lib`: **1754 passed, 0 failed** (incl. 8 new `threading` + 121 `events` tests, 3 doctests)
- `cargo clippy --lib`: no new warnings
- `examples/callback_hop` runs standalone (graceful no-DVM exit)

Note: the integration-test suite under `tests/` has a pre-existing breakage on `main` (`tests/daemon_helper.rs` still uses the pre-#70 `PmixToolHandle` API) — unrelated to this PR. CI for this repo has no recorded workflow runs.

Closes #51