### PR TITLE
test(threading): add public Send and Sync matrix

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -81,28 +81,74 @@ Worked example: `examples/server_upcall_hop.rs` (issue #52).
 
 ## 5. Type inventory
 
-### 5.1 Sessions / POD — `Send + Sync` (enforced in `threading_assert.rs`)
+### 5.1 Sessions, identities, POD, and Rust-owned values — `Send + Sync`
 
-`PmixClient`, `PmixClientState`, `PmixServer`, `PmixServerState`, `PmixTool`, `PmixToolState`, `Proc`
+The following types contain process-safe session state, copied process identity,
+scalar/POD data, or data copied into Rust-owned allocations. They are enforced
+in `src/threading_assert.rs`:
 
-### 5.2 C-owned — `!Send + !Sync` (enforced)
+- Sessions and lifecycle state: `PmixClient`, `PmixClientState`, `PmixServer`,
+  `PmixServerState`, `server::PmixServerHandle` (an alias for `PmixServer`),
+  `PmixTool`, and `PmixToolState`.
+- Identity tokens: `Proc`, `PmixToolHandle`, and `tool::PmixServerHandle`.
+  The two `PmixServerHandle` names are intentionally different: the server
+  module's name is a session alias, while the tool module's name is an attached
+  server identity (`nspace + rank`).
+- Scalar/POD values: status/error enums, PMIx enum mirrors, `IOFChannelFlags`,
+  `InfoFlags`, `PmixTimeval`, `PmixEnvar`, `PmixBindEnvelope`, and
+  `PmixLocality`.
+- Rust-owned wrappers/builders: `InitOptions`, `PmixCredential`,
+  `utility::PmixByteObject`, `data_serialization::PmixPrintOutput`,
+  `fabric::PmixDeviceDistance`, `process_mgmt::PmixApp`,
+  `process_mgmt::PmixAppBuilder`, `PmixProcRef`, and the zero-sized
+  `threading::ProgressContext` marker.
+- Function-pointer aliases are `Send + Sync`; `PmixServerModule` is deliberately
+  not included in this matrix because its `as_c_ptr()` method currently casts
+  the Rust struct directly to the generated C struct. That ABI representation
+  must be made explicit before its threading contract is frozen.
 
-| Type | Module |
-|------|--------|
-| `Info`, `InfoBuilder`, `PmixOwnedValue` | `lib` |
-| `PmixDataBuffer`, `PmixByteObject` | `data_serialization` |
-| `PmixFabric`, `PmixTopology`, `PmixCpuset`, `DeviceDistances` | `fabric` |
-| `QueryResults`, `PmixQuery` | `query_log` |
-| `AllocationResults`, `JobControlResults`, `SessionControlResults` | `allocation` |
-| `MonitorResults` | `monitoring` |
-| `ValidationResults` | `security` |
-| `CollectInventoryResults` | `server` |
+### 5.2 C-owned or raw-pointer-bearing values — `!Send + !Sync`
 
-**Share model:** build ephemeral handles **per call** on the calling thread. Optional app-side `Arc<Mutex<T>>` if you must share (no library `into_shared` helper — YAGNI).
+These values either own PMIx allocations, release C memory in `Drop`, retain an
+opaque C pointer, or contain a raw `pmix_value_t` union whose active arm controls
+ownership. The complete matrix is centralized in `src/threading_assert.rs`.
 
-### 5.3 Pure Rust / remaining
+| Type | Module | Why |
+|------|--------|-----|
+| `Info`, `InfoBuilder`, `PmixOwnedValue` | `lib` | PMIx allocation / raw value union |
+| `PmixPayload`, `PmixValueBuilder` | `lib` | Deliberate raw-pointer payload variant and raw C values |
+| `PmixPdata` | `data_ops` | Contains `PmixOwnedValue` |
+| `PmixDataBuffer`, `data_serialization::PmixByteObject` | `data_serialization` | PMIx-managed buffer/byte-object lifetime |
+| `PmixFabric`, `PmixTopology`, `PmixCpuset`, `DeviceDistances` | `fabric` | PMIx/C-owned state and cleanup pointers |
+| `PmixQuery`, `QueryResults` | `query_log` | Query/result allocations released through PMIx |
+| `AllocationResults`, `JobControlResults`, `SessionControlResults` | `allocation` | Returned `pmix_info_t` arrays |
+| `MonitorResults` | `monitoring` | Returned `pmix_info_t` array |
+| `CredentialResults`, `ValidationResults` | `security` | Results contain PMIx info allocations |
+| `CollectInventoryResults` | `server` | Returned `pmix_info_t` array |
 
-`PmixCredential` holds a Rust `Vec<u8>` (opaque bytes) — stays `Send + Sync`. Enums and pure builders are `Send + Sync`.
+The `utility::PmixByteObject` type is intentionally different: it owns a
+`Vec<u8>` and is `Send + Sync`; do not confuse it with the PMIx-backed
+`data_serialization::PmixByteObject`.
+
+**Share model:** build ephemeral handles **per call** on the calling thread.
+`Arc<Mutex<T>>` does not make a `!Send` PMIx wrapper transferable: Rust still
+requires `T: Send` for the mutex to cross threads. If work must leave the
+creating thread, send a Rust-owned snapshot (for example, copied bytes or
+materialized fields) through a channel, or keep the C-owned wrapper and all
+operations on its owner thread. A library `into_shared` helper is intentionally
+not provided (YAGNI).
+
+### 5.3 Callback carriers
+
+The public callback wrapper structs are movable (`Send`) because their trait
+objects require `Send`, but they are not concurrently shareable (`!Sync`) unless
+the API explicitly adds a `Sync` bound. Function-pointer aliases are
+`Send + Sync`. `threading::CallbackChannel<T>` is movable when `T: Send`, but
+its `Receiver` makes the channel itself `!Sync`.
+
+Callback results must be converted to Rust-owned data before hopping off the
+PMIx progress thread; do not send a C-owned result wrapper through a callback
+channel.
 
 ---
 
@@ -192,4 +238,4 @@ process. Companion example: `examples/external_progress_mt.rs`.
 | Server upcall example | #52 | Done (`PmixServerModule` docs + `server_upcall_hop` example) |
 | Global FFI mutex | #53 | Deferred |
 | MT integration tests | #54 | Done (`tests/threading_mt_via_prterun.rs` + `run_daemon_tests.sh THREADING`) |
-| Extra static_assertions | #66 | Mostly superseded by #50 |
+| Extra public Send/Sync matrix | #66 | Done (centralized matrix + inventory) |

--- a/THREADING.md
+++ b/THREADING.md
@@ -83,9 +83,9 @@ Worked example: `examples/server_upcall_hop.rs` (issue #52).
 
 ### 5.1 Sessions, identities, POD, and Rust-owned values — `Send + Sync`
 
-The following types contain process-safe session state, copied process identity,
-scalar/POD data, or data copied into Rust-owned allocations. They are enforced
-in `src/threading_assert.rs`:
+The following concrete public values and handles contain process-safe session
+state, copied process identity, scalar/POD data, or data copied into Rust-owned
+allocations. They are enforced in `src/threading_assert.rs`:
 
 - Sessions and lifecycle state: `PmixClient`, `PmixClientState`, `PmixServer`,
   `PmixServerState`, `server::PmixServerHandle` (an alias for `PmixServer`),
@@ -111,7 +111,8 @@ in `src/threading_assert.rs`:
 
 These values either own PMIx allocations, release C memory in `Drop`, retain an
 opaque C pointer, or contain a raw `pmix_value_t` union whose active arm controls
-ownership. The complete matrix is centralized in `src/threading_assert.rs`.
+ownership. The complete concrete value/handle matrix is centralized in
+`src/threading_assert.rs`.
 
 | Type | Module | Why |
 |------|--------|-----|
@@ -145,6 +146,12 @@ objects require `Send`, but they are not concurrently shareable (`!Sync`) unless
 the API explicitly adds a `Sync` bound. Function-pointer aliases are
 `Send + Sync`. `threading::CallbackChannel<T>` is movable when `T: Send`, but
 its `Receiver` makes the channel itself `!Sync`.
+
+Callback trait definitions are contracts rather than concrete values in this
+matrix: each public callback trait declares its required `Send` bound at its
+definition site. The concrete wrapper carriers are asserted above. A callback
+trait object can be moved only when its object type is `Send`, and it is not
+concurrently shareable unless `Sync` is also part of the bound.
 
 Callback results must be converted to Rust-owned data before hopping off the
 PMIx progress thread; do not send a C-owned result wrapper through a callback

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@
 //! - Data ops stay as free functions ([`put_value`], [`get_value`], [`commit`],
 //!   [`fence`], …). Pass [`Proc`] from the client; build [`Info`] per call.
 //! - [`Info`] and other C-owned handles are **`!Send` + `!Sync`**
-//!   (`PhantomData<*mut u8>`). Share only behind your own `Mutex` if you must.
+//!   (`PhantomData<*mut u8>`). Keep them on their owner thread, or convert
+//!   them to Rust-owned snapshots before sending data to another thread.
+//!   `Arc<Mutex<T>>` does not make a `!Send` wrapper transferable: `T` must
+//!   still be `Send` for the mutex to cross threads.
 //! - One logical connect/disconnect per process. **Drop does not finalize**
 //!   (clones must not each run `PMIx_Finalize`). Call [`disconnect`](PmixClient::disconnect)
 //!   or [`finalize`].

--- a/src/threading_assert.rs
+++ b/src/threading_assert.rs
@@ -1,69 +1,154 @@
-//! Compile-time `Send`/`Sync` matrix for public session vs C-owned handle types.
+//! Compile-time `Send`/`Sync` matrix for the public PMIx API.
 //!
-//! See [THREADING.md](../THREADING.md) and issue #50.
+//! This is intentionally centralized: when a public wrapper is added or its
+//! ownership model changes, add its intended auto-traits here.  The negative
+//! assertions are as important as the positive ones.  In particular, they
+//! prevent a raw-pointer-bearing wrapper from silently becoming movable or
+//! shareable after a representation change.
+//!
+//! See [THREADING.md](../THREADING.md), issue #50, and issue #66.
 
 #[cfg(test)]
 mod asserts {
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
-    // ── Sessions: must stay shareable ─────────────────────────────────────
-    use crate::{PmixClient, PmixClientState, Proc};
-    use crate::server::{PmixServer, PmixServerState};
-    use crate::tool::{PmixTool, PmixToolState};
+    // ── Sessions, identities, POD, and scalar values ──────────────────────
+    //
+    // These values contain either process-safe session state, copied process
+    // identity, scalar data, or Rust-owned memory.  They are deliberately
+    // usable from worker threads.
+    assert_impl_all!(crate::PmixClient: Clone, Send, Sync);
+    assert_impl_all!(crate::PmixClientState: Send, Sync);
+    assert_impl_all!(crate::server::PmixServer: Clone, Send, Sync);
+    assert_impl_all!(crate::server::PmixServerHandle: Clone, Send, Sync);
+    assert_impl_all!(crate::server::PmixServerState: Send, Sync);
+    assert_impl_all!(crate::tool::PmixTool: Clone, Send, Sync);
+    assert_impl_all!(crate::tool::PmixToolState: Send, Sync);
+    assert_impl_all!(crate::tool::PmixToolHandle: Clone, Send, Sync);
+    assert_impl_all!(crate::tool::PmixServerHandle: Clone, Send, Sync);
+    assert_impl_all!(crate::Proc: Clone, Send, Sync);
 
-    assert_impl_all!(PmixClient: Clone, Send, Sync);
-    assert_impl_all!(PmixClientState: Send, Sync);
-    assert_impl_all!(PmixServer: Clone, Send, Sync);
-    assert_impl_all!(PmixServerState: Send, Sync);
-    assert_impl_all!(PmixTool: Clone, Send, Sync);
-    assert_impl_all!(PmixToolState: Send, Sync);
-    // POD process identity — free-threaded by design
-    assert_impl_all!(Proc: Clone, Send, Sync);
+    assert_impl_all!(crate::PmixError: Send, Sync);
+    assert_impl_all!(crate::PmixStatus: Send, Sync);
+    assert_impl_all!(crate::PmixProcState: Send, Sync);
+    assert_impl_all!(crate::PmixScope: Send, Sync);
+    assert_impl_all!(crate::PmixJobState: Send, Sync);
+    assert_impl_all!(crate::PmixLinkState: Send, Sync);
+    assert_impl_all!(crate::PmixDeviceType: Send, Sync);
+    assert_impl_all!(crate::PmixPersistence: Send, Sync);
+    assert_impl_all!(crate::PmixDataRange: Send, Sync);
+    assert_impl_all!(crate::PmixDataType: Send, Sync);
+    assert_impl_all!(crate::PmixAllocDirective: Send, Sync);
+    assert_impl_all!(crate::allocation::PmixAllocDirective: Send, Sync);
+    assert_impl_all!(crate::allocation::PmixJobCtrlAction: Send, Sync);
+    assert_impl_all!(crate::cpu_locality::PmixBindEnvelope: Send, Sync);
+    assert_impl_all!(crate::cpu_locality::PmixLocality: Send, Sync);
+    assert_impl_all!(crate::IOFChannelFlags: Send, Sync);
+    assert_impl_all!(crate::InfoFlags: Send, Sync);
+    assert_impl_all!(crate::BuilderError: Send, Sync);
+    assert_impl_all!(crate::ValueError: Send, Sync);
+    assert_impl_all!(crate::PmixTimeval: Send, Sync);
+    assert_impl_all!(crate::PmixEnvar: Send, Sync);
+    assert_impl_all!(crate::InitOptions: Send, Sync);
 
-    // ── C-owned / exclusive handles: must NOT be free-threaded ────────────
-    use crate::Info;
-    use crate::InfoBuilder;
-    use crate::PmixOwnedValue;
-    use crate::allocation::{AllocationResults, JobControlResults, SessionControlResults};
-    use crate::data_serialization::{PmixByteObject, PmixDataBuffer};
-    use crate::fabric::{DeviceDistances, PmixCpuset, PmixFabric, PmixTopology};
-    use crate::monitoring::MonitorResults;
-    use crate::query_log::{PmixQuery, QueryResults};
-    use crate::security::ValidationResults;
-    use crate::server::CollectInventoryResults;
+    // Rust-owned wrappers and materialized results.  These do not retain a
+    // PMIx allocation after construction.  `utility::PmixByteObject` is the
+    // exception to the similarly named data-serialization wrapper: it owns a
+    // Rust `Vec<u8>` and is only used to create a short-lived FFI copy.
+    assert_impl_all!(crate::security::PmixCredential: Clone, Send, Sync);
+    assert_impl_all!(crate::utility::PmixByteObject: Clone, Send, Sync);
+    assert_impl_all!(crate::data_serialization::PmixPrintOutput: Send, Sync);
+    assert_impl_all!(crate::fabric::PmixDeviceDistance: Send, Sync);
+    assert_impl_all!(crate::process_mgmt::PmixApp: Send, Sync);
+    assert_impl_all!(crate::process_mgmt::PmixAppBuilder: Send, Sync);
+    assert_impl_all!(crate::data_serialization::PmixProcRef<'static>: Send, Sync);
+    assert_impl_all!(crate::threading::ProgressContext: Send, Sync);
 
-    assert_not_impl_any!(Info: Send);
-    assert_not_impl_any!(Info: Sync);
-    assert_not_impl_any!(InfoBuilder: Send);
-    assert_not_impl_any!(InfoBuilder: Sync);
-    assert_not_impl_any!(PmixOwnedValue: Send);
-    assert_not_impl_any!(PmixOwnedValue: Sync);
-    assert_not_impl_any!(PmixDataBuffer: Send);
-    assert_not_impl_any!(PmixDataBuffer: Sync);
-    assert_not_impl_any!(PmixByteObject: Send);
-    assert_not_impl_any!(PmixByteObject: Sync);
-    assert_not_impl_any!(PmixFabric: Send);
-    assert_not_impl_any!(PmixFabric: Sync);
-    assert_not_impl_any!(PmixTopology: Send);
-    assert_not_impl_any!(PmixTopology: Sync);
-    assert_not_impl_any!(PmixCpuset: Send);
-    assert_not_impl_any!(PmixCpuset: Sync);
-    assert_not_impl_any!(DeviceDistances: Send);
-    assert_not_impl_any!(DeviceDistances: Sync);
-    assert_not_impl_any!(QueryResults: Send);
-    assert_not_impl_any!(QueryResults: Sync);
-    assert_not_impl_any!(PmixQuery: Send);
-    assert_not_impl_any!(PmixQuery: Sync);
-    assert_not_impl_any!(AllocationResults: Send);
-    assert_not_impl_any!(AllocationResults: Sync);
-    assert_not_impl_any!(JobControlResults: Send);
-    assert_not_impl_any!(JobControlResults: Sync);
-    assert_not_impl_any!(SessionControlResults: Send);
-    assert_not_impl_any!(SessionControlResults: Sync);
-    assert_not_impl_any!(MonitorResults: Send);
-    assert_not_impl_any!(MonitorResults: Sync);
-    assert_not_impl_any!(ValidationResults: Send);
-    assert_not_impl_any!(ValidationResults: Sync);
-    assert_not_impl_any!(CollectInventoryResults: Send);
-    assert_not_impl_any!(CollectInventoryResults: Sync);
+    // ── Function pointers and callback carriers ───────────────────────────
+    //
+    // A function pointer has no captured state.  Callback wrapper structs are
+    // movable because their trait objects require `Send`, but they are not
+    // advertised as concurrently shareable (`Sync` is intentionally absent).
+    assert_impl_all!(crate::events::EventHandlerRef: Send, Sync);
+    assert_impl_all!(crate::events::NotificationFn: Send, Sync);
+    assert_impl_all!(crate::events::HandlerRegCbFn: Send, Sync);
+    assert_impl_all!(crate::events::OpCbFn: Send, Sync);
+    assert_impl_all!(crate::events::pmix_event_notification_cbfunc_fn_t: Send, Sync);
+    assert_impl_all!(crate::groups::pmix_group_opt_t: Send, Sync);
+    assert_impl_all!(crate::process_mgmt::SpawnCallback: Send, Sync);
+    assert_impl_all!(crate::groups::GroupConstructCallbackWrapper: Send);
+    assert_impl_all!(crate::groups::GroupInviteCallbackWrapper: Send);
+    assert_impl_all!(crate::groups::GroupJoinCallbackWrapper: Send);
+    assert_impl_all!(crate::groups::GroupLeaveCallbackWrapper: Send);
+    assert_impl_all!(crate::groups::GroupDestructCallbackWrapper: Send);
+    assert_impl_all!(crate::process_mgmt::SpawnCallbackWrapper: Send);
+    assert_impl_all!(crate::process_mgmt::ConnectCallbackWrapper: Send);
+    assert_impl_all!(crate::process_mgmt::DisconnectCallbackWrapper: Send);
+    assert_impl_all!(crate::server::FenceNbCallbackWrapper: Send);
+
+    assert_not_impl_any!(crate::groups::GroupConstructCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::groups::GroupInviteCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::groups::GroupJoinCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::groups::GroupLeaveCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::groups::GroupDestructCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::process_mgmt::SpawnCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::process_mgmt::ConnectCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::process_mgmt::DisconnectCallbackWrapper: Sync);
+    assert_not_impl_any!(crate::server::FenceNbCallbackWrapper: Sync);
+
+    // `Receiver<T>` is movable but not shareable.  This locks the intended
+    // hop-off design without pretending that arbitrary `T` is thread-safe.
+    assert_impl_all!(crate::threading::CallbackChannel<u8>: Send);
+    assert_not_impl_any!(crate::threading::CallbackChannel<u8>: Sync);
+
+    // ── C-owned or raw-pointer-bearing values ─────────────────────────────
+    //
+    // These types either own PMIx memory, release C allocations in `Drop`,
+    // contain a borrowed/opaque C pointer, or contain a raw `pmix_value_t`
+    // whose active union arm controls ownership.  They must stay on the
+    // creating/application thread.  Convert their contents to Rust-owned
+    // data before sending callback results to another thread.
+    assert_not_impl_any!(crate::Info: Send);
+    assert_not_impl_any!(crate::Info: Sync);
+    assert_not_impl_any!(crate::InfoBuilder: Send);
+    assert_not_impl_any!(crate::InfoBuilder: Sync);
+    assert_not_impl_any!(crate::PmixPayload: Send);
+    assert_not_impl_any!(crate::PmixPayload: Sync);
+    assert_not_impl_any!(crate::PmixValueBuilder: Send);
+    assert_not_impl_any!(crate::PmixValueBuilder: Sync);
+    assert_not_impl_any!(crate::PmixOwnedValue: Send);
+    assert_not_impl_any!(crate::PmixOwnedValue: Sync);
+
+    assert_not_impl_any!(crate::data_ops::PmixPdata: Send);
+    assert_not_impl_any!(crate::data_ops::PmixPdata: Sync);
+    assert_not_impl_any!(crate::data_serialization::PmixByteObject: Send);
+    assert_not_impl_any!(crate::data_serialization::PmixByteObject: Sync);
+    assert_not_impl_any!(crate::data_serialization::PmixDataBuffer: Send);
+    assert_not_impl_any!(crate::data_serialization::PmixDataBuffer: Sync);
+    assert_not_impl_any!(crate::fabric::PmixFabric: Send);
+    assert_not_impl_any!(crate::fabric::PmixFabric: Sync);
+    assert_not_impl_any!(crate::fabric::PmixTopology: Send);
+    assert_not_impl_any!(crate::fabric::PmixTopology: Sync);
+    assert_not_impl_any!(crate::fabric::PmixCpuset: Send);
+    assert_not_impl_any!(crate::fabric::PmixCpuset: Sync);
+    assert_not_impl_any!(crate::fabric::DeviceDistances: Send);
+    assert_not_impl_any!(crate::fabric::DeviceDistances: Sync);
+    assert_not_impl_any!(crate::query_log::PmixQuery: Send);
+    assert_not_impl_any!(crate::query_log::PmixQuery: Sync);
+    assert_not_impl_any!(crate::query_log::QueryResults: Send);
+    assert_not_impl_any!(crate::query_log::QueryResults: Sync);
+    assert_not_impl_any!(crate::allocation::AllocationResults: Send);
+    assert_not_impl_any!(crate::allocation::AllocationResults: Sync);
+    assert_not_impl_any!(crate::allocation::JobControlResults: Send);
+    assert_not_impl_any!(crate::allocation::JobControlResults: Sync);
+    assert_not_impl_any!(crate::allocation::SessionControlResults: Send);
+    assert_not_impl_any!(crate::allocation::SessionControlResults: Sync);
+    assert_not_impl_any!(crate::monitoring::MonitorResults: Send);
+    assert_not_impl_any!(crate::monitoring::MonitorResults: Sync);
+    assert_not_impl_any!(crate::security::CredentialResults: Send);
+    assert_not_impl_any!(crate::security::CredentialResults: Sync);
+    assert_not_impl_any!(crate::security::ValidationResults: Send);
+    assert_not_impl_any!(crate::security::ValidationResults: Sync);
+    assert_not_impl_any!(crate::server::CollectInventoryResults: Send);
+    assert_not_impl_any!(crate::server::CollectInventoryResults: Sync);
 }

--- a/src/threading_assert.rs
+++ b/src/threading_assert.rs
@@ -1,10 +1,15 @@
-//! Compile-time `Send`/`Sync` matrix for the public PMIx API.
+//! Compile-time `Send`/`Sync` matrix for concrete public PMIx handles and values.
 //!
 //! This is intentionally centralized: when a public wrapper is added or its
 //! ownership model changes, add its intended auto-traits here.  The negative
 //! assertions are as important as the positive ones.  In particular, they
 //! prevent a raw-pointer-bearing wrapper from silently becoming movable or
 //! shareable after a representation change.
+//!
+//! The matrix covers concrete public values, handles, and callback carrier
+//! structs. Public callback traits declare their required `Send` bounds at
+//! their definitions; trait objects inherit those bounds and are governed by
+//! their explicit object-type bounds.
 //!
 //! See [THREADING.md](../THREADING.md), issue #50, and issue #66.
 

--- a/src/threading_assert.rs
+++ b/src/threading_assert.rs
@@ -55,6 +55,7 @@ mod asserts {
     assert_impl_all!(crate::PmixTimeval: Send, Sync);
     assert_impl_all!(crate::PmixEnvar: Send, Sync);
     assert_impl_all!(crate::InitOptions: Send, Sync);
+    assert_impl_all!(crate::groups::pmix_group_opt_t: Send, Sync);
 
     // Rust-owned wrappers and materialized results.  These do not retain a
     // PMIx allocation after construction.  `utility::PmixByteObject` is the
@@ -71,7 +72,7 @@ mod asserts {
 
     // ── Function pointers and callback carriers ───────────────────────────
     //
-    // A function pointer has no captured state.  Callback wrapper structs are
+    // A function pointer has no captured state. Callback wrapper structs are
     // movable because their trait objects require `Send`, but they are not
     // advertised as concurrently shareable (`Sync` is intentionally absent).
     assert_impl_all!(crate::events::EventHandlerRef: Send, Sync);
@@ -79,7 +80,6 @@ mod asserts {
     assert_impl_all!(crate::events::HandlerRegCbFn: Send, Sync);
     assert_impl_all!(crate::events::OpCbFn: Send, Sync);
     assert_impl_all!(crate::events::pmix_event_notification_cbfunc_fn_t: Send, Sync);
-    assert_impl_all!(crate::groups::pmix_group_opt_t: Send, Sync);
     assert_impl_all!(crate::process_mgmt::SpawnCallback: Send, Sync);
     assert_impl_all!(crate::groups::GroupConstructCallbackWrapper: Send);
     assert_impl_all!(crate::groups::GroupInviteCallbackWrapper: Send);


### PR DESCRIPTION
## Summary
- Add a centralized compile-time `Send`/`Sync` classification matrix for the public PMIx API.
- Document ownership, callback, session, identity, and thread-affinity rules in `THREADING.md`.
- Keep server and tool `PmixServerHandle` aliases clearly distinguished.

## Validation
- `cargo test --lib --no-default-features` — 1,753 passed, 0 failed, 29 ignored.
- `cargo check --all-targets --no-default-features` — passed.
- `cargo check --tests --no-default-features` — passed.
- `rustfmt --check src/threading_assert.rs` — passed.
- `git diff --check` — passed.

The full all-target test command reaches the existing `data_serialization_bench` target, which requires PMIx initialization for `PMIx_Data_load`; on an uninitialized process it returns `ErrInit` and the benchmark currently unwraps it. This is an existing benchmark/environment limitation, not a failure in the changed files.

Closes #66

Pushed commit: `68b3acf79ddd275eca74ad48c44d9d153bb2b8e0`