### PR TITLE
test(threading): multi-thread + external-progress integration (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,21 @@ cargo run --example simple_fence
 cargo run --example data_packing
 cargo run --example callback_hop          # client _nb / events hop-off (#51)
 cargo run --example server_upcall_hop     # server fence/modex upcall hop (#52)
+cargo run --example external_progress_mt  # host progress + MT put (#54)
 ```
 
 Under a PMIx DVM:
 
 ```bash
 prterun -np 2 ./target/debug/examples/simple_put_get
+```
+
+Multi-thread + external-progress integration tests (issue #54):
+
+```bash
+./scripts/run_daemon_tests.sh THREADING
+# or:
+prterun -np 1 cargo test --test threading_mt_via_prterun -- --ignored --test-threads=1
 # or
 ./scripts/run_daemon_tests.sh
 ```

--- a/THREADING.md
+++ b/THREADING.md
@@ -151,6 +151,31 @@ work on an application thread. Full policy: `src/threading.rs`.
 callback hop-off via `threading` helpers), `server_upcall_hop.rs`
 (server module fence/modex upcall hop + delayed `cbfunc`).
 
+### 7.1 Multi-thread + external-progress integration tests (#54)
+
+| Goal | Test (`tests/threading_mt_via_prterun.rs`) |
+|------|---------------------------------------------|
+| (1) N threads: clone `PmixClient`, concurrent put + fence | `mt_concurrent_put_and_fence` |
+| (2) Concurrent `_nb` completions | `mt_concurrent_fence_nb_completions` |
+| (3) `external_progress` + host `progress()` | `mt_external_progress_host_thread` (own process) |
+| (4) Callback must-not-block timeout | `callback_must_not_block_progress_timeout` |
+
+Run under PRTE ≥ 4.1 / OpenPMIx ≥ 6.1:
+
+```bash
+export PMIX_PREFIX=${PMIX_PREFIX:-$HOME/.local/openpmix-6.1.0}
+export LD_LIBRARY_PATH=$PMIX_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export PATH=/path/to/prte-4.1/bin:$PATH
+
+cargo test --test threading_mt_via_prterun -- --test-threads=1
+./scripts/run_daemon_tests.sh THREADING
+```
+
+All DVM cases use the **process-wide** `PmixClient` (no bare `Context`, no
+per-thread init). Goal (3) applies `InitOptions::external_progress(true)` on
+the first connect; the harness runs each ignored test under its own `prterun`
+process. Companion example: `examples/external_progress_mt.rs`.
+
 ---
 
 ## 8. Roadmap
@@ -166,5 +191,5 @@ callback hop-off via `threading` helpers), `server_upcall_hop.rs`
 | Callback hop / audit | #51, #67 | #51 Done (`threading` module + events registry); #67 Open |
 | Server upcall example | #52 | Done (`PmixServerModule` docs + `server_upcall_hop` example) |
 | Global FFI mutex | #53 | Deferred |
-| MT integration tests | #54 | Open |
+| MT integration tests | #54 | Done (`tests/threading_mt_via_prterun.rs` + `run_daemon_tests.sh THREADING`) |
 | Extra static_assertions | #66 | Mostly superseded by #50 |

--- a/examples/external_progress_mt.rs
+++ b/examples/external_progress_mt.rs
@@ -1,0 +1,67 @@
+//! Minimal external_progress + host progress + multi-thread put (issue #54 goal 3).
+use std::ffi::CString;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop2 = Arc::clone(&stop);
+    let _progress = thread::Builder::new()
+        .name("host-progress".into())
+        .spawn(move || {
+            while !stop2.load(Ordering::Acquire) {
+                pmix::progress();
+                thread::sleep(Duration::from_millis(1));
+            }
+            for _ in 0..64 {
+                pmix::progress();
+            }
+        })
+        .unwrap();
+
+    let mut opts = pmix::InitOptions::new();
+    opts.external_progress(true);
+    let info = opts.build();
+    eprintln!("connecting...");
+    let client = pmix::PmixClient::connect_new(Some(info)).expect("connect");
+    eprintln!("connected rank={:?}", client.rank());
+
+    const N: usize = 4;
+    let barrier = Arc::new(Barrier::new(N));
+    let mut hs = vec![];
+    for i in 0..N {
+        let w = client.clone();
+        let b = Arc::clone(&barrier);
+        hs.push(thread::spawn(move || {
+            assert!(w.is_live());
+            b.wait();
+            let key = CString::new(format!("ex.ext.{i}")).unwrap();
+            let mut val = pmix::PmixValueBuilder::new()
+                .string(&format!("v{i}"))
+                .unwrap()
+                .build()
+                .unwrap();
+            pmix::put_value(pmix::PmixScope::Global.to_raw(), &key, &mut val).expect("put");
+        }));
+    }
+    for h in hs {
+        h.join().unwrap();
+    }
+    eprintln!("puts done");
+    let proc = client.require_proc();
+    pmix::commit().expect("commit");
+    eprintln!("commit done");
+    pmix::fence(&proc, None).expect("fence");
+    eprintln!("fence done");
+    // PMIx_Progress may block, so do not join the progress thread.
+    stop.store(true, Ordering::Release);
+    // Give the loop a moment to observe stop between Progress calls.
+    thread::sleep(Duration::from_millis(50));
+    match client.disconnect(None) {
+        Ok(()) => eprintln!("disconnect ok"),
+        Err(e) => eprintln!("disconnect: {e:?}"),
+    }
+    eprintln!("ok");
+}

--- a/scripts/run_daemon_tests.sh
+++ b/scripts/run_daemon_tests.sh
@@ -1,71 +1,134 @@
 #!/bin/bash
-# Run pmix-rs tests that require a PMIx daemon.
-# Reads the PRTE URI from the systemd-managed service and exports PMIX_SERVER_URI.
+# Run pmix-rs tests that require a PMIx daemon / DVM.
 #
 # Usage:
-#   ./scripts/run_daemon_tests.sh          # Run all daemon tests
-#   ./scripts/run_daemon_tests.sh TOOL     # Run only tool_tool_init tests
-#   ./scripts/run_daemon_tests.sh LIB      # Run only lib_core_api daemon tests
-#   ./scripts/run_daemon_tests.sh FABRIC   # Run only fabric daemon tests
-#   ./scripts/run_daemon_tests.sh COV      # Run coverage with daemon tests included
+#   ./scripts/run_daemon_tests.sh              # Run all daemon tests
+#   ./scripts/run_daemon_tests.sh TOOL         # tool_tool_init tests
+#   ./scripts/run_daemon_tests.sh LIB          # lib_core_api daemon tests
+#   ./scripts/run_daemon_tests.sh FABRIC       # fabric daemon tests
+#   ./scripts/run_daemon_tests.sh THREADING    # multi-thread + external-progress (#54)
+#   ./scripts/run_daemon_tests.sh COV          # coverage with daemon tests included
 #
-# Prerequisites:
-#   systemctl --user start prte
+# Prerequisites (TOOL/LIB/FABRIC/ALL — tool URI path):
+#   systemctl --user start prte   # or a PRTE system-server writing $URI_FILE
+#
+# Prerequisites (THREADING — DVM / prterun path):
+#   OpenPMIx ≥ 6.1 and PRTE ≥ 4.1 on PATH (same libpmix), e.g.:
+#     export PMIX_PREFIX=$HOME/.local/openpmix-6.1.0
+#     export PATH=/path/to/prte-4.1/bin:$PATH
+#     export LD_LIBRARY_PATH=$PMIX_PREFIX/lib:$LD_LIBRARY_PATH
+#   prterun must work: `prterun --version`
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-URI_FILE="/run/user/1000/prte/uri"
+URI_FILE="${PMIX_TEST_URI_FILE:-/run/user/$(id -u)/prte/uri}"
 
-# Check PRTE is running
-if ! systemctl --user is-active prte &>/dev/null; then
-    echo "ERROR: prte systemd service is not running."
-    echo "Start it with: systemctl --user start prte"
-    exit 1
-fi
+require_uri_daemon() {
+    if [ ! -f "$URI_FILE" ]; then
+        # Best-effort: systemd unit may not exist on all hosts.
+        if systemctl --user is-active prte &>/dev/null; then
+            :
+        elif systemctl --user list-unit-files 2>/dev/null | grep -q '^prte'; then
+            echo "ERROR: prte systemd service is not running."
+            echo "Start it with: systemctl --user start prte"
+            exit 1
+        else
+            echo "ERROR: PRTE URI file not found at $URI_FILE"
+            echo "Start a PRTE system-server that writes the URI, or set PMIX_TEST_URI_FILE."
+            exit 1
+        fi
+    fi
+    if [ ! -f "$URI_FILE" ]; then
+        echo "ERROR: PRTE URI file not found at $URI_FILE"
+        exit 1
+    fi
+    PMIX_SERVER_URI=$(head -1 "$URI_FILE")
+    echo "PRTE URI: $PMIX_SERVER_URI"
+    export PMIX_SERVER_URI
+    export PMIX_TEST_URI_FILE="$URI_FILE"
+}
 
-# Read URI
-if [ ! -f "$URI_FILE" ]; then
-    echo "ERROR: PRTE URI file not found at $URI_FILE"
-    echo "The prte service may not have started properly."
-    exit 1
-fi
-
-PMIX_SERVER_URI=$(head -1 "$URI_FILE")
-echo "PRTE URI: $PMIX_SERVER_URI"
-
-# Verify connectivity with a quick C test
-export PMIX_SERVER_URI
-export PMIX_TEST_URI_FILE="$URI_FILE"
+require_prterun() {
+    if ! command -v prterun >/dev/null 2>&1; then
+        echo "ERROR: prterun not on PATH (need PRTE ≥ 4.1 built against OpenPMIx ≥ 6.1)."
+        exit 1
+    fi
+    echo "Using prterun: $(command -v prterun)"
+    prterun --version 2>&1 | head -3 || true
+}
 
 cd "$PROJECT_DIR"
 
 case "${1:-ALL}" in
     TOOL)
+        require_uri_daemon
         echo "Running tool_tool_init daemon tests..."
-        cargo test --test tool_tool_init -- --ignored
+        cargo test --test tool_tool_init -- --ignored --test-threads=1
         ;;
     LIB)
+        require_uri_daemon
         echo "Running lib_core_api daemon tests..."
-        cargo test --test lib_core_api -- --ignored
+        cargo test --test lib_core_api -- --ignored --test-threads=1
         ;;
     FABRIC)
+        require_uri_daemon
         echo "Running fabric_fabric_comprehensive daemon tests..."
-        cargo test --test fabric_fabric_comprehensive -- --ignored
+        cargo test --test fabric_fabric_comprehensive -- --ignored --test-threads=1
+        ;;
+    THREADING)
+        require_prterun
+        echo "Running multi-thread + external-progress tests (issue #54)..."
+        # Build once, then run the test binary under prterun (avoids nested cargo
+        # and lets us bound each case with timeout).
+        cargo test --test threading_mt_via_prterun --no-run
+        BIN=$(ls -1t target/debug/deps/threading_mt_via_prterun-* | grep -v '\.d$' | head -1)
+        if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+            echo "ERROR: could not locate threading_mt_via_prterun test binary"
+            exit 1
+        fi
+        echo "Test binary: $BIN"
+        # Standalone first (no DVM).
+        "$BIN" --test-threads=1
+        # cargo TESTNAME is a *substring* filter (not a regex). Each DVM case
+        # runs under its own prterun so process-wide session state stays clean.
+        for tname in \
+            mt_concurrent_put_and_fence \
+            mt_concurrent_fence_nb_completions \
+            callback_must_not_block_progress_timeout \
+            mt_external_progress_host_thread
+        do
+            echo "---- prterun: $tname ----"
+            # 60s wall clock per case — external_progress hangs must fail closed.
+            if command -v timeout >/dev/null 2>&1; then
+                timeout 60 prterun -np 1 "$BIN" "$tname" --ignored --test-threads=1
+            else
+                prterun -np 1 "$BIN" "$tname" --ignored --test-threads=1
+            fi
+        done
         ;;
     COV)
+        require_uri_daemon
         echo "Running coverage with daemon tests..."
-        cargo llvm-cov --json -- --ignored
+        cargo llvm-cov --json -- --ignored --test-threads=1
         ;;
     ALL)
+        require_uri_daemon
         echo "Running all daemon-dependent tests..."
-        cargo test --test tool_tool_init -- --ignored
-        cargo test --test lib_core_api -- --ignored
-        cargo test --test fabric_fabric_comprehensive -- --ignored
+        cargo test --test tool_tool_init -- --ignored --test-threads=1
+        cargo test --test lib_core_api -- --ignored --test-threads=1
+        cargo test --test fabric_fabric_comprehensive -- --ignored --test-threads=1
+        # THREADING is opt-in when prterun is available (does not need URI file).
+        if command -v prterun >/dev/null 2>&1; then
+            echo "Also running THREADING suite (prterun available)..."
+            "$0" THREADING
+        else
+            echo "Skipping THREADING suite (prterun not on PATH)."
+        fi
         ;;
     *)
-        echo "Usage: $0 [TOOL|LIB|FABRIC|COV|ALL]"
+        echo "Usage: $0 [TOOL|LIB|FABRIC|THREADING|COV|ALL]"
         exit 1
         ;;
 esac

--- a/scripts/run_daemon_tests.sh
+++ b/scripts/run_daemon_tests.sh
@@ -82,10 +82,42 @@ case "${1:-ALL}" in
         echo "Running multi-thread + external-progress tests (issue #54)..."
         # Build once, then run the test binary under prterun (avoids nested cargo
         # and lets us bound each case with timeout).
-        cargo test --test threading_mt_via_prterun --no-run
-        BIN=$(ls -1t target/debug/deps/threading_mt_via_prterun-* | grep -v '\.d$' | head -1)
-        if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+        # Resolve the exact executable via cargo JSON (deterministic; avoids
+        # `ls <glob>` dying under set -e when the glob is empty).
+        BIN=$(
+            cargo test --test threading_mt_via_prterun --no-run --message-format=json \
+                | python3 -c '
+import json, sys
+bin_path = None
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if msg.get("reason") != "compiler-artifact":
+        continue
+    target = msg.get("target") or {}
+    if "test" not in (target.get("kind") or []):
+        continue
+    name = target.get("name") or ""
+    if name != "threading_mt_via_prterun" and not name.startswith("threading_mt_via_prterun"):
+        continue
+    exe = msg.get("executable")
+    if exe:
+        bin_path = exe
+if not bin_path:
+    sys.exit(1)
+print(bin_path)
+'
+        ) || {
             echo "ERROR: could not locate threading_mt_via_prterun test binary"
+            exit 1
+        }
+        if [ ! -x "$BIN" ]; then
+            echo "ERROR: threading_mt_via_prterun test binary is not executable: $BIN"
             exit 1
         fi
         echo "Test binary: $BIN"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3022,11 +3022,24 @@ struct InfoEntryString {
     data_type: pmix_data_type_t,
 }
 
+/// String-key `PMIX_BOOL` entry with owned storage (`uint8_t` 0/1).
+///
+/// OpenPMIx loads `PMIX_BOOL` from a pointer to a byte, not a C string. Using
+/// `add_string_key(..., "1", PMIX_BOOL)` mis-encodes the value and attributes
+/// such as `PMIX_EXTERNAL_PROGRESS` are ignored (internal progress still runs).
+struct InfoEntryBool {
+    key: CString,
+    /// `1` = true, `0` = false — matches PMIx `PMIX_BOOL` packing.
+    value: u8,
+}
+
 #[derive(Default)]
 pub struct InfoBuilder {
     infos: Vec<InfoEntry>,
     /// String-key entries for keys that exceed the 13-byte limit.
     string_infos: Vec<InfoEntryString>,
+    /// String-key boolean attributes (`pmix.evext`, `pmix.bind.reqd`, …).
+    bool_infos: Vec<InfoEntryBool>,
     /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
@@ -3069,6 +3082,16 @@ impl InfoBuilder {
         });
     }
 
+    /// Append a string-key `PMIX_BOOL` attribute with correct scalar encoding.
+    fn add_bool_key(&mut self, key: &str, value: bool) -> &mut Self {
+        let key_cstr = CString::new(key).expect("key must not contain null bytes");
+        self.bool_infos.push(InfoEntryBool {
+            key: key_cstr,
+            value: u8::from(value),
+        });
+        self
+    }
+
     /// Set `PMIX_EXTERNAL_PROGRESS` attribute.
     ///
     /// When `true`, tells PMIx that the host provides its own event
@@ -3080,12 +3103,7 @@ impl InfoBuilder {
     /// # C API
     /// `PMIX_EXTERNAL_PROGRESS` (`pmix.evext`) — `PMIX_BOOL`
     pub fn external_progress(&mut self, external: bool) -> &mut Self {
-        self.add_string_key(
-            "pmix.evext",
-            if external { "1" } else { "0" },
-            PMIX_BOOL as pmix_data_type_t,
-        );
-        self
+        self.add_bool_key("pmix.evext", external)
     }
 
     /// Set `PMIX_BIND_PROGRESS_THREAD` attribute.
@@ -3117,12 +3135,7 @@ impl InfoBuilder {
     /// # C API
     /// `PMIX_BIND_REQUIRED` (`pmix.bind.reqd`) — `PMIX_BOOL`
     pub fn bind_required(&mut self, required: bool) -> &mut Self {
-        self.add_string_key(
-            "pmix.bind.reqd",
-            if required { "1" } else { "0" },
-            PMIX_BOOL as pmix_data_type_t,
-        );
-        self
+        self.add_bool_key("pmix.bind.reqd", required)
     }
 
     /// Set `PMIX_PROGRESS_THREAD_FLUSH` attribute.
@@ -3134,12 +3147,7 @@ impl InfoBuilder {
     /// # C API
     /// `PMIX_PROGRESS_THREAD_FLUSH` (`pmix.evflush`) — `PMIX_BOOL`
     pub fn progress_thread_flush(&mut self, flush: bool) -> &mut Self {
-        self.add_string_key(
-            "pmix.evflush",
-            if flush { "1" } else { "0" },
-            PMIX_BOOL as pmix_data_type_t,
-        );
-        self
+        self.add_bool_key("pmix.evflush", flush)
     }
 
     /// Set `PMIX_PROGRESS_THREAD_NAME` attribute.
@@ -3156,16 +3164,12 @@ impl InfoBuilder {
     }
 
     pub fn collect_data(&mut self) -> &mut InfoBuilder {
-        let collect = true;
-        self.add(
-            PMIX_COLLECT_DATA,
-            &collect as *const bool as *const c_void,
-            PMIX_BOOL as pmix_data_type_t,
-        );
-        self
+        // Owned storage: `add` only stores a raw pointer, so a stack bool
+        // would dangle by `build()`. Use bool_infos for correct lifetime.
+        self.add_bool_key("pmix.collect", true)
     }
     pub fn build(self) -> Info {
-        let n = self.infos.len() + self.string_infos.len();
+        let n = self.infos.len() + self.string_infos.len() + self.bool_infos.len();
         let info_ptr = unsafe { PMIx_Info_create(n) };
         if info_ptr.is_null() && n > 0 {
             panic!("PMIx_Info_create({n}) returned null");
@@ -3210,10 +3214,29 @@ impl InfoBuilder {
             idx += 1;
         }
 
+        // Process string-key boolean attributes with owned u8 storage.
+        for info in &self.bool_infos {
+            let status = unsafe {
+                PMIx_Info_load(
+                    info_ptr.add(idx),
+                    info.key.as_ptr(),
+                    (&info.value as *const u8).cast(),
+                    PMIX_BOOL as pmix_data_type_t,
+                )
+            };
+            if status != PMIX_SUCCESS as i32 {
+                unsafe {
+                    PMIx_Info_free(info_ptr, n);
+                }
+                panic!("Error loading bool-key info: {}", status);
+            }
+            idx += 1;
+        }
+
         Info {
             handle: info_ptr,
             len: idx,
-        _not_thread_safe: std::marker::PhantomData,
+            _not_thread_safe: std::marker::PhantomData,
         }
     }
 }

--- a/tests/threading_mt_via_prterun.rs
+++ b/tests/threading_mt_via_prterun.rs
@@ -398,6 +398,8 @@ fn mt_concurrent_fence_nb_completions() {
 /// Callback parks on the progress path — models THREADING.md §6.1 deadlock class.
 struct BlockingFenceCb {
     pair: Arc<(Mutex<bool>, Condvar)>,
+    /// Set after the condvar wait so the test can prove `on_complete` ran.
+    ran: Arc<AtomicBool>,
 }
 
 impl FenceCallback for BlockingFenceCb {
@@ -409,11 +411,15 @@ impl FenceCallback for BlockingFenceCb {
         let _ = cvar
             .wait_timeout(guard, Duration::from_secs(3))
             .expect("condvar");
+        self.ran.store(true, Ordering::Release);
     }
 }
 
 /// Regression: progress-thread blocking is detected with a wall-clock timeout
 /// on a follow-up op, rather than hanging the suite forever.
+///
+/// Also asserts the blocking `fence_nb` completion actually ran — otherwise a
+/// silent no-op callback path would still pass the hang-smoke check.
 #[test]
 #[ignore = "requires DVM-launched process (prterun) — issue #54 goal (4)"]
 fn callback_must_not_block_progress_timeout() {
@@ -426,8 +432,10 @@ fn callback_must_not_block_progress_timeout() {
     let proc = client.require_proc();
 
     let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let ran = Arc::new(AtomicBool::new(false));
     let cb = Box::new(BlockingFenceCb {
         pair: Arc::clone(&pair),
+        ran: Arc::clone(&ran),
     });
 
     fence_nb(std::slice::from_ref(&proc), None, cb)
@@ -445,6 +453,10 @@ fn callback_must_not_block_progress_timeout() {
     match rx.recv_timeout(Duration::from_secs(8)) {
         Ok(fence_result) => {
             // Completed (in-place nb, or block finished). Must not hang.
+            eprintln!(
+                "callback_must_not_block_progress_timeout: secondary fence completed \
+                 (branch=Ok, result={fence_result:?})"
+            );
             match fence_result {
                 Ok(()) => {}
                 Err(e) => {
@@ -459,4 +471,15 @@ fn callback_must_not_block_progress_timeout() {
             );
         }
     }
+
+    // Allow the blocking callback to finish its 3s wait if it is still parked.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !ran.load(Ordering::Acquire) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        ran.load(Ordering::Acquire),
+        "BlockingFenceCb::on_complete must have run (regression guard against \
+         silent callback drop / never-submitted fence_nb)"
+    );
 }

--- a/tests/threading_mt_via_prterun.rs
+++ b/tests/threading_mt_via_prterun.rs
@@ -1,0 +1,462 @@
+//! Multi-thread + external-progress integration tests (issue #54).
+//!
+//! ## Goals covered
+//!
+//! 1. **N threads**: clone process-wide [`pmix::PmixClient`], concurrent
+//!    `put_value` (distinct keys) + a process `fence` under `prterun`.
+//! 2. **Concurrent `_nb` completions**: several `fence_nb` submissions with
+//!    completions counted under internal progress.
+//! 3. **`external_progress=true`**: host thread runs [`pmix::progress`] while
+//!    workers issue ops; main thread fences once progress is running.
+//! 4. **Callback must-not-block regression**: a `fence_nb` completion that
+//!    blocks on the progress path is bounded by an application-side timeout
+//!    (deadlock class from #51 / `THREADING.md`).
+//!
+//! ## How to run
+//!
+//! ```bash
+//! export PMIX_PREFIX=${PMIX_PREFIX:-$HOME/.local/openpmix-6.1.0}
+//! export LD_LIBRARY_PATH=$PMIX_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+//! # PRTE ≥ 4.1 built against the same OpenPMIx (system PRTE 3.x is not enough):
+//! export PATH=/path/to/prte-4.1/bin:$PATH
+//!
+//! # Standalone (Send/Clone + InitOptions only):
+//! cargo test --test threading_mt_via_prterun -- --test-threads=1
+//!
+//! # DVM — each ignored test under its own prterun (cargo filter is a substring):
+//! for t in mt_concurrent_put_and_fence mt_concurrent_fence_nb_completions \
+//!          callback_must_not_block_progress_timeout mt_external_progress_host_thread; do
+//!   prterun -np 1 cargo test --test threading_mt_via_prterun "$t" -- --ignored --test-threads=1
+//! done
+//!
+//! # Harness (standalone + all DVM goals):
+//! ./scripts/run_daemon_tests.sh THREADING
+//! ```
+//!
+//! Uses **process-wide** [`PmixClient`] only (no bare `Context`, no per-thread init).
+
+mod daemon_helper;
+
+use std::ffi::CString;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use pmix::data_ops::{fence_nb, FenceCallback};
+use pmix::{InitOptions, PmixClient, PmixError, PmixScope, PmixStatus, PmixValueBuilder};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn is_dvm_launched() -> bool {
+    std::env::var("PMIX_NAMESPACE").is_ok()
+        || std::env::var("PMIX_RANK").is_ok()
+        || std::env::var("PRTE_LAUNCHED").is_ok()
+        || std::env::var("PMIX_SERVER_URI2").is_ok()
+}
+
+/// Connect once with default (internal) progress — process-wide session.
+fn ensure_client_internal() -> &'static PmixClient {
+    daemon_helper::ensure_pmix_init()
+}
+
+fn put_string_key(key: &str, value: &str) -> Result<(), String> {
+    let ckey = CString::new(key).map_err(|e| format!("key NUL: {e}"))?;
+    let mut owned = PmixValueBuilder::new()
+        .string(value)
+        .map_err(|e| format!("string value: {e:?}"))?
+        .build()
+        .map_err(|e| format!("build value: {e:?}"))?;
+    pmix::put_value(PmixScope::Global.to_raw(), &ckey, &mut owned)
+        .map_err(|e| format!("put_value({key}): {e:?}"))
+}
+
+// ─── Standalone (no DVM) ────────────────────────────────────────────────────
+
+/// `PmixClient` is `Clone + Send + Sync` — clones can move to worker threads.
+#[test]
+fn client_clone_is_send_across_threads() {
+    let client = PmixClient::new();
+    let worker = client.clone();
+    let handle = thread::spawn(move || {
+        let _ = worker.state();
+        worker.is_live()
+    });
+    let _live = handle.join().expect("worker must not panic");
+    assert!(client.same_session(&PmixClient::new()));
+}
+
+/// Building `InitOptions` with external progress does not require a DVM.
+#[test]
+fn init_options_external_progress_builds() {
+    let mut opts = InitOptions::new();
+    opts.external_progress(true);
+    let info = opts.build();
+    assert_eq!(info.len(), 1, "external_progress must emit one Info entry");
+    unsafe {
+        let ent = &*info.as_ptr();
+        let key = std::ffi::CStr::from_ptr(ent.key.as_ptr());
+        eprintln!(
+            "external_progress info: key={:?} type={} flag={}",
+            key, ent.value.type_, ent.value.data.flag
+        );
+        assert_eq!(key.to_bytes(), b"pmix.evext");
+        // PMIX_BOOL is type tag 1 in OpenPMIx.
+        assert_eq!(ent.value.type_, 1);
+        assert_ne!(ent.value.data.flag as u8, 0, "flag must be true");
+    }
+    drop(info);
+}
+
+#[test]
+fn pmix_client_is_clone_send_sync() {
+    fn assert_clone_send_sync<T: Clone + Send + Sync>() {}
+    assert_clone_send_sync::<PmixClient>();
+}
+
+/// Documents session SM used by MT tests: second connect on Live → ErrExists.
+#[test]
+fn connect_new_err_exists_when_already_live_is_documented() {
+    let client = PmixClient::new();
+    match client.connect(None) {
+        Ok(()) => {
+            let err = client.connect(None).expect_err("second connect");
+            assert_eq!(err, PmixError::ErrExists);
+            let _ = client.disconnect(None);
+        }
+        Err(_) => {
+            // No DVM — expected in standalone `cargo test`.
+        }
+    }
+}
+
+// ─── Goal (1): N threads, concurrent put + fence ────────────────────────────
+
+/// Clone `PmixClient` onto N workers; each puts a distinct key. The main
+/// thread then `commit` + `fence` once and verifies every key.
+#[test]
+#[ignore = "requires DVM-launched process (prterun) — issue #54 goal (1)"]
+fn mt_concurrent_put_and_fence() {
+    assert!(
+        is_dvm_launched(),
+        "mt_concurrent_put_and_fence must be launched by prterun"
+    );
+
+    let client = ensure_client_internal();
+    assert!(
+        client.is_live(),
+        "session must be Live after ensure_pmix_init"
+    );
+    let proc = client.require_proc();
+
+    const N: usize = 8;
+    let barrier = Arc::new(Barrier::new(N));
+    let errors = Arc::new(Mutex::new(Vec::<String>::new()));
+    let mut handles = Vec::with_capacity(N);
+
+    for i in 0..N {
+        let worker = client.clone();
+        let barrier = Arc::clone(&barrier);
+        let errors = Arc::clone(&errors);
+        handles.push(thread::spawn(move || {
+            assert!(worker.is_live(), "cloned client must observe Live session");
+            let _rank = worker.require_rank();
+
+            let key = format!("pmix.rs.mt.put.{i}");
+            let val = format!("worker-{i}");
+            // Align before put so the KVS writes race under load.
+            barrier.wait();
+            if let Err(e) = put_string_key(&key, &val) {
+                errors.lock().expect("errors mutex").push(e);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("worker must not panic");
+    }
+
+    {
+        let errs = errors.lock().expect("errors mutex");
+        assert!(
+            errs.is_empty(),
+            "concurrent put errors: {}",
+            errs.join("; ")
+        );
+    }
+
+    pmix::commit().unwrap_or_else(|e| panic!("commit after concurrent puts: {e:?}"));
+    pmix::fence(&proc, None).unwrap_or_else(|e| panic!("fence after concurrent puts: {e:?}"));
+
+    for i in 0..N {
+        let key = CString::new(format!("pmix.rs.mt.put.{i}")).unwrap();
+        let got = pmix::get_value(&proc, key.to_bytes_with_nul(), None);
+        assert!(
+            got.is_ok(),
+            "get pmix.rs.mt.put.{i} after concurrent put/fence: {got:?}"
+        );
+    }
+}
+
+// ─── Goal (3): external_progress + host progress thread ─────────────────────
+
+/// Host-driven progress: connect with `external_progress(true)`, run a
+/// progress loop on a dedicated thread, workers put concurrently, main thread
+/// commit/fence while progress runs.
+///
+/// **Must run in its own process** — `InitOptions` apply only on the first
+/// process-wide connect. The THREADING harness isolates this test.
+#[test]
+#[ignore = "requires DVM-launched process (prterun) — issue #54 goal (3); run alone"]
+fn mt_external_progress_host_thread() {
+    assert!(
+        is_dvm_launched(),
+        "mt_external_progress_host_thread must be launched by prterun"
+    );
+
+    let probe = PmixClient::new();
+    if probe.is_live() {
+        panic!(
+            "process-wide PmixClient already Live; run this test in its own \
+             cargo test process (see scripts/run_daemon_tests.sh THREADING)"
+        );
+    }
+
+    // Host progress before connect (external_progress has no internal thread).
+    //
+    // Important: `PMIx_Progress` may block inside libevent, so a stop flag is
+    // not enough to make `JoinHandle::join` return promptly. We therefore
+    // *detach* the progress thread and tear the session down via explicit
+    // disconnect + atexit safety net (same process-exit model as
+    // `daemon_helper::ensure_pmix_init`).
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_progress = Arc::clone(&stop);
+    thread::Builder::new()
+        .name("pmix-host-progress".into())
+        .spawn(move || {
+            while !stop_progress.load(Ordering::Acquire) {
+                pmix::progress();
+                thread::sleep(Duration::from_millis(1));
+            }
+            // Best-effort drain; may block — thread is detached at process exit.
+            for _ in 0..16 {
+                pmix::progress();
+            }
+        })
+        .expect("spawn host progress thread");
+
+    let mut opts = InitOptions::new();
+    opts.external_progress(true);
+    let info = opts.build();
+
+    let client = PmixClient::connect_new(Some(info))
+        .expect("connect_new with external_progress must succeed under prterun");
+    assert!(client.is_live());
+    {
+        use std::sync::Once;
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            extern "C" fn finalize_at_exit() {
+                let _ = pmix::finalize(None);
+            }
+            unsafe {
+                libc::atexit(finalize_at_exit);
+            }
+        });
+    }
+
+    const N: usize = 4;
+    let barrier = Arc::new(Barrier::new(N));
+    let errors = Arc::new(Mutex::new(Vec::<String>::new()));
+    let mut handles = Vec::with_capacity(N);
+
+    for i in 0..N {
+        let worker = client.clone();
+        let barrier = Arc::clone(&barrier);
+        let errors = Arc::clone(&errors);
+        handles.push(thread::spawn(move || {
+            assert!(worker.is_live());
+            barrier.wait();
+            let key = format!("pmix.rs.mt.ext.{i}");
+            if let Err(e) = put_string_key(&key, &format!("ext-{i}")) {
+                errors.lock().expect("errors").push(e);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("worker must not panic");
+    }
+
+    {
+        let errs = errors.lock().expect("errors");
+        assert!(
+            errs.is_empty(),
+            "external_progress put errors: {}",
+            errs.join("; ")
+        );
+    }
+
+    let proc = client.require_proc();
+    pmix::commit().unwrap_or_else(|e| panic!("commit (external progress): {e:?}"));
+    pmix::fence(&proc, None).unwrap_or_else(|e| panic!("fence (external progress): {e:?}"));
+
+    for i in 0..N {
+        let key = CString::new(format!("pmix.rs.mt.ext.{i}")).unwrap();
+        let got = pmix::get_value(&proc, key.to_bytes_with_nul(), None);
+        assert!(
+            got.is_ok(),
+            "get pmix.rs.mt.ext.{i} under external progress: {got:?}"
+        );
+    }
+
+    // Signal progress to wind down; do not join (Progress may block).
+    stop.store(true, Ordering::Release);
+
+    // Disconnect while the progress thread may still be runnable — try with a
+    // short timeout so a stuck finalize cannot hang the harness.
+    let client2 = client.clone();
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let r = client2.disconnect(None);
+        let _ = tx.send(r);
+    });
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => eprintln!("disconnect error (non-fatal): {e:?}"),
+        Err(_) => {
+            eprintln!(
+                "disconnect timed out under external_progress — atexit finalize \
+                 will clean up; concurrent put/fence/get already verified"
+            );
+        }
+    }
+}
+
+// ─── Goal (2): concurrent _nb completions ───────────────────────────────────
+
+struct CountingFenceCb {
+    done: Arc<AtomicUsize>,
+    ok: Arc<AtomicUsize>,
+}
+
+impl FenceCallback for CountingFenceCb {
+    fn on_complete(self: Box<Self>, status: PmixStatus) {
+        if status.is_success() {
+            self.ok.fetch_add(1, Ordering::Release);
+        }
+        self.done.fetch_add(1, Ordering::Release);
+    }
+}
+
+/// Submit several `fence_nb` ops; wait for all completions (internal progress).
+#[test]
+#[ignore = "requires DVM-launched process (prterun) — issue #54 goal (2)"]
+fn mt_concurrent_fence_nb_completions() {
+    assert!(
+        is_dvm_launched(),
+        "mt_concurrent_fence_nb_completions must be launched by prterun"
+    );
+
+    let client = ensure_client_internal();
+    let proc = client.require_proc();
+
+    const N: usize = 4;
+    let done = Arc::new(AtomicUsize::new(0));
+    let ok = Arc::new(AtomicUsize::new(0));
+
+    for _ in 0..N {
+        let cb = Box::new(CountingFenceCb {
+            done: Arc::clone(&done),
+            ok: Arc::clone(&ok),
+        });
+        fence_nb(std::slice::from_ref(&proc), None, cb)
+            .unwrap_or_else(|e| panic!("fence_nb submit: {e:?}"));
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while done.load(Ordering::Acquire) < N {
+        if Instant::now() > deadline {
+            panic!(
+                "timed out waiting for fence_nb completions: {}/{N}",
+                done.load(Ordering::Acquire)
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    assert_eq!(done.load(Ordering::Acquire), N);
+    assert_eq!(
+        ok.load(Ordering::Acquire),
+        N,
+        "all fence_nb completions should be success"
+    );
+}
+
+// ─── Goal (4): callback must-not-block regression ───────────────────────────
+
+/// Callback parks on the progress path — models THREADING.md §6.1 deadlock class.
+struct BlockingFenceCb {
+    pair: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl FenceCallback for BlockingFenceCb {
+    fn on_complete(self: Box<Self>, _status: PmixStatus) {
+        let (lock, cvar) = &*self.pair;
+        let guard = lock.lock().expect("mutex");
+        // Wait up to 3s for a flag that nobody sets — holds the progress
+        // thread if the callback runs there.
+        let _ = cvar
+            .wait_timeout(guard, Duration::from_secs(3))
+            .expect("condvar");
+    }
+}
+
+/// Regression: progress-thread blocking is detected with a wall-clock timeout
+/// on a follow-up op, rather than hanging the suite forever.
+#[test]
+#[ignore = "requires DVM-launched process (prterun) — issue #54 goal (4)"]
+fn callback_must_not_block_progress_timeout() {
+    assert!(
+        is_dvm_launched(),
+        "callback_must_not_block_progress_timeout must be launched by prterun"
+    );
+
+    let client = ensure_client_internal();
+    let proc = client.require_proc();
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let cb = Box::new(BlockingFenceCb {
+        pair: Arc::clone(&pair),
+    });
+
+    fence_nb(std::slice::from_ref(&proc), None, cb)
+        .unwrap_or_else(|e| panic!("fence_nb submit: {e:?}"));
+
+    let client2 = client.clone();
+    let proc2 = proc.clone();
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let _ = client2.is_live();
+        let r = pmix::fence(&proc2, None);
+        let _ = tx.send(r);
+    });
+
+    match rx.recv_timeout(Duration::from_secs(8)) {
+        Ok(fence_result) => {
+            // Completed (in-place nb, or block finished). Must not hang.
+            match fence_result {
+                Ok(()) => {}
+                Err(e) => {
+                    eprintln!("secondary fence returned error (non-fatal for timeout test): {e:?}");
+                }
+            }
+        }
+        Err(_) => {
+            eprintln!(
+                "callback_must_not_block_progress_timeout: secondary fence \
+                 timed out (expected when a progress callback blocks) — OK"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `tests/threading_mt_via_prterun.rs` covering issue #54 goals (1)–(4) with **process-wide** `PmixClient` (no bare `Context`, no per-thread init).
- Wires `./scripts/run_daemon_tests.sh THREADING` (build once, run each ignored case under its own `prterun -np 1`).
- Documents how to run in `THREADING.md` + `README.md`.
- Companion example: `examples/external_progress_mt.rs`.
- **Bugfix:** `InfoBuilder` now encodes `PMIX_BOOL` attributes (`pmix.evext`, etc.) as real `u8` flags instead of the C strings `"1"`/`"0"`, so `InitOptions::external_progress(true)` is actually honored by OpenPMIx.

## Test plan
- [x] `cargo test --test threading_mt_via_prterun -- --test-threads=1` (standalone)
- [x] `./scripts/run_daemon_tests.sh THREADING` under PRTE 4.1 + OpenPMIx 6.1
- [x] All four DVM cases pass: put/fence, fence_nb, callback timeout, external_progress
- [x] `cargo test --lib test_infobuilder_ -- --test-threads=1`

Closes #54