### PR TITLE
fix(threading): audit callback registries for lock-across-user-code (#67)

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -123,7 +123,9 @@ Worked example: `examples/server_upcall_hop.rs` (issue #52).
 5. Progress must run.  
 6. cbdata: `crate::cbdata::encode_req_id` / `decode_req_id`.  
 7. Bridges never hold a registry `Mutex` across user callback execution
-   (regression-tested in `events`).
+   (regression-tested in `events` / `groups`; full inventory in §9).
+   Prefer `threading::invoke_user_callback` so user panics cannot unwind
+   into OpenPMIx.
 
 ### 6.1 Forbidden on the progress thread (concrete)
 
@@ -188,8 +190,53 @@ process. Companion example: `examples/external_progress_mt.rs`.
 | Remove Context/init | #69 | Done |
 | Server/tool sessions | #49 | Done |
 | C-owned !Send + assert matrix | #50 | Done (`threading_assert.rs`) |
-| Callback hop / audit | #51, #67 | #51 Done (`threading` module + events registry); #67 Open |
+| Callback hop / audit | #51, #67 | Done (`threading` helpers + #67 registry audit checklist §9) |
 | Server upcall example | #52 | Done (`PmixServerModule` docs + `server_upcall_hop` example) |
 | Global FFI mutex | #53 | Deferred |
 | MT integration tests | #54 | Done (`tests/threading_mt_via_prterun.rs` + `run_daemon_tests.sh THREADING`) |
 | Extra static_assertions | #66 | Mostly superseded by #50 |
+
+---
+
+## 9. Callback registry audit checklist (#67)
+
+Policy (`src/threading.rs`): bridges **never** hold a registry `Mutex` across
+user callback execution; one-shot completions encode cbdata with
+`cbdata::encode_req_id` / `decode_req_id` (not a raw `Box` pointer); user
+panics are **contained** at the `extern "C"` boundary via
+`threading::invoke_user_callback` (events also complete the OpenPMIx chain).
+
+| Module | Bridges / registries | Lock scope | cbdata | Panic contain |
+|--------|----------------------|------------|--------|---------------|
+| `data_ops` | publish / get / lookup / unpublish / fence | remove under lock, invoke after | `encode_req_id` | `invoke_user_callback` |
+| `events` | `HANDLER_REGISTRY`, `notification_bridge`, reg bridge | copy/`remove` under lock | handler ref id / `Box` reg state only for nb reg | `catch_unwind` + chain `cbfunc` |
+| `query_log` | query / log | remove → invoke | `encode_req_id` | `invoke_user_callback` |
+| `security` | credential / validation | remove → invoke | `encode_req_id` | `invoke_user_callback` |
+| `allocation` | allocation / job_ctrl / session_ctrl | remove → invoke | `encode_req_id` | `invoke_user_callback` |
+| `monitoring` | monitor | remove → `drop` → invoke | `encode_req_id_u64` | `invoke_user_callback` |
+| `groups` | construct / invite / join / leave / destruct | remove → invoke | `encode_req_id` (migrated off `Box` cbdata) | `invoke_user_callback` |
+| `process_mgmt` | spawn / connect / disconnect `_nb` | remove → invoke | `encode_req_id` (migrated off `Box` cbdata) | `invoke_user_callback` |
+| `server` | nspace/client/dmodex/setup/iof/inventory | remove → invoke | `encode_req_id` | `invoke_user_callback` |
+| `server/data` | fence/connect/disconnect `_nb` | remove → invoke | `encode_req_id` (migrated off `Box` cbdata) | `invoke_user_callback` |
+| `server/pset` | register/deregister resources | remove → invoke | `encode_req_id` | `invoke_user_callback` |
+| `utility` IOF | `IOF_REGISTRY` + pull/dereg/push | lock released before user IO/reg/dereg/push cbs | pull: C handle + context ptr (long-lived); dereg/push one-shot `Box` ctx | `invoke_user_callback` |
+
+**Exceptions (documented, not hold-across-user-code):**
+
+- **Events nb registration** parks `HandlerRegState` via `Box` in C `cbdata`
+  until the registration completion delivers a ref id (then registry insert).
+- **IOF pull** is long-lived: the IO callback is keyed by the C handle in
+  `IOF_REGISTRY`; the registration `cbdata` is the context pointer. One-shot
+  dereg/push completions still use a boxed context pointer today (no registry
+  mutex held across the user call).
+
+**Regression tests:**
+
+- `events::test_notification_bridge_no_lock_across_user_code`
+- `events::test_notification_bridge_user_panic_completes_chain_and_is_contained`
+- `groups::test_group_leave_bridge_no_lock_across_user_code`
+- `groups::test_group_leave_bridge_contains_user_panic`
+- `threading::invoke_user_callback_contains_panic`
+
+No known hold-across-user-code sites remain after this audit.
+

--- a/THREADING.md
+++ b/THREADING.md
@@ -232,7 +232,7 @@ panics are **contained** at the `extern "C"` boundary via
 
 **Regression tests:**
 
-- `events::test_notification_bridge_no_lock_across_user_code`
+- `events::test_event_handler_lock_not_held_during_user_callback`
 - `events::test_notification_bridge_user_panic_completes_chain_and_is_contained`
 - `groups::test_group_leave_bridge_no_lock_across_user_code`
 - `groups::test_group_leave_bridge_contains_user_panic`

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -54,6 +54,7 @@ use std::sync::Mutex;
 use std::sync::LazyLock;
 
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::cbdata::{decode_req_id, encode_req_id};
 use crate::{Info, PmixStatus, Proc};
 
@@ -344,7 +345,9 @@ extern "C" fn allocation_callback_bridge(
     
             _not_thread_safe: std::marker::PhantomData,
         };
-    cb.on_complete(pmix_status, results);
+    let _ = invoke_user_callback("allocation", move || {
+            cb.on_complete(pmix_status, results);
+    });
     // release_fn is unused — we manage our own memory via AllocationResults Drop.
     let _ = release_fn;
 }
@@ -718,7 +721,9 @@ extern "C" fn job_control_callback_bridge(
     
             _not_thread_safe: std::marker::PhantomData,
         };
-    cb.on_complete(pmix_status, results);
+    let _ = invoke_user_callback("allocation", move || {
+            cb.on_complete(pmix_status, results);
+    });
     // release_fn is unused — we manage our own memory via JobControlResults Drop.
     let _ = release_fn;
 }
@@ -910,7 +915,9 @@ extern "C" fn session_control_callback_bridge(
     
             _not_thread_safe: std::marker::PhantomData,
         };
-    cb.on_complete(pmix_status, results);
+    let _ = invoke_user_callback("allocation", move || {
+            cb.on_complete(pmix_status, results);
+    });
     let _ = release_fn;
 }
 

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -11,6 +11,7 @@
 //!    conversion is explicit and portable.
 
 use std::os::raw::c_void;
+use std::sync::Mutex;
 
 /// Encode a non-zero request ID as opaque cbdata for a PMIx C callback.
 ///
@@ -18,7 +19,10 @@ use std::os::raw::c_void;
 /// Debug builds panic if `req_id == 0` (would become a null pointer).
 #[inline]
 pub fn encode_req_id(req_id: usize) -> *mut c_void {
-    debug_assert!(req_id != 0, "request id must be non-zero to avoid null cbdata");
+    debug_assert!(
+        req_id != 0,
+        "request id must be non-zero to avoid null cbdata"
+    );
     std::ptr::with_exposed_provenance_mut::<c_void>(req_id)
 }
 
@@ -31,7 +35,10 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
 /// Encode a `u64` request ID (used by some monitoring paths).
 #[inline]
 pub fn encode_req_id_u64(req_id: u64) -> *mut c_void {
-    debug_assert!(req_id != 0, "request id must be non-zero to avoid null cbdata");
+    debug_assert!(
+        req_id != 0,
+        "request id must be non-zero to avoid null cbdata"
+    );
     std::ptr::with_exposed_provenance_mut::<c_void>(req_id as usize)
 }
 
@@ -39,6 +46,17 @@ pub fn encode_req_id_u64(req_id: u64) -> *mut c_void {
 #[inline]
 pub fn decode_req_id_u64(cbdata: *mut c_void) -> u64 {
     cbdata.addr() as u64
+}
+
+/// Allocate the next non-zero request ID from a per-registry sequence counter.
+///
+/// Starts at 1 (never returns 0 / null cbdata). Saturates rather than wrapping
+/// so a pathological overflow cannot produce a null id.
+#[inline]
+pub fn next_req_id(seq: &Mutex<usize>) -> usize {
+    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
+    *g = g.saturating_add(1).max(1);
+    *g
 }
 
 #[cfg(test)]
@@ -57,5 +75,13 @@ mod tests {
     #[test]
     fn never_null_for_nonzero() {
         assert!(!encode_req_id(1).is_null());
+    }
+
+    #[test]
+    fn next_req_id_starts_at_one_and_increments() {
+        let seq = Mutex::new(0);
+        assert_eq!(next_req_id(&seq), 1);
+        assert_eq!(next_req_id(&seq), 2);
+        assert_eq!(next_req_id(&seq), 3);
     }
 }

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -13,6 +13,7 @@ use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, free_value};
 
 #[cfg(any(test, feature = "mock_ffi"))]
@@ -114,7 +115,9 @@ extern "C" fn publish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("data_ops", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Non-blocking publish of data for later lookup.
@@ -268,7 +271,9 @@ extern "C" fn get_value_callback_bridge(
     };
 
     // Invoke the user's Rust callback.
-    cb.on_result(pmix_status, value);
+    let _ = invoke_user_callback("data_ops", move || {
+        cb.on_result(pmix_status, value);
+    });
 }
 
 /// Non-blocking retrieval of a key-value attribute.
@@ -767,7 +772,9 @@ extern "C" fn lookup_callback_bridge(
         Vec::new()
     };
 
-    cb.on_result(pmix_status, results);
+    let _ = invoke_user_callback("data_ops", move || {
+        cb.on_result(pmix_status, results);
+    });
 }
 
 /// Non-blocking lookup of published data.
@@ -937,7 +944,9 @@ extern "C" fn unpublish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("data_ops", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Unpublish data posted by this process using the given keys.
@@ -1280,7 +1289,9 @@ extern "C" fn fence_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_v
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("data_ops", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Non-blocking fence / barrier across a group of processes.

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -6,17 +6,76 @@
 //! This module provides safe Rust wrappers around the PMIx group
 //! management APIs.
 
+use crate::cbdata::{decode_req_id, encode_req_id};
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
+use std::sync::{LazyLock, Mutex};
 
 /// Re-export of the PMIx group accept/decline option enum.
 ///
 /// Used by `group_join` and `group_join_nb` to specify whether
 /// to accept or decline a group invitation.
 pub use ffi::pmix_group_opt_t;
+
+
+// ── One-shot completion registries (issue #67) ───────────────────────────────
+//
+// Bridges never pass a `Box` pointer as cbdata. Request IDs are encoded with
+// `encode_req_id`; the bridge does `lock → remove → unlock → invoke_user_callback`.
+
+static GROUP_CONSTRUCT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static GROUP_CONSTRUCT_REGISTRY: LazyLock<
+    Mutex<HashMap<usize, GroupConstructCallbackWrapper>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static GROUP_INVITE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static GROUP_INVITE_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupInviteCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static GROUP_JOIN_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static GROUP_JOIN_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupJoinCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static GROUP_LEAVE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static GROUP_LEAVE_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupLeaveCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static GROUP_DESTRUCT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static GROUP_DESTRUCT_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupDestructCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn next_req_id(seq: &Mutex<usize>) -> usize {
+    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
+    *g = g.saturating_add(1).max(1);
+    *g
+}
+
+fn info_results_from_c(status: PmixStatus, info: *mut ffi::pmix_info_t, ninfo: usize) -> Vec<Info> {
+    if !status.is_success() || info.is_null() || ninfo == 0 {
+        return Vec::new();
+    }
+    // SAFETY: PMIx handed us a valid pmix_info_t array of length ninfo for the
+    // duration of the completion callback. We wrap each entry without taking
+    // free ownership of the whole array (same model as the previous Box-cbdata
+    // bridges in this module).
+    let mut vec = Vec::with_capacity(ninfo);
+    unsafe {
+        for i in 0..ninfo {
+            vec.push(Info {
+                handle: info.add(i),
+                len: 1,
+                _not_thread_safe: std::marker::PhantomData,
+            });
+        }
+    }
+    vec
+}
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_Group_construct
@@ -137,11 +196,11 @@ impl GroupConstructCallbackWrapper {
 // PMIx_Group_construct_nb
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// FFI callback bridge for non-blocking group construct.
+/// FFI callback bridge for non-blocking group completion (`pmix_info_cbfunc_t`).
 ///
 /// # Safety
-/// `cbdata` must be a valid pointer to a `GroupConstructCallbackWrapper`
-/// created by `Box::into_raw`. This function consumes the box.
+/// `cbdata` is an opaque request ID from [`encode_req_id`]. OpenPMIx invokes
+/// this from the progress thread exactly once per accepted request.
 pub unsafe extern "C" fn group_construct_callback_bridge(
     status: i32,
     info: *mut ffi::pmix_info_t,
@@ -150,30 +209,22 @@ pub unsafe extern "C" fn group_construct_callback_bridge(
     _release_fn: Option<unsafe extern "C" fn(*mut c_void)>,
     _release_cbdata: *mut c_void,
 ) {
-    unsafe {
-        let cb_wrapper = Box::from_raw(cbdata as *mut GroupConstructCallbackWrapper);
-        let pmix_status = PmixStatus::from_raw(status);
-
-        let rust_results: Vec<Info> = if pmix_status.is_success() {
-            if info.is_null() || ninfo == 0 {
-                Vec::new()
-            } else {
-                let mut vec = Vec::with_capacity(ninfo);
-                for i in 0..ninfo {
-                    vec.push(Info {
-                        handle: info.add(i),
-                        len: 1,
-                    _not_thread_safe: std::marker::PhantomData,
-                    });
-                }
-                vec
-            }
-        } else {
-            Vec::new()
-        };
-
-        (cb_wrapper.callback)(pmix_status, rust_results);
+    if cbdata.is_null() {
+        return;
     }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let rust_results = info_results_from_c(pmix_status, info, ninfo);
+    let _ = invoke_user_callback("groups", move || {
+        (cb_wrapper.callback)(pmix_status, rust_results);
+    });
 }
 
 /// Non-blocking group construct with a Rust closure callback.
@@ -200,7 +251,13 @@ pub fn group_construct_nb(
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
 
-    let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(callback));
+    let req_id = next_req_id(&GROUP_CONSTRUCT_SEQ);
+    {
+        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
+    }
+    let cbdata = encode_req_id(req_id);
+
 
     let procs_ptr = unsafe {
         std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
@@ -225,7 +282,7 @@ pub fn group_construct_nb(
             info_ptr,
             ninfo,
             Some(group_construct_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -233,7 +290,8 @@ pub fn group_construct_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -344,11 +402,11 @@ impl GroupInviteCallbackWrapper {
     }
 }
 
-/// FFI callback bridge for non-blocking group invite.
+/// FFI callback bridge for non-blocking group completion (`pmix_info_cbfunc_t`).
 ///
 /// # Safety
-/// `cbdata` must be a valid pointer to a `GroupInviteCallbackWrapper`
-/// created by `Box::into_raw`. This function consumes the box.
+/// `cbdata` is an opaque request ID from [`encode_req_id`]. OpenPMIx invokes
+/// this from the progress thread exactly once per accepted request.
 pub unsafe extern "C" fn group_invite_callback_bridge(
     status: i32,
     info: *mut ffi::pmix_info_t,
@@ -357,30 +415,22 @@ pub unsafe extern "C" fn group_invite_callback_bridge(
     _release_fn: Option<unsafe extern "C" fn(*mut c_void)>,
     _release_cbdata: *mut c_void,
 ) {
-    unsafe {
-        let cb_wrapper = Box::from_raw(cbdata as *mut GroupInviteCallbackWrapper);
-        let pmix_status = PmixStatus::from_raw(status);
-
-        let rust_results: Vec<Info> = if pmix_status.is_success() {
-            if info.is_null() || ninfo == 0 {
-                Vec::new()
-            } else {
-                let mut vec = Vec::with_capacity(ninfo);
-                for i in 0..ninfo {
-                    vec.push(Info {
-                        handle: info.add(i),
-                        len: 1,
-                    _not_thread_safe: std::marker::PhantomData,
-                    });
-                }
-                vec
-            }
-        } else {
-            Vec::new()
-        };
-
-        (cb_wrapper.callback)(pmix_status, rust_results);
+    if cbdata.is_null() {
+        return;
     }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let rust_results = info_results_from_c(pmix_status, info, ninfo);
+    let _ = invoke_user_callback("groups", move || {
+        (cb_wrapper.callback)(pmix_status, rust_results);
+    });
 }
 
 /// Non-blocking invite with a Rust closure callback.
@@ -406,7 +456,13 @@ pub fn group_invite_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let cb_box: *mut GroupInviteCallbackWrapper = Box::into_raw(Box::new(callback));
+    let req_id = next_req_id(&GROUP_INVITE_SEQ);
+    {
+        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
+    }
+    let cbdata = encode_req_id(req_id);
+
 
     let procs_ptr = unsafe {
         std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
@@ -431,7 +487,7 @@ pub fn group_invite_nb(
             info_ptr,
             ninfo,
             Some(group_invite_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -439,7 +495,8 @@ pub fn group_invite_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -552,11 +609,11 @@ impl GroupJoinCallbackWrapper {
     }
 }
 
-/// FFI callback bridge for non-blocking group join.
+/// FFI callback bridge for non-blocking group completion (`pmix_info_cbfunc_t`).
 ///
 /// # Safety
-/// `cbdata` must be a valid pointer to a `GroupJoinCallbackWrapper`
-/// created by `Box::into_raw`. This function consumes the box.
+/// `cbdata` is an opaque request ID from [`encode_req_id`]. OpenPMIx invokes
+/// this from the progress thread exactly once per accepted request.
 pub unsafe extern "C" fn group_join_callback_bridge(
     status: i32,
     info: *mut ffi::pmix_info_t,
@@ -565,30 +622,22 @@ pub unsafe extern "C" fn group_join_callback_bridge(
     _release_fn: Option<unsafe extern "C" fn(*mut c_void)>,
     _release_cbdata: *mut c_void,
 ) {
-    unsafe {
-        let cb_wrapper = Box::from_raw(cbdata as *mut GroupJoinCallbackWrapper);
-        let pmix_status = PmixStatus::from_raw(status);
-
-        let rust_results: Vec<Info> = if pmix_status.is_success() {
-            if info.is_null() || ninfo == 0 {
-                Vec::new()
-            } else {
-                let mut vec = Vec::with_capacity(ninfo);
-                for i in 0..ninfo {
-                    vec.push(Info {
-                        handle: info.add(i),
-                        len: 1,
-                    _not_thread_safe: std::marker::PhantomData,
-                    });
-                }
-                vec
-            }
-        } else {
-            Vec::new()
-        };
-
-        (cb_wrapper.callback)(pmix_status, rust_results);
+    if cbdata.is_null() {
+        return;
     }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let rust_results = info_results_from_c(pmix_status, info, ninfo);
+    let _ = invoke_user_callback("groups", move || {
+        (cb_wrapper.callback)(pmix_status, rust_results);
+    });
 }
 
 /// Non-blocking join with a Rust closure callback.
@@ -613,7 +662,13 @@ pub fn group_join_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let cb_box: *mut GroupJoinCallbackWrapper = Box::into_raw(Box::new(callback));
+    let req_id = next_req_id(&GROUP_JOIN_SEQ);
+    {
+        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
+    }
+    let cbdata = encode_req_id(req_id);
+
     let leader_ptr = std::ptr::addr_of!(leader.handle) as *const ffi::pmix_proc_t;
 
     let (info_ptr, ninfo) = if info.is_empty() {
@@ -635,7 +690,7 @@ pub fn group_join_nb(
             info_ptr,
             ninfo,
             Some(group_join_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -643,7 +698,8 @@ pub fn group_join_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -711,13 +767,22 @@ impl GroupLeaveCallbackWrapper {
 ///
 /// # Safety
 /// `cbdata` must be a valid pointer to a `GroupLeaveCallbackWrapper`
-/// created by `Box::into_raw`. This function consumes the box.
 pub unsafe extern "C" fn group_leave_callback_bridge(status: i32, cbdata: *mut c_void) {
-    unsafe {
-        let cb_wrapper = Box::from_raw(cbdata as *mut GroupLeaveCallbackWrapper);
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
+    if cbdata.is_null() {
+        return;
     }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("groups", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
 }
 
 /// Non-blocking leave with a Rust closure callback.
@@ -738,7 +803,13 @@ pub fn group_leave_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let cb_box: *mut GroupLeaveCallbackWrapper = Box::into_raw(Box::new(callback));
+    let req_id = next_req_id(&GROUP_LEAVE_SEQ);
+    {
+        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
+    }
+    let cbdata = encode_req_id(req_id);
+
 
     let (info_ptr, ninfo) = if info.is_empty() {
         (ptr::null(), 0)
@@ -757,7 +828,7 @@ pub fn group_leave_nb(
             info_ptr,
             ninfo,
             Some(group_leave_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -765,7 +836,8 @@ pub fn group_leave_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -833,13 +905,22 @@ impl GroupDestructCallbackWrapper {
 ///
 /// # Safety
 /// `cbdata` must be a valid pointer to a `GroupDestructCallbackWrapper`
-/// created by `Box::into_raw`. This function consumes the box.
 pub unsafe extern "C" fn group_destruct_callback_bridge(status: i32, cbdata: *mut c_void) {
-    unsafe {
-        let cb_wrapper = Box::from_raw(cbdata as *mut GroupDestructCallbackWrapper);
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
+    if cbdata.is_null() {
+        return;
     }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("groups", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
 }
 
 /// Non-blocking destruct with a Rust closure callback.
@@ -860,7 +941,13 @@ pub fn group_destruct_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(callback));
+    let req_id = next_req_id(&GROUP_DESTRUCT_SEQ);
+    {
+        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
+    }
+    let cbdata = encode_req_id(req_id);
+
 
     let (info_ptr, ninfo) = if info.is_empty() {
         (ptr::null(), 0)
@@ -879,7 +966,7 @@ pub fn group_destruct_nb(
             info_ptr,
             ninfo,
             Some(group_destruct_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -887,7 +974,8 @@ pub fn group_destruct_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -1035,14 +1123,19 @@ mod tests {
                 called_clone.store(true, Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900001usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         // Invoke the bridge directly with success status
         unsafe {
             group_construct_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1070,13 +1163,18 @@ mod tests {
                 status_clone.store(status.to_raw(), Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900002usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_construct_callback_bridge(
                 ffi::PMIX_ERR_NOT_SUPPORTED,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1186,13 +1284,18 @@ mod tests {
                 called_clone.store(true, Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupInviteCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900003usize;
+        {
+            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_invite_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1315,13 +1418,18 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupJoinCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900004usize;
+        {
+            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_join_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1401,11 +1509,16 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupLeaveCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900005usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_leave_callback_bridge(
                 0, // PMIX_SUCCESS
-                cb_box as *mut c_void,
+                cbdata,
             );
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -1423,9 +1536,14 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupLeaveCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900006usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_leave_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cb_box as *mut c_void);
+            group_leave_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(called.load(Ordering::SeqCst));
@@ -1502,11 +1620,16 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900007usize;
+        {
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_destruct_callback_bridge(
                 0, // PMIX_SUCCESS
-                cb_box as *mut c_void,
+                cbdata,
             );
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -1524,9 +1647,14 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900008usize;
+        {
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_destruct_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cb_box as *mut c_void);
+            group_destruct_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(called.load(Ordering::SeqCst));
@@ -1683,13 +1811,18 @@ mod tests {
                 info_clone.store(info.len(), Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900009usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_construct_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1712,13 +1845,18 @@ mod tests {
                 called_clone.store(true, Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900010usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_construct_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1742,13 +1880,18 @@ mod tests {
                 status_clone.store(status.to_raw(), Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupConstructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900011usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_construct_callback_bridge(
                 ffi::PMIX_ERR_INIT,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1784,13 +1927,18 @@ mod tests {
                 called_clone.store(true, Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupInviteCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900012usize;
+        {
+            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_invite_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1814,13 +1962,18 @@ mod tests {
                 status_clone.store(status.to_raw(), Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupInviteCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900013usize;
+        {
+            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_invite_callback_bridge(
                 ffi::PMIX_ERR_NOT_SUPPORTED,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1857,13 +2010,18 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupJoinCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900014usize;
+        {
+            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_join_callback_bridge(
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1886,13 +2044,18 @@ mod tests {
             status_clone.store(status.to_raw(), Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupJoinCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900015usize;
+        {
+            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_join_callback_bridge(
                 ffi::PMIX_ERR_NOT_SUPPORTED,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -1942,9 +2105,14 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupLeaveCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900016usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_leave_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cb_box as *mut c_void);
+            group_leave_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(called.load(Ordering::SeqCst));
@@ -1963,9 +2131,14 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900017usize;
+        {
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_destruct_callback_bridge(0, cb_box as *mut c_void);
+            group_destruct_callback_bridge(0, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(called.load(Ordering::SeqCst));
@@ -1982,9 +2155,14 @@ mod tests {
             called_clone.store(true, Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900018usize;
+        {
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_destruct_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cb_box as *mut c_void);
+            group_destruct_callback_bridge(ffi::PMIX_ERR_NOT_SUPPORTED, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(called.load(Ordering::SeqCst));
@@ -2202,13 +2380,18 @@ mod tests {
                 status_clone.store(status.to_raw(), Ordering::SeqCst);
             });
 
-        let cb_box: *mut GroupInviteCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900019usize;
+        {
+            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_invite_callback_bridge(
                 ffi::PMIX_ERR_TIMEOUT,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -2227,13 +2410,18 @@ mod tests {
             status_clone.store(status.to_raw(), Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupJoinCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900020usize;
+        {
+            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
             group_join_callback_bridge(
                 ffi::PMIX_ERR_TIMEOUT,
                 std::ptr::null_mut(),
                 0,
-                cb_box as *mut c_void,
+                cbdata,
                 None,
                 std::ptr::null_mut(),
             );
@@ -2252,9 +2440,14 @@ mod tests {
             status_clone.store(status.to_raw(), Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupLeaveCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900021usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_leave_callback_bridge(ffi::PMIX_ERR_TIMEOUT, cb_box as *mut c_void);
+            group_leave_callback_bridge(ffi::PMIX_ERR_TIMEOUT, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert_eq!(status_recv.load(Ordering::SeqCst), ffi::PMIX_ERR_TIMEOUT);
@@ -2270,9 +2463,14 @@ mod tests {
             status_clone.store(status.to_raw(), Ordering::SeqCst);
         });
 
-        let cb_box: *mut GroupDestructCallbackWrapper = Box::into_raw(Box::new(wrapper));
+        let req_id = 900022usize;
+        {
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
         unsafe {
-            group_destruct_callback_bridge(ffi::PMIX_ERR_TIMEOUT, cb_box as *mut c_void);
+            group_destruct_callback_bridge(ffi::PMIX_ERR_TIMEOUT, cbdata);
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert_eq!(status_recv.load(Ordering::SeqCst), ffi::PMIX_ERR_TIMEOUT);
@@ -2343,4 +2541,93 @@ mod tests {
             }
         }
     }
+
+    // ── issue #67: lock / panic bridge hygiene ────────────────────────────────
+
+    #[test]
+    fn test_group_leave_bridge_no_lock_across_user_code() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (enter_tx, enter_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let wrapper = GroupLeaveCallbackWrapper::new(move |_status| {
+            let _ = enter_tx.send(());
+            let _ = release_rx.recv_timeout(Duration::from_secs(5));
+        });
+        let req_id = 424_267usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata_addr = encode_req_id(req_id) as usize;
+
+        let progress = std::thread::spawn(move || unsafe {
+            group_leave_callback_bridge(0, cbdata_addr as *mut std::ffi::c_void);
+        });
+
+        enter_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("user callback should enter");
+        let guard = GROUP_LEAVE_REGISTRY
+            .try_lock()
+            .expect("registry lock must not be held across user callback code");
+        drop(guard);
+
+        let _ = release_tx.send(());
+        progress.join().expect("bridge returns");
+        assert!(
+            GROUP_LEAVE_REGISTRY.lock().unwrap().get(&req_id).is_none(),
+            "one-shot leave callback must be removed before user invoke"
+        );
+    }
+
+    #[test]
+    fn test_group_leave_bridge_contains_user_panic() {
+        let wrapper = GroupLeaveCallbackWrapper::new(move |_status| {
+            panic!("group leave user boom");
+        });
+        let req_id = 424_268usize;
+        {
+            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
+        // Must return normally — panic is contained at the bridge.
+        unsafe {
+            group_leave_callback_bridge(0, cbdata);
+        }
+        assert!(GROUP_LEAVE_REGISTRY.lock().unwrap().get(&req_id).is_none());
+    }
+
+    #[test]
+    fn test_group_construct_bridge_uses_encode_req_id() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static HIT: AtomicBool = AtomicBool::new(false);
+        let wrapper = GroupConstructCallbackWrapper::new(move |status, info| {
+            assert!(status.is_success());
+            assert!(info.is_empty());
+            HIT.store(true, Ordering::SeqCst);
+        });
+        let req_id = 424_269usize;
+        {
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            registry.insert(req_id, wrapper);
+        }
+        let cbdata = encode_req_id(req_id);
+        assert_eq!(decode_req_id(cbdata), req_id);
+        unsafe {
+            group_construct_callback_bridge(
+                0,
+                std::ptr::null_mut(),
+                0,
+                cbdata,
+                None,
+                std::ptr::null_mut(),
+            );
+        }
+        assert!(HIT.load(Ordering::SeqCst));
+    }
 }
+

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -6,7 +6,7 @@
 //! This module provides safe Rust wrappers around the PMIx group
 //! management APIs.
 
-use crate::cbdata::{decode_req_id, encode_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
@@ -48,12 +48,6 @@ static GROUP_LEAVE_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupLeaveCallbackWra
 static GROUP_DESTRUCT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 static GROUP_DESTRUCT_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupDestructCallbackWrapper>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-fn next_req_id(seq: &Mutex<usize>) -> usize {
-    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
-    *g = g.saturating_add(1).max(1);
-    *g
-}
 
 fn info_results_from_c(status: PmixStatus, info: *mut ffi::pmix_info_t, ninfo: usize) -> Vec<Info> {
     if !status.is_success() || info.is_null() || ninfo == 0 {

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -49,6 +49,7 @@ use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::cbdata::{decode_req_id_u64, encode_req_id_u64};
 use crate::{Info, PmixError, PmixStatus};
 
@@ -166,7 +167,9 @@ unsafe extern "C" fn monitor_callback_bridge(
             } else {
                 None
             };
-            cb.on_complete(PmixStatus::from_raw(status), results);
+            let _ = invoke_user_callback("monitoring", move || {
+                    cb.on_complete(PmixStatus::from_raw(status), results);
+            });
         }
         None => {
             // Callback already consumed or never registered — free the info

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -51,7 +51,7 @@
 //! let result = disconnect(&[target], &[disconnect_info]);
 //! ```
 
-use crate::cbdata::{decode_req_id, encode_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
@@ -489,12 +489,6 @@ static DISCONNECT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 static DISCONNECT_REGISTRY: LazyLock<Mutex<HashMap<usize, DisconnectCallbackWrapper>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-fn next_req_id(seq: &Mutex<usize>) -> usize {
-    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
-    *g = g.saturating_add(1).max(1);
-    *g
-}
-
 /// Non-blocking spawn callback wrapper.
 ///
 /// Wraps a Rust closure so it can be called from the C FFI callback.
@@ -834,7 +828,27 @@ extern "C" fn connect_callback_bridge(status: i32, cbdata: *mut c_void) {
     });
 }
 
-/// C bridge for `pmix_spawn_cbfunc_t` — registry lookup, then user invoke.
+/// Non-blocking connect with a Rust closure callback.
+///
+/// Records a set of processes as "connected" without blocking. The
+/// provided callback is invoked when the operation completes.
+///
+/// * The callback receives `PmixStatus`:
+///   - `PMIX_SUCCESS` — all participating processes have connected.
+///   - Error code — the connect operation failed.
+/// * The `callback` closure must be `Send + 'static` because it may
+///   be invoked from a different thread by the PMIx library.
+///
+/// # Returns
+/// * `Ok(())` — the connect request was accepted (async, result in callback).
+/// * `Err(PmixStatus)` — the connect request itself failed synchronously.
+///
+/// # C API
+/// ```c
+/// pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
+///                               const pmix_info_t info[], size_t ninfo,
+///                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+/// ```
 pub fn connect_nb(
     procs: &[Proc],
     info: &[Info],
@@ -1025,6 +1039,24 @@ impl DisconnectCallbackWrapper {
 // PMIx_Disconnect_nb
 // ─────────────────────────────────────────────────────────────────────────────
 
+extern "C" fn disconnect_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("process_mgmt", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
 /// Non-blocking disconnect with a Rust closure callback.
 ///
 /// Disconnects a previously connected set of processes without blocking.
@@ -1045,45 +1077,6 @@ impl DisconnectCallbackWrapper {
 /// pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t nprocs,
 ///                                  const pmix_info_t info[], size_t ninfo,
 ///                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
-/// ```
-extern "C" fn disconnect_callback_bridge(status: i32, cbdata: *mut c_void) {
-    if cbdata.is_null() {
-        return;
-    }
-    let req_id = decode_req_id(cbdata);
-    let cb = {
-        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.remove(&req_id)
-    };
-    let Some(cb_wrapper) = cb else {
-        return;
-    };
-    let pmix_status = PmixStatus::from_raw(status);
-    let _ = invoke_user_callback("process_mgmt", move || {
-        (cb_wrapper.callback)(pmix_status);
-    });
-}
-
-/// Non-blocking connect with a Rust closure callback.
-///
-/// Records a set of processes as "connected" without blocking. The
-/// provided callback is invoked when the operation completes.
-///
-/// * The callback receives `PmixStatus`:
-///   - `PMIX_SUCCESS` — all participating processes have connected.
-///   - Error code — the connect operation failed.
-/// * The `callback` closure must be `Send + 'static` because it may
-///   be invoked from a different thread by the PMIx library.
-///
-/// # Returns
-/// * `Ok(())` — the connect request was accepted (async, result in callback).
-/// * `Err(PmixStatus)` — the connect request itself failed synchronously.
-///
-/// # C API
-/// ```c
-/// pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
-///                               const pmix_info_t info[], size_t ninfo,
-///                               pmix_op_cbfunc_t cbfunc, void *cbdata);
 /// ```
 pub fn disconnect_nb(
     procs: &[Proc],

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -51,11 +51,15 @@
 //! let result = disconnect(&[target], &[disconnect_info]);
 //! ```
 
+use crate::cbdata::{decode_req_id, encode_req_id};
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
+use std::sync::{LazyLock, Mutex};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_Abort
@@ -474,6 +478,23 @@ pub fn spawn(_job_info: &[Info], apps: &[PmixApp]) -> Result<String, PmixStatus>
 // PMIx_Spawn_nb
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ── One-shot completion registries (issue #67) ───────────────────────────────
+static SPAWN_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static SPAWN_REGISTRY: LazyLock<Mutex<HashMap<usize, SpawnCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static CONNECT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static CONNECT_REGISTRY: LazyLock<Mutex<HashMap<usize, ConnectCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static DISCONNECT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static DISCONNECT_REGISTRY: LazyLock<Mutex<HashMap<usize, DisconnectCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn next_req_id(seq: &Mutex<usize>) -> usize {
+    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
+    *g = g.saturating_add(1).max(1);
+    *g
+}
+
 /// Non-blocking spawn callback wrapper.
 ///
 /// Wraps a Rust closure so it can be called from the C FFI callback.
@@ -494,6 +515,35 @@ impl SpawnCallbackWrapper {
             callback: Box::new(f),
         }
     }
+}
+
+extern "C" fn spawn_callback_bridge(
+    status: ffi::pmix_status_t,
+    nspace: *mut c_char,
+    cbdata: *mut c_void,
+) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let nspace_str = if pmix_status.is_success() && !nspace.is_null() {
+        // SAFETY: PMIx provides a NUL-terminated nspace on success for this call.
+        let cstr = unsafe { CStr::from_ptr(nspace) };
+        Some(cstr.to_string_lossy().into_owned())
+    } else {
+        None
+    };
+    let _ = invoke_user_callback("process_mgmt", move || {
+        (cb_wrapper.callback)(pmix_status, nspace_str);
+    });
 }
 
 /// Non-blocking spawn with a Rust closure callback.
@@ -527,40 +577,20 @@ pub fn spawn_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    // Box the callback wrapper so it lives on the heap and outlives
-    // the FFI call. We pass it as cbdata and recover it in the C
-    // callback via Box::from_raw.
-    let cb_box: *mut SpawnCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    // The C bridge function that PMIx calls back into.
-    // SAFETY: This extern "C" function is only called by PMIx with
-    // the cbdata pointer we provided (Box<SpawnCallbackWrapper>).
-    // It takes ownership of the box via Box::from_raw.
-    extern "C" fn spawn_callback_bridge(
-        status: ffi::pmix_status_t,
-        nspace: *mut c_char,
-        cbdata: *mut c_void,
-    ) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut SpawnCallbackWrapper) };
-
-        let pmix_status = PmixStatus::from_raw(status);
-        let nspace_str = if pmix_status.is_success() && !nspace.is_null() {
-            let cstr = unsafe { CStr::from_ptr(nspace) };
-            Some(cstr.to_string_lossy().into_owned())
-        } else {
-            None
-        };
-
-        (cb_wrapper.callback)(pmix_status, nspace_str);
-        // The box is dropped here.
+    let req_id = next_req_id(&SPAWN_SEQ);
+    {
+        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
 
     let napps = apps.len();
 
     // SAFETY: PMIx_App_create allocates and constructs napps pmix_app_t.
     let raw_apps: *mut ffi::pmix_app_t = unsafe { ffi::PMIx_App_create(napps) };
     if raw_apps.is_null() {
-        unsafe { drop(Box::from_raw(cb_box)) };
+        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_OUT_OF_RESOURCE));
     }
 
@@ -636,7 +666,7 @@ pub fn spawn_nb(
     // - `raw_apps` is a valid array of `napps` pmix_app_t structures
     //   with C-allocated string fields.
     // - `spawn_callback_bridge` is a valid extern "C" callback.
-    // - `cb_box` is a valid heap-allocated SpawnCallbackWrapper.
+    // - `cbdata` is an opaque request ID (`encode_req_id`) for SPAWN_REGISTRY.
     // - PMIx_Spawn_nb returns immediately; the callback is invoked
     //   asynchronously by the PMIx library at a later time.
     // - PMIx copies app data internally, so our guard can free
@@ -648,7 +678,7 @@ pub fn spawn_nb(
             raw_apps,
             napps,
             Some(spawn_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -658,8 +688,10 @@ pub fn spawn_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        // On synchronous failure, PMIx still calls the callback with
-        // the error status, so the bridge function will drop cb_box.
+        // Sync failure: OpenPMIx may still deliver the completion; if it does
+        // not, drop the parked callback so the registry does not leak.
+        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -784,27 +816,25 @@ impl ConnectCallbackWrapper {
 // PMIx_Connect_nb
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Non-blocking connect with a Rust closure callback.
-///
-/// Records a set of processes as "connected" without blocking. The
-/// provided callback is invoked when the operation completes.
-///
-/// * The callback receives `PmixStatus`:
-///   - `PMIX_SUCCESS` — all participating processes have connected.
-///   - Error code — the connect operation failed.
-/// * The `callback` closure must be `Send + 'static` because it may
-///   be invoked from a different thread by the PMIx library.
-///
-/// # Returns
-/// * `Ok(())` — the connect request was accepted (async, result in callback).
-/// * `Err(PmixStatus)` — the connect request itself failed synchronously.
-///
-/// # C API
-/// ```c
-/// pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
-///                               const pmix_info_t info[], size_t ninfo,
-///                               pmix_op_cbfunc_t cbfunc, void *cbdata);
-/// ```
+extern "C" fn connect_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("process_mgmt", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
+/// C bridge for `pmix_spawn_cbfunc_t` — registry lookup, then user invoke.
 pub fn connect_nb(
     procs: &[Proc],
     info: &[Info],
@@ -814,21 +844,12 @@ pub fn connect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    // Box the callback wrapper so it lives on the heap and outlives
-    // the FFI call. We pass it as cbdata and recover it in the C
-    // callback via Box::from_raw.
-    let cb_box: *mut ConnectCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    // The C bridge function that PMIx calls back into.
-    // SAFETY: This extern "C" function is only called by PMIx with
-    // the cbdata pointer we provided (Box<ConnectCallbackWrapper>).
-    // It takes ownership of the box via Box::from_raw.
-    extern "C" fn connect_callback_bridge(status: i32, cbdata: *mut c_void) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut ConnectCallbackWrapper) };
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
-        // The box is dropped here.
+    let req_id = next_req_id(&CONNECT_SEQ);
+    {
+        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
 
     // Convert proc slice to a raw pointer.
     // SAFETY: `procs` is a non-empty slice of `Proc` values.
@@ -853,8 +874,7 @@ pub fn connect_nb(
     // - `info_ptr` is either null or points to a valid slice of
     //   `pmix_info_t` pointers.
     // - `connect_callback_bridge` is a valid extern "C" callback.
-    // - `cb_box` is a valid heap-allocated ConnectCallbackWrapper
-    //   that will be recovered in the callback via Box::from_raw.
+    // - `cbdata` is an opaque request ID for CONNECT_REGISTRY.
     // - PMIx_Connect_nb returns immediately; the callback is invoked
     //   asynchronously by the PMIx library at a later time.
     let raw_status = unsafe {
@@ -864,7 +884,7 @@ pub fn connect_nb(
             info_ptr,
             ninfo,
             Some(connect_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -872,9 +892,8 @@ pub fn connect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        // On synchronous failure, PMIx may or may not call the callback.
-        // To be safe, reclaim the box to avoid a memory leak.
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -1027,6 +1046,45 @@ impl DisconnectCallbackWrapper {
 ///                                  const pmix_info_t info[], size_t ninfo,
 ///                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
 /// ```
+extern "C" fn disconnect_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("process_mgmt", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
+/// Non-blocking connect with a Rust closure callback.
+///
+/// Records a set of processes as "connected" without blocking. The
+/// provided callback is invoked when the operation completes.
+///
+/// * The callback receives `PmixStatus`:
+///   - `PMIX_SUCCESS` — all participating processes have connected.
+///   - Error code — the connect operation failed.
+/// * The `callback` closure must be `Send + 'static` because it may
+///   be invoked from a different thread by the PMIx library.
+///
+/// # Returns
+/// * `Ok(())` — the connect request was accepted (async, result in callback).
+/// * `Err(PmixStatus)` — the connect request itself failed synchronously.
+///
+/// # C API
+/// ```c
+/// pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
+///                               const pmix_info_t info[], size_t ninfo,
+///                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+/// ```
 pub fn disconnect_nb(
     procs: &[Proc],
     info: &[Info],
@@ -1036,21 +1094,12 @@ pub fn disconnect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    // Box the callback wrapper so it lives on the heap and outlives
-    // the FFI call. We pass it as cbdata and recover it in the C
-    // callback via Box::from_raw.
-    let cb_box: *mut DisconnectCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    // The C bridge function that PMIx calls back into.
-    // SAFETY: This extern "C" function is only called by PMIx with
-    // the cbdata pointer we provided (Box<DisconnectCallbackWrapper>).
-    // It takes ownership of the box via Box::from_raw.
-    extern "C" fn disconnect_callback_bridge(status: i32, cbdata: *mut c_void) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut DisconnectCallbackWrapper) };
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
-        // The box is dropped here.
+    let req_id = next_req_id(&DISCONNECT_SEQ);
+    {
+        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
 
     // Convert proc slice to a raw pointer.
     // SAFETY: `procs` is a non-empty slice of `Proc` values.
@@ -1075,8 +1124,7 @@ pub fn disconnect_nb(
     // - `info_ptr` is either null or points to a valid slice of
     //   `pmix_info_t` pointers.
     // - `disconnect_callback_bridge` is a valid extern "C" callback.
-    // - `cb_box` is a valid heap-allocated DisconnectCallbackWrapper
-    //   that will be recovered in the callback via Box::from_raw.
+    // - `cbdata` is an opaque request ID for DISCONNECT_REGISTRY.
     // - PMIx_Disconnect_nb returns immediately; the callback is invoked
     //   asynchronously by the PMIx library at a later time.
     let raw_status = unsafe {
@@ -1086,7 +1134,7 @@ pub fn disconnect_nb(
             info_ptr,
             ninfo,
             Some(disconnect_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -1094,9 +1142,8 @@ pub fn disconnect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        // On synchronous failure, PMIx may or may not call the callback.
-        // To be safe, reclaim the box to avoid a memory leak.
-        unsafe { drop(Box::from_raw(cb_box)) }
+        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -41,6 +41,7 @@ use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
 
 #[cfg(any(test, feature = "mock_ffi"))]
@@ -457,7 +458,9 @@ extern "C" fn query_callback_bridge(
     
             _not_thread_safe: std::marker::PhantomData,
         };
-    cb.on_complete(pmix_status, results);
+    let _ = invoke_user_callback("query_log", move || {
+            cb.on_complete(pmix_status, results);
+    });
     // release_fn is unused — we manage our own memory via QueryResults Drop.
     let _ = release_fn;
 }
@@ -668,7 +671,9 @@ extern "C" fn log_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_voi
     };
 
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("query_log", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Non-blocking log of data to the host environment's logging service.

--- a/src/security.rs
+++ b/src/security.rs
@@ -35,6 +35,7 @@ use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
 use crate::ffi;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -457,7 +458,9 @@ extern "C" fn credential_callback_bridge(
         CredentialResults::default()
     };
 
-    cb.on_complete(pmix_status, cred, results);
+    let _ = invoke_user_callback("security", move || {
+            cb.on_complete(pmix_status, cred, results);
+    });
 }
 
 /// Non-blocking request for a credential from the PMIx server.
@@ -775,7 +778,9 @@ extern "C" fn validation_callback_bridge(
         }
     };
 
-    cb.on_complete(pmix_status, results);
+    let _ = invoke_user_callback("security", move || {
+            cb.on_complete(pmix_status, results);
+    });
 }
 
 /// Non-blocking validation of a credential obtained from [`get_credential`].

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,6 +1,10 @@
 //! Server submodule: data
 
 use super::*;
+use crate::cbdata::{decode_req_id, encode_req_id};
+use crate::threading::invoke_user_callback;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
@@ -327,6 +331,77 @@ pub fn server_fence(
 // PMIx_Fence_nb — non-blocking synchronization fence (server context)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ── One-shot completion registries (issue #67) ───────────────────────────────
+static SERVER_FENCE_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static SERVER_FENCE_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SERVER_CONNECT_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static SERVER_CONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SERVER_DISCONNECT_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static SERVER_DISCONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn next_req_id(seq: &Mutex<usize>) -> usize {
+    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
+    *g = g.saturating_add(1).max(1);
+    *g
+}
+
+pub(crate) extern "C" fn fence_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("server::data", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
+pub(crate) extern "C" fn connect_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("server::data", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
+pub(crate) extern "C" fn disconnect_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let req_id = decode_req_id(cbdata);
+    let cb = {
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id)
+    };
+    let Some(cb_wrapper) = cb else {
+        return;
+    };
+    let pmix_status = PmixStatus::from_raw(status);
+    let _ = invoke_user_callback("server::data", move || {
+        (cb_wrapper.callback)(pmix_status);
+    });
+}
+
 /// Callback wrapper for [`server_fence_nb`].
 ///
 /// Wraps a Rust closure so it can be called from the C FFI callback.
@@ -372,13 +447,13 @@ pub fn server_fence_nb(
     _info: &[Info],
     callback: FenceNbCallbackWrapper,
 ) -> Result<(), PmixStatus> {
-    let cb_box: *mut FenceNbCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    pub(crate) extern "C" fn fence_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut FenceNbCallbackWrapper) };
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
+    let req_id = next_req_id(&SERVER_FENCE_NB_SEQ);
+    {
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
+
 
     let (info_ptr, ninfo) = if !_info.is_empty() && _info[0].len > 0 {
         (_info[0].handle as *const ffi::pmix_info_t, _info[0].len)
@@ -393,7 +468,7 @@ pub fn server_fence_nb(
             info_ptr,
             ninfo,
             Some(fence_nb_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -401,9 +476,8 @@ pub fn server_fence_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe {
-            let _ = Box::from_raw(cb_box);
-        }
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -505,13 +579,13 @@ pub fn server_connect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let cb_box: *mut FenceNbCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    pub(crate) extern "C" fn connect_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut FenceNbCallbackWrapper) };
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
+    let req_id = next_req_id(&SERVER_CONNECT_NB_SEQ);
+    {
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
+
 
     let procs_ptr = unsafe {
         std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
@@ -535,7 +609,7 @@ pub fn server_connect_nb(
             info_ptr,
             ninfo,
             Some(connect_nb_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -543,9 +617,8 @@ pub fn server_connect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe {
-            let _ = Box::from_raw(cb_box);
-        }
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -643,13 +716,13 @@ pub fn server_disconnect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let cb_box: *mut FenceNbCallbackWrapper = Box::into_raw(Box::new(callback));
-
-    pub(crate) extern "C" fn disconnect_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
-        let cb_wrapper = unsafe { Box::from_raw(cbdata as *mut FenceNbCallbackWrapper) };
-        let pmix_status = PmixStatus::from_raw(status);
-        (cb_wrapper.callback)(pmix_status);
+    let req_id = next_req_id(&SERVER_DISCONNECT_NB_SEQ);
+    {
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.insert(req_id, callback);
     }
+    let cbdata = encode_req_id(req_id);
+
 
     let procs_ptr = unsafe {
         std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
@@ -673,7 +746,7 @@ pub fn server_disconnect_nb(
             info_ptr,
             ninfo,
             Some(disconnect_nb_callback_bridge),
-            cb_box as *mut c_void,
+            cbdata,
         )
     };
 
@@ -681,9 +754,8 @@ pub fn server_disconnect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        unsafe {
-            let _ = Box::from_raw(cb_box);
-        }
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        registry.remove(&req_id);
         Err(pmix_status)
     }
 }

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,7 +1,7 @@
 //! Server submodule: data
 
 use super::*;
-use crate::cbdata::{decode_req_id, encode_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
 use crate::threading::invoke_user_callback;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -341,12 +341,6 @@ static SERVER_CONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallback
 static SERVER_DISCONNECT_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 static SERVER_DISCONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
-
-fn next_req_id(seq: &Mutex<usize>) -> usize {
-    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
-    *g = g.saturating_add(1).max(1);
-    *g
-}
 
 pub(crate) extern "C" fn fence_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
     if cbdata.is_null() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,6 +69,7 @@
 
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::security::PmixCredential;
+use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, ffi};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
@@ -538,7 +539,9 @@ pub(crate) extern "C" fn register_nspace_callback_bridge(status: ffi::pmix_statu
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Register an nspace (job namespace) with the PMIx server library.
@@ -751,7 +754,9 @@ pub(crate) extern "C" fn deregister_nspace_callback_bridge(status: ffi::pmix_sta
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Deregister an nspace (job namespace) and purge all related data.
@@ -912,7 +917,9 @@ pub(crate) extern "C" fn register_client_callback_bridge(status: ffi::pmix_statu
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Register a client process with the PMIx server library.
@@ -1084,7 +1091,9 @@ pub(crate) extern "C" fn deregister_client_callback_bridge(status: ffi::pmix_sta
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Deregister a specific client process and purge all data relating to it.
@@ -1472,7 +1481,9 @@ pub(crate) extern "C" fn dmodex_request_callback_bridge(
 
     // Invoke the user's Rust callback with the copied data.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status, blob);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status, blob);
+    });
 }
 
 /// Request modex data for a specific process (direct modex operation).
@@ -1732,7 +1743,9 @@ pub(crate) extern "C" fn setup_application_callback_bridge(
 
     // Invoke the user's Rust callback with the copied data.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status, copied_info);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status, copied_info);
+    });
 }
 
 /// Request application-specific setup prior to process launch.
@@ -1928,7 +1941,9 @@ pub(crate) extern "C" fn setup_local_support_callback_bridge(status: ffi::pmix_s
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Setup local support for a given namespace before spawning local clients.
@@ -2133,7 +2148,9 @@ pub(crate) extern "C" fn iof_deliver_callback_bridge(status: ffi::pmix_status_t,
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Deliver forwarded I/O data to the local PMIx server for distribution.
@@ -2410,7 +2427,9 @@ pub(crate) extern "C" fn collect_inventory_callback_bridge(
     
             _not_thread_safe: std::marker::PhantomData,
         };
-    cb.on_complete(pmix_status, inventory);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status, inventory);
+    });
     // release_fn is unused — we manage our own memory via CollectInventoryResults Drop.
     let _ = release_fn;
 }
@@ -2611,7 +2630,9 @@ pub(crate) extern "C" fn deliver_inventory_callback_bridge(status: ffi::pmix_sta
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Deliver collected inventory information to the PMIx server library.

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -1,6 +1,7 @@
 //! Server submodule: pset
 
 use super::*;
+use crate::threading::invoke_user_callback;
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
@@ -285,7 +286,9 @@ pub(crate) extern "C" fn register_resources_callback_bridge(status: ffi::pmix_st
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server::pset", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Register non-namespace related resource information with the PMIx server.
@@ -486,7 +489,9 @@ pub(crate) extern "C" fn deregister_resources_callback_bridge(
 
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
-    cb.on_complete(pmix_status);
+    let _ = invoke_user_callback("server::pset", move || {
+            cb.on_complete(pmix_status);
+    });
 }
 
 /// Deregister non-namespace related resource information from the PMIx server.

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -176,7 +176,6 @@ where
         })
 }
 
-
 /// Invoke a user callback from an `extern "C"` bridge **without** letting a
 /// panic unwind into OpenPMIx / C.
 ///
@@ -200,7 +199,8 @@ where
         Ok(()) => true,
         Err(_) => {
             eprintln!(
-                "pmix::{bridge}: user callback panicked on the progress thread;                  containing the panic (must not unwind across FFI)"
+                "pmix::{bridge}: user callback panicked on the progress thread; \
+                 containing the panic (must not unwind across FFI)"
             );
             false
         }
@@ -350,7 +350,6 @@ mod tests {
             "unexpected panic payload: {msg}"
         );
     }
-
 
     #[test]
     fn invoke_user_callback_contains_panic() {

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -27,7 +27,14 @@
 //!    dropped. (Regression-tested in `events`.)
 //! 4. **cbdata** is an opaque request ID encoded with
 //!    [`crate::cbdata::encode_req_id`] / [`crate::cbdata::decode_req_id`],
-//!    never a raw pointer to a callback.
+//!    never a raw pointer to a Rust callback/`Box` (one-shot completions use a
+//!    registry keyed by that ID; long-lived IOF pull contexts are a documented
+//!    exception because the handle is the C-side key).
+//! 5. **User-callback panics are contained at the bridge.** An `extern "C"`
+//!    entry must not unwind into OpenPMIx. Use [`invoke_user_callback`] (or an
+//!    equivalent `catch_unwind`) so a panicking handler is logged and the
+//!    panic is **not** resumed across the FFI boundary. (Event-chain bridges
+//!    must still complete OpenPMIx's `cbfunc` — see `events::notification_bridge`.)
 //!
 //! # Hop-off template
 //!
@@ -167,6 +174,37 @@ where
                 std::panic::resume_unwind(payload);
             }
         })
+}
+
+
+/// Invoke a user callback from an `extern "C"` bridge **without** letting a
+/// panic unwind into OpenPMIx / C.
+///
+/// Bridges are called from C on the progress thread. Unwinding across that
+/// FFI boundary is undefined behaviour. This helper runs `f` under
+/// [`catch_unwind`](std::panic::catch_unwind), logs a branded diagnostic on
+/// panic, and **contains** the panic (does not `resume_unwind`).
+///
+/// Prefer this for one-shot completion bridges (`_nb` ops). Event-notification
+/// bridges that must also complete an OpenPMIx event chain should catch
+/// panics themselves so they can call `cbfunc` on the failure path (see
+/// `events::notification_bridge`).
+///
+/// Returns `true` if `f` completed normally, `false` if it panicked.
+#[inline]
+pub fn invoke_user_callback<F>(bridge: &str, f: F) -> bool
+where
+    F: FnOnce(),
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(()) => true,
+        Err(_) => {
+            eprintln!(
+                "pmix::{bridge}: user callback panicked on the progress thread;                  containing the panic (must not unwind across FFI)"
+            );
+            false
+        }
+    }
 }
 
 /// Channel pair for hopping callback payloads off the progress thread.
@@ -311,6 +349,15 @@ mod tests {
             msg.contains("hop-work boom"),
             "unexpected panic payload: {msg}"
         );
+    }
+
+
+    #[test]
+    fn invoke_user_callback_contains_panic() {
+        let ok = invoke_user_callback("test", || {});
+        assert!(ok);
+        let panicked = invoke_user_callback("test", || panic!("bridge-boom"));
+        assert!(!panicked, "panic must be contained, not resumed");
     }
 
     #[test]

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -951,6 +951,7 @@ pub fn register_attributes(function: &str, attrs: &[&str]) -> Result<(), PmixSta
 // ─────────────────────────────────────────────────────────────────────────────
 
 use std::collections::HashMap;
+use crate::threading::invoke_user_callback;
 use std::sync::{LazyLock, Mutex};
 
 /// Global registry mapping IOF handles to their Rust callback contexts.
@@ -1038,7 +1039,9 @@ extern "C" fn io_callback_bridge(
     };
 
     let channel_flags = IOFChannelFlags(channel);
-    (ctx.io_cb)(iofhdlr, channel_flags, source_proc, bytes);
+    let _ = invoke_user_callback("utility", move || {
+        (ctx.io_cb)(iofhdlr, channel_flags, source_proc, bytes);
+    });
 }
 
 /// C bridge for the registration callback (`pmix_hdlr_reg_cbfunc_t`).
@@ -1066,7 +1069,9 @@ extern "C" fn reg_callback_bridge(
     }
 
     let pmix_status = PmixStatus::from_raw(status);
-    (ctx.reg_cb)(pmix_status, refid);
+    let _ = invoke_user_callback("utility", move || {
+        (ctx.reg_cb)(pmix_status, refid);
+    });
 }
 
 /// Callback trait for receiving IO data from remote processes.
@@ -1270,7 +1275,9 @@ extern "C" fn dereg_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut std
 
     // Invoke the user's deregistration callback, then the Box drops,
     // freeing both the context and the contained closure.
-    (boxed_ctx.cb)(pmix_status);
+    let _ = invoke_user_callback("utility", move || {
+        (boxed_ctx.cb)(pmix_status);
+    });
 }
 
 /// Deregister from IO forwarding previously established via `iof_pull`.
@@ -1559,7 +1566,9 @@ extern "C" fn push_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut std:
     let ctx = unsafe { Box::from_raw(ctx_ptr) };
 
     let pmix_status = PmixStatus::from_raw(status);
-    (ctx.cb)(pmix_status);
+    let _ = invoke_user_callback("utility", move || {
+        (ctx.cb)(pmix_status);
+    });
 }
 
 /// Push data collected locally (typically from stdin) to stdin of target


### PR DESCRIPTION
## Summary
- Full inventory of callback bridges/registries (data_ops, events, query_log, security, allocation, monitoring, groups, process_mgmt, server, utility IOF).
- **No hold-across-user-code**: every registry bridge does scoped `remove`/`get` then drops the lock before user code (regression tests in `events` + new `groups` lock test).
- Prefer `encode_req_id` for one-shot completions: **migrated** `groups`, `process_mgmt` (`spawn`/`connect`/`disconnect` `_nb`), and `server/data` fence/connect/disconnect `_nb` off raw `Box` cbdata.
- Panic containment: new `threading::invoke_user_callback` used by one-shot bridges; events keep chain-aware `catch_unwind` (addresses review note from #369).
- `THREADING.md` §9 audit checklist + roadmap #67 marked Done.

## Test plan
- [x] `cargo test --lib` (1757 passed, 29 ignored)
- [x] `cargo clippy --lib -- -D warnings`
- [x] Focused: `groups::` lock/panic bridge tests, `threading::invoke_user_callback_contains_panic`

Closes #67