### PR TITLE
docs(threading): server module upcall guidelines + hop-off example (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ cargo run --example tool_attach
 cargo run --example simple_put_get
 cargo run --example simple_fence
 cargo run --example data_packing
+cargo run --example callback_hop          # client _nb / events hop-off (#51)
+cargo run --example server_upcall_hop     # server fence/modex upcall hop (#52)
 ```
 
 Under a PMIx DVM:

--- a/THREADING.md
+++ b/THREADING.md
@@ -61,6 +61,22 @@ client.disconnect(None)?;
 
 Deadlocks: external progress without a loop; mutex held across `progress()` + callback; blocking PMIx inside a callback; `progress()` after `progress_thread_stop()`.
 
+### 4.1 Server module upcalls (not pin targets)
+
+`PmixServerModule` host callbacks (`fence_nb`, `direct_modex`, `publish`, …)
+run in **progress context**. They are **not** CPU-pin targets — pin the
+progress engine (table above), not which core runs a given upcall body.
+
+Rules (same deadlock class as client `_nb` / events — issue #51 helpers):
+
+1. Return quickly; never call blocking PMIx from the upcall.
+2. Hop with `threading::spawn_from_callback` or `CallbackChannel`.
+3. Invoke the provided `cbfunc` **later** when RM / network work finishes.
+4. Copy C buffers before hopping; do not join hop work in-handler.
+
+Docs live next to the type: `PmixServerModule` in `src/server/mod.rs`.  
+Worked example: `examples/server_upcall_hop.rs` (issue #52).
+
 ---
 
 ## 5. Type inventory
@@ -94,11 +110,15 @@ Deadlocks: external progress without a loop; mutex held across `progress()` + ca
 
 1. Use session types (`PmixClient` / `PmixServer` / `PmixTool`) — clone for workers; `disconnect` once.  
 2. Build `Info` and other C-owned handles on the calling thread.  
-3. Callbacks = progress thread — hop before blocking PMIx. Use
-   `threading::spawn_from_callback` (fire-and-forget thread) or
-   `threading::CallbackChannel` (app-thread receiver) — see
-   `examples/callback_hop.rs`. Never join/wait in-handler; convert C-owned
-   (`!Send`) values to Rust-owned data (e.g. `bytes_copy()`) before hopping.  
+3. Callbacks **and server module upcalls** = progress context — hop before
+   blocking PMIx. Use `threading::spawn_from_callback` (fire-and-forget
+   thread) or `threading::CallbackChannel` (app-thread receiver) — see
+   `examples/callback_hop.rs` (client `_nb` / events) and
+   `examples/server_upcall_hop.rs` (fence_nb / direct_modex + delayed
+   `cbfunc`). Never join/wait in-handler; convert C-owned (`!Send`) values
+   to Rust-owned data (e.g. `bytes_copy()`) before hopping. Server upcalls
+   are **not** CPU-pin targets (§4.1).  
+
 4. One connect/disconnect cycle per process (per role).  
 5. Progress must run.  
 6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.  
@@ -128,7 +148,8 @@ work on an application thread. Full policy: `src/threading.rs`.
 
 `examples/client_minimal.rs`, `simple_put_get.rs`, `simple_fence.rs`,
 `server_minimal.rs`, `tool_attach.rs`, `callback_hop.rs` (get_nb + events
-callback hop-off via `threading` helpers).
+callback hop-off via `threading` helpers), `server_upcall_hop.rs`
+(server module fence/modex upcall hop + delayed `cbfunc`).
 
 ---
 
@@ -143,7 +164,7 @@ callback hop-off via `threading` helpers).
 | Server/tool sessions | #49 | Done |
 | C-owned !Send + assert matrix | #50 | Done (`threading_assert.rs`) |
 | Callback hop / audit | #51, #67 | #51 Done (`threading` module + events registry); #67 Open |
-| Server upcall example | #52 | Open |
+| Server upcall example | #52 | Done (`PmixServerModule` docs + `server_upcall_hop` example) |
 | Global FFI mutex | #53 | Deferred |
 | MT integration tests | #54 | Open |
 | Extra static_assertions | #66 | Mostly superseded by #50 |

--- a/examples/server_upcall_hop.rs
+++ b/examples/server_upcall_hop.rs
@@ -1,0 +1,296 @@
+//! Server-module upcall hop-off example (issue #52).
+//!
+//! Host callbacks in [`PmixServerModule`](pmix::server::PmixServerModule)
+//! (`fence_nb`, `direct_modex`, …) run in PMIx **progress context**. Blocking
+//! back into PMIx from an upcall deadlocks progress. The pattern is:
+//!
+//! 1. Mark the handler with [`ProgressContext`](pmix::threading::ProgressContext).
+//! 2. Copy any C buffers you need (lifetimes end when the upcall returns;
+//!    pointers are `!Send`).
+//! 3. [`spawn_from_callback`](pmix::threading::spawn_from_callback) (or a
+//!    [`CallbackChannel`](pmix::threading::CallbackChannel)) to hop off.
+//! 4. Return `PMIX_SUCCESS` from the upcall immediately.
+//! 5. Invoke the provided `cbfunc` **later** from the app thread when RM work
+//!    finishes.
+//!
+//! Upcalls are **not** CPU-pin targets — pin the progress engine via
+//! `InitOptions::bind_progress_thread` (see THREADING.md §4), not the
+//! `fence_nb` / `direct_modex` bodies themselves.
+//!
+//! Shared hop-off helpers and client `_nb` / events counterpart:
+//! [`pmix::threading`], `examples/callback_hop.rs` (issue #51).
+//!
+//! # Running
+//!
+//! Compiles and runs standalone (no clients → no real upcalls). The example
+//! also **self-drives** the hop pattern once so the async `cbfunc` path is
+//! exercised without a full RM:
+//!
+//! ```text
+//! cargo run --example server_upcall_hop
+//! ```
+//!
+//! Under a real resource manager the same function pointers are installed on
+//! the module OpenPMIx copies at `PMIx_server_init`.
+
+use std::os::raw::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use pmix::server::{PmixServer, PmixServerModule};
+use pmix::threading::{spawn_from_callback, CallbackChannel, ProgressContext};
+use pmix::InfoBuilder;
+
+/// Counts successful async completions from hopped-off upcall work.
+static COMPLETIONS: AtomicUsize = AtomicUsize::new(0);
+
+fn main() {
+    println!("pmix-rs: server upcall hop-off example (issue #52)");
+    println!("Pattern: progress upcall → spawn_from_callback → delayed cbfunc");
+    println!();
+
+    // ── 1. Install typed host upcalls on the module ────────────────────────
+    //
+    // `PmixServerModule` stores `Option<unsafe extern "C" fn()>` so the layout
+    // matches a C function-pointer table. Real OpenPMIx signatures are richer;
+    // transmute is the established install path (see server module docs).
+    let mut module = PmixServerModule::default();
+    // SAFETY: `host_fence_nb` / `host_direct_modex` match the C typedefs
+    // `pmix_server_fencenb_fn_t` / `pmix_server_dmodex_req_fn_t`. OpenPMIx
+    // only calls them through those typed slots after `server_init`.
+    module.fence_nb = Some(unsafe {
+        std::mem::transmute::<
+            unsafe extern "C" fn(
+                *const c_void,
+                usize,
+                *const c_void,
+                usize,
+                *mut i8,
+                usize,
+                Option<ModexCb>,
+                *mut c_void,
+            ) -> i32,
+            unsafe extern "C" fn(),
+        >(host_fence_nb)
+    });
+    module.direct_modex = Some(unsafe {
+        std::mem::transmute::<
+            unsafe extern "C" fn(
+                *const c_void,
+                *const c_void,
+                usize,
+                Option<ModexCb>,
+                *mut c_void,
+            ) -> i32,
+            unsafe extern "C" fn(),
+        >(host_direct_modex)
+    });
+
+    let info = InfoBuilder::new().build();
+    let server = match PmixServer::connect_new(Some(&module), &info) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("PmixServer::connect_new failed: {e:?}");
+            eprintln!("(OpenPMIx ≥ 6.1 must be discoverable via PMIX_PREFIX.)");
+            return;
+        }
+    };
+    println!(
+        "server live={} — fence_nb + direct_modex installed",
+        server.is_live()
+    );
+
+    // ── 2. Self-drive the hop pattern (no client fence required) ───────────
+    //
+    // Mirrors what OpenPMIx does when a client fence/modex arrives: enter the
+    // upcall on a "progress" stand-in thread, hop, complete via cbfunc later.
+    let hop = CallbackChannel::<&'static str>::new();
+    let tx = hop.sender();
+    let progress_stand_in = std::thread::Builder::new()
+        .name("pmix-progress-standin".into())
+        .spawn(move || {
+            // SAFETY: synthetic call with null procs/info and a real completion
+            // path — demonstrates the hop rules without a full RM collective.
+            let status = unsafe {
+                host_fence_nb(
+                    ptr::null(),
+                    0,
+                    ptr::null(),
+                    0,
+                    ptr::null_mut(),
+                    0,
+                    Some(demo_modex_complete),
+                    // Tag the cbdata so demo_modex_complete can signal the app.
+                    Box::into_raw(Box::new(tx)) as *mut c_void,
+                )
+            };
+            assert_eq!(status, 0, "upcall must return PMIX_SUCCESS immediately");
+        })
+        .expect("spawn progress stand-in");
+
+    // Application side: wait for the hopped completion (never join hop work
+    // from inside the upcall).
+    match hop.recv_timeout(Duration::from_secs(5)) {
+        Ok(msg) => println!("[app thread] async fence completion: {msg}"),
+        Err(e) => eprintln!("[app thread] no completion within 5s: {e}"),
+    }
+    progress_stand_in.join().expect("progress stand-in");
+
+    // Brief spin so fire-and-forget hop threads finish counting (standalone).
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while COMPLETIONS.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
+        std::thread::yield_now();
+    }
+    println!(
+        "hopped completions observed: {}",
+        COMPLETIONS.load(Ordering::SeqCst)
+    );
+
+    if let Err(e) = server.disconnect() {
+        eprintln!("disconnect failed: {e:?}");
+        return;
+    }
+    println!("server_upcall_hop example done");
+}
+
+/// `pmix_modex_cbfunc_t` — OpenPMIx completion for fence / direct-modex upcalls.
+type ModexCb = unsafe extern "C" fn(
+    status: i32,
+    data: *const i8,
+    ndata: usize,
+    cbdata: *mut c_void,
+    release_fn: Option<unsafe extern "C" fn(*mut c_void)>,
+    release_cbdata: *mut c_void,
+);
+
+/// Demo completion used by the self-driven path: signals the app channel.
+unsafe extern "C" fn demo_modex_complete(
+    status: i32,
+    _data: *const i8,
+    _ndata: usize,
+    cbdata: *mut c_void,
+    release_fn: Option<unsafe extern "C" fn(*mut c_void)>,
+    release_cbdata: *mut c_void,
+) {
+    COMPLETIONS.fetch_add(1, Ordering::SeqCst);
+    if !cbdata.is_null() {
+        // SAFETY: cbdata is the Box'd Sender we passed from main.
+        let tx = unsafe { Box::from_raw(cbdata as *mut std::sync::mpsc::Sender<&'static str>) };
+        let _ = tx.send(if status == 0 {
+            "fence_nb hopped + cbfunc OK"
+        } else {
+            "fence_nb hopped + cbfunc error"
+        });
+    }
+    if let Some(rel) = release_fn {
+        // SAFETY: release pair is whatever the host passed; null is fine.
+        unsafe { rel(release_cbdata) };
+    }
+}
+
+/// Host `fence_nb` upcall — **progress context**.
+///
+/// Matches `pmix_server_fencenb_fn_t`. Must not block on PMIx; hop and call
+/// `cbfunc` later.
+unsafe extern "C" fn host_fence_nb(
+    _procs: *const c_void,
+    nprocs: usize,
+    _info: *const c_void,
+    _ninfo: usize,
+    data: *mut i8,
+    ndata: usize,
+    cbfunc: Option<ModexCb>,
+    cbdata: *mut c_void,
+) -> i32 {
+    let _ctx = ProgressContext;
+
+    // Copy contributed blob before return — C buffer lifetime ends with the
+    // upcall frame; the pointer is also !Send.
+    let blob: Arc<Vec<u8>> = Arc::new(if data.is_null() || ndata == 0 {
+        Vec::new()
+    } else {
+        // SAFETY: OpenPMIx guarantees `data` is ndata bytes for the call.
+        unsafe { std::slice::from_raw_parts(data as *const u8, ndata) }.to_vec()
+    });
+
+    // *mut c_void is !Send — carry the chain address as usize across the hop.
+    let chain_addr = cbdata as usize;
+    let nprocs = nprocs;
+
+    let spawn_result = spawn_from_callback(move || {
+        // Application / RM thread — blocking work and delayed completion are OK.
+        println!(
+            "[app thread] fence_nb: nprocs={nprocs} blob_len={} — collective/RM work safe here",
+            blob.len()
+        );
+        // Real RMs would exchange `blob` with peer daemons here, then complete.
+        if let Some(cb) = cbfunc {
+            // SAFETY: complete the OpenPMIx fence chain. Return the chain
+            // pointer verbatim; no host-owned release blob in this demo.
+            unsafe {
+                cb(
+                    0, // PMIX_SUCCESS
+                    if blob.is_empty() {
+                        ptr::null()
+                    } else {
+                        blob.as_ptr() as *const i8
+                    },
+                    blob.len(),
+                    chain_addr as *mut c_void,
+                    None,
+                    ptr::null_mut(),
+                );
+            }
+        } else {
+            COMPLETIONS.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+    if let Err(e) = spawn_result {
+        // Never panic from a PMIx upcall — log and fail the request.
+        eprintln!("pmix: fence_nb hop spawn failed: {e}");
+        return -1; // PMIX_ERROR
+    }
+
+    // Return immediately — do NOT wait for the hop thread.
+    0 // PMIX_SUCCESS
+}
+
+/// Host `direct_modex` upcall — **progress context**.
+///
+/// Matches `pmix_server_dmodex_req_fn_t`. Same hop-then-`cbfunc` rules as fence.
+unsafe extern "C" fn host_direct_modex(
+    _proc: *const c_void,
+    _info: *const c_void,
+    _ninfo: usize,
+    cbfunc: Option<ModexCb>,
+    cbdata: *mut c_void,
+) -> i32 {
+    let _ctx = ProgressContext;
+    let chain_addr = cbdata as usize;
+
+    let spawn_result = spawn_from_callback(move || {
+        println!("[app thread] direct_modex: remote fetch would run here");
+        // Standalone demo: empty blob success. Real RMs contact the remote
+        // daemon, assemble the modex blob, then complete.
+        if let Some(cb) = cbfunc {
+            unsafe {
+                cb(
+                    0,
+                    ptr::null(),
+                    0,
+                    chain_addr as *mut c_void,
+                    None,
+                    ptr::null_mut(),
+                );
+            }
+        }
+        COMPLETIONS.fetch_add(1, Ordering::SeqCst);
+    });
+    if let Err(e) = spawn_result {
+        eprintln!("pmix: direct_modex hop spawn failed: {e}");
+        return -1;
+    }
+    0
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,11 @@
 //! - One logical connect/disconnect per process. **Drop does not finalize**
 //!   (clones must not each run `PMIx_Finalize`). Call [`disconnect`](PmixClient::disconnect)
 //!   or [`finalize`].
-//! - Server upcalls may run on PMIx internal threads; keep callbacks short.
+//! - Server module upcalls ([`server::PmixServerModule`]) run in **progress
+//!   context** — keep them short, hop before blocking PMIx, complete via the
+//!   provided `cbfunc` later. They are **not** CPU-pin targets (pin progress
+//!   via [`InitOptions::bind_progress_thread`]). See
+//!   `examples/server_upcall_hop.rs` and [THREADING.md](../THREADING.md) §4.1.
 //! - `_nb` completions and events are delivered on the **progress thread**.
 //!   Hop off before any blocking work with the [`threading`] helpers
 //!   (`spawn_from_callback`, `CallbackChannel`); never call blocking PMIx

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -27,6 +27,29 @@
 //! server.disconnect().expect("server disconnect");
 //! ```
 //!
+//! # Server module upcalls (progress context)
+//!
+//! Host callbacks in [`PmixServerModule`] (`fence_nb`, `direct_modex`,
+//! `publish`, …) run on the PMIx **progress thread** (or another host
+//! progress context OpenPMIx chooses) — **not** on an application worker
+//! you pin. That has two consequences:
+//!
+//! 1. **Do not block back into PMIx from an upcall.** Waiting on a
+//!    blocking `PMIx_*` entry (or joining a thread that does) deadlocks
+//!    progress. Hop first with
+//!    [`crate::threading::spawn_from_callback`] /
+//!    [`crate::threading::CallbackChannel`], then finish the request by
+//!    invoking the provided `cbfunc` **later** from an app thread.
+//! 2. **Upcalls are not CPU-pin targets.** Pin the progress engine via
+//!    [`InitOptions::bind_progress_thread`](crate::InitOptions::bind_progress_thread)
+//!    (see [THREADING.md](../../THREADING.md) §4). Do not try to pin
+//!    which core runs `fence_nb` / `direct_modex` themselves.
+//!
+//! Full hop-off policy and forbidden APIs:
+//! [`crate::threading::ProgressContext`]. Worked fence/modex pattern:
+//! `examples/server_upcall_hop.rs`. Client `_nb` / events counterpart:
+//! `examples/callback_hop.rs` ([#51](https://github.com/SedahsDev/pmix-rs/issues/51)).
+//!
 //! # Callbacks
 //!
 //! The `PmixServerModule` struct mirrors `pmix_server_module_t`. Each
@@ -81,11 +104,58 @@ pub use pset::*;
 /// implemented by the server. The PMIx library checks for null before
 /// calling each callback, so it is safe to set only the ones you need.
 ///
+/// # Progress-thread rules (read before implementing any field)
+///
+/// OpenPMIx invokes these host upcalls from **progress context** (typically
+/// the PMIx progress / event-engine thread). They are **not** a place to
+/// pin application CPUs — pin progress separately
+/// ([THREADING.md](../../THREADING.md) §4; helpers in [`crate::threading`]).
+///
+/// | Do | Don't |
+/// |----|--------|
+/// | Return quickly from the upcall | Call blocking PMIx APIs in-handler |
+/// | Hop off with [`spawn_from_callback`](crate::threading::spawn_from_callback) or [`CallbackChannel`](crate::threading::CallbackChannel) | Join / park waiting for progress |
+/// | Invoke the provided `cbfunc` **later** when RM work finishes | Block the upcall until remote collectives complete |
+/// | Copy C buffers you need before hopping (`!Send` / lifetime ends at return) | Hold crate registry locks across user/RM code |
+///
+/// ```rust,ignore
+/// // ❌ NEVER — blocks progress on a PMIx round-trip from a server upcall
+/// let _ = pmix::data_ops::get(&proc, "pmix.job.size", None);
+///
+/// // ❌ NEVER — waits in-handler for work that needs progress
+/// handle.join().unwrap();
+///
+/// // ✅ Hop, then complete asynchronously via cbfunc
+/// let _ctx = pmix::threading::ProgressContext;
+/// let cb = cbfunc; // capture
+/// let chain = cbdata as usize; // *mut c_void is !Send
+/// let _ = pmix::threading::spawn_from_callback(move || {
+///     // RM / network work is safe here
+///     if let Some(cb) = cb {
+///         unsafe { cb(PMIX_SUCCESS, /* … */, chain as *mut _, None, std::ptr::null_mut()); }
+///     }
+/// });
+/// // return PMIX_SUCCESS from the upcall immediately
+/// ```
+///
+/// See `examples/server_upcall_hop.rs` for a complete fence_nb / direct_modex
+/// pattern, and [`crate::threading`] / `examples/callback_hop.rs` for the
+/// shared hop-off helpers used by client `_nb` completions and events.
+///
+/// # Field types
+///
+/// Fields are stored as `Option<unsafe extern "C" fn()>` so the struct layout
+/// matches a table of C function pointers. Real upcalls have richer C
+/// signatures (`pmix_server_fencenb_fn_t`, …); cast with `std::mem::transmute`
+/// when installing a typed handler (as in the example).
+///
 /// # C API
 /// `struct pmix_server_module_4_0_0_t` (aliased as `pmix_server_module_t`)
 #[derive(Debug, Default)]
 pub struct PmixServerModule {
     /// Called when a client process connects to this server.
+    ///
+    /// Runs in **progress context** — see [struct-level progress rules](PmixServerModule#progress-thread-rules-read-before-implementing-any-field).
     ///
     /// # C type
     /// `pmix_server_client_connected_fn_t`
@@ -93,23 +163,40 @@ pub struct PmixServerModule {
 
     /// Called when a client process finalizes its connection.
     ///
+    /// Runs in **progress context** — see [struct-level progress rules](PmixServerModule#progress-thread-rules-read-before-implementing-any-field).
+    ///
     /// # C type
     /// `pmix_server_client_finalized_fn_t`
     pub client_finalized: Option<unsafe extern "C" fn()>,
 
     /// Called when a client requests an abort.
     ///
+    /// Runs in **progress context** — see [struct-level progress rules](PmixServerModule#progress-thread-rules-read-before-implementing-any-field).
+    /// Complete via the provided `pmix_op_cbfunc_t` after hopping if work blocks.
+    ///
     /// # C type
     /// `pmix_server_abort_fn_t`
     pub abort: Option<unsafe extern "C" fn()>,
 
-    /// Non-blocking fence callback.
+    /// Non-blocking fence / collective upcall (`PMIx_Fence` / `PMIx_Fence_nb`).
+    ///
+    /// OpenPMIx calls this once local participants have contributed. The host
+    /// must share any provided modex blob with peer daemons and complete via
+    /// `pmix_modex_cbfunc_t` — typically **after** hopping off progress
+    /// (network / collective work must not block the upcall).
+    ///
+    /// **Not a CPU-pin target** — progress pinning is separate ([THREADING.md](../../THREADING.md)).
+    /// Pattern: `examples/server_upcall_hop.rs`.
     ///
     /// # C type
     /// `pmix_server_fencenb_fn_t`
     pub fence_nb: Option<unsafe extern "C" fn()>,
 
-    /// Direct modex request callback.
+    /// Direct modex request — fetch a remote proc's modex blob via the host.
+    ///
+    /// Same progress-thread rules as [`Self::fence_nb`]: schedule the remote
+    /// fetch off-progress and invoke `pmix_modex_cbfunc_t` when the blob is
+    /// ready (or on error). See `examples/server_upcall_hop.rs`.
     ///
     /// # C type
     /// `pmix_server_dmodex_req_fn_t`

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -64,8 +64,9 @@
 //! Rust-owned data first (e.g. [`bytes_copy`](crate::PmixOwnedValue::bytes_copy))
 //! and send the copy.
 //!
-//! See also `examples/callback_hop.rs` for a complete `get_nb` + events
-//! demonstration, and [THREADING.md](../THREADING.md).
+//! See also `examples/callback_hop.rs` (`get_nb` + events) and
+//! `examples/server_upcall_hop.rs` (server module fence/modex upcalls +
+//! delayed `cbfunc`), plus [THREADING.md](../THREADING.md).
 
 use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, Sender, TryRecvError};
 


### PR DESCRIPTION
## Summary
- Document progress-thread / host-upcall rules on `PmixServerModule` (and module-level docs): never block back into PMIx; hop with `threading` helpers; invoke `cbfunc` later; upcalls are **not** CPU-pin targets.
- Add `examples/server_upcall_hop.rs` — fence_nb + direct_modex hop-off pattern with delayed `pmix_modex_cbfunc_t`, self-driven so it builds/runs without a full RM.
- Cross-link `THREADING.md` §4.1, crate concurrency docs, `threading` module, README, and #51 `callback_hop`.

## Test plan
- [x] `cargo build --examples` (OpenPMIx ≥ 6.1 via `PMIX_PREFIX`)
- [x] `cargo run --example server_upcall_hop` — observes hopped fence completion + delayed cbfunc
- [ ] CI green

Closes #52