### PR TITLE
feat(fabric): add safe PmixGeometry wrapper (PMIx_Geometry_construct)

### DIFF
--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -732,6 +732,64 @@ impl Drop for PmixTopology {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// PmixGeometry — safe wrapper for pmix_geometry_t
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A safe Rust wrapper around `pmix_geometry_t`.
+#[derive(Debug)]
+pub struct PmixGeometry {
+    raw: std::mem::MaybeUninit<ffi::pmix_geometry_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixGeometry {
+    /// Construct an empty geometry object using PMIx.
+    pub fn new() -> Self {
+        let mut this = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        let raw_ptr = this.raw.as_mut_ptr();
+        // SAFETY: raw_ptr points to storage owned by this; PMIx initializes the complete object.
+        #[cfg(any(test, feature = "mock_ffi"))]
+        { if mock_ffi::is_mock_enabled() { mock_ffi::mock_geometry_construct(raw_ptr); } else { unsafe { ffi::PMIx_Geometry_construct(raw_ptr) }; } }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        { unsafe { ffi::PMIx_Geometry_construct(raw_ptr) }; }
+        this.constructed = true;
+        this
+    }
+
+    /// Create an empty geometry object without calling into PMIx.
+    pub fn test_new() -> Self { Self { raw: std::mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
+
+    /// Return the fabric identifier.
+    pub fn fabric(&self) -> usize { unsafe { self.raw.assume_init_ref().fabric } }
+    /// Return the geometry UUID, if present and valid UTF-8.
+    pub fn uuid(&self) -> Option<&str> { self.c_string(|raw| raw.uuid) }
+    /// Return the operating-system device name, if present and valid UTF-8.
+    pub fn osname(&self) -> Option<&str> { self.c_string(|raw| raw.osname) }
+    /// Return the number of coordinate entries.
+    pub fn ncoords(&self) -> usize { unsafe { self.raw.assume_init_ref().ncoords } }
+    /// Return the raw coordinate array, when PMIx supplied one.
+    pub fn coordinates(&self) -> Option<&[ffi::pmix_coord_t]> {
+        unsafe { let raw = self.raw.assume_init_ref(); (!raw.coordinates.is_null()).then(|| std::slice::from_raw_parts(raw.coordinates, raw.ncoords)) }
+    }
+    fn c_string(&self, get: impl FnOnce(&ffi::pmix_geometry_t) -> *mut libc::c_char) -> Option<&str> {
+        unsafe { let ptr = get(self.raw.assume_init_ref()); (!ptr.is_null()).then(|| std::ffi::CStr::from_ptr(ptr).to_str().ok()).flatten() }
+    }
+}
+impl Default for PmixGeometry { fn default() -> Self { Self::new() } }
+impl Drop for PmixGeometry {
+    fn drop(&mut self) {
+        if self.constructed {
+            // SAFETY: the object was initialized by the matching constructor and is destroyed once.
+            #[cfg(any(test, feature = "mock_ffi"))]
+            { if mock_ffi::is_mock_enabled() { mock_ffi::mock_geometry_destruct(self.raw.as_mut_ptr()); } else { unsafe { ffi::PMIx_Geometry_destruct(self.raw.as_mut_ptr()) }; } }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            { unsafe { ffi::PMIx_Geometry_destruct(self.raw.as_mut_ptr()) }; }
+            self.constructed = false;
+        }
+    }
+}
+
 // PmixCpuset — safe wrapper for pmix_cpuset_t
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -2319,6 +2377,26 @@ mod tests {
         let mut cpuset = PmixCpuset::new();
         let _ptr = cpuset.as_mut_ptr();
         // Should not panic — mock construct succeeded
+    }
+
+    #[test]
+    fn test_geometry_construct_and_accessors_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let geometry = PmixGeometry::new();
+        assert_eq!(geometry.fabric(), 0);
+        assert!(geometry.uuid().is_none());
+        assert!(geometry.osname().is_none());
+        assert_eq!(geometry.ncoords(), 0);
+        assert!(geometry.coordinates().is_none());
+    }
+
+    #[test]
+    fn test_geometry_test_new_drop_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let geometry = PmixGeometry::test_new();
+        assert_eq!(geometry.fabric(), 0);
+        assert_eq!(geometry.ncoords(), 0);
+        drop(geometry);
     }
 
     #[test]

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -746,34 +746,77 @@ pub struct PmixGeometry {
 impl PmixGeometry {
     /// Construct an empty geometry object using PMIx.
     pub fn new() -> Self {
-        let mut this = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        let mut this = Self {
+            raw: std::mem::MaybeUninit::uninit(),
+            constructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        };
         let raw_ptr = this.raw.as_mut_ptr();
         // SAFETY: raw_ptr points to storage owned by this; PMIx initializes the complete object.
         #[cfg(any(test, feature = "mock_ffi"))]
-        { if mock_ffi::is_mock_enabled() { mock_ffi::mock_geometry_construct(raw_ptr); } else { unsafe { ffi::PMIx_Geometry_construct(raw_ptr) }; } }
+        {
+            if mock_ffi::is_mock_enabled() {
+                mock_ffi::mock_geometry_construct(raw_ptr);
+            } else {
+                unsafe { ffi::PMIx_Geometry_construct(raw_ptr) };
+            }
+        }
         #[cfg(not(any(test, feature = "mock_ffi")))]
-        { unsafe { ffi::PMIx_Geometry_construct(raw_ptr) }; }
+        {
+            unsafe { ffi::PMIx_Geometry_construct(raw_ptr) };
+        }
         this.constructed = true;
         this
     }
 
     /// Create an empty geometry object without calling into PMIx.
-    pub fn test_new() -> Self { Self { raw: std::mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
+    pub fn test_new() -> Self {
+        Self {
+            raw: std::mem::MaybeUninit::zeroed(),
+            constructed: true,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
 
     /// Return the fabric identifier.
-    pub fn fabric(&self) -> usize { unsafe { self.raw.assume_init_ref().fabric } }
+    pub fn fabric(&self) -> usize {
+        // SAFETY: `self.raw` is initialized by `new` or `test_new`, and the returned
+        // value does not outlive the shared borrow of `self`.
+        unsafe { self.raw.assume_init_ref().fabric }
+    }
     /// Return the geometry UUID, if present and valid UTF-8.
-    pub fn uuid(&self) -> Option<&str> { self.c_string(|raw| raw.uuid) }
+    pub fn uuid(&self) -> Option<&str> {
+        self.c_string(|raw| raw.uuid)
+    }
     /// Return the operating-system device name, if present and valid UTF-8.
-    pub fn osname(&self) -> Option<&str> { self.c_string(|raw| raw.osname) }
+    pub fn osname(&self) -> Option<&str> {
+        self.c_string(|raw| raw.osname)
+    }
     /// Return the number of coordinate entries.
-    pub fn ncoords(&self) -> usize { unsafe { self.raw.assume_init_ref().ncoords } }
+    pub fn ncoords(&self) -> usize {
+        // SAFETY: `self.raw` is initialized by `new` or `test_new`, and the returned
+        // value does not outlive the shared borrow of `self`.
+        unsafe { self.raw.assume_init_ref().ncoords }
+    }
     /// Return the raw coordinate array, when PMIx supplied one.
     pub fn coordinates(&self) -> Option<&[ffi::pmix_coord_t]> {
-        unsafe { let raw = self.raw.assume_init_ref(); (!raw.coordinates.is_null()).then(|| std::slice::from_raw_parts(raw.coordinates, raw.ncoords)) }
+        // SAFETY: `self.raw` is initialized by `new` or `test_new`; the slice borrows
+        // `self` and therefore cannot outlive the PMIx-owned coordinate array.
+        unsafe {
+            let raw = self.raw.assume_init_ref();
+            (!raw.coordinates.is_null())
+                .then(|| std::slice::from_raw_parts(raw.coordinates, raw.ncoords))
+        }
     }
     fn c_string(&self, get: impl FnOnce(&ffi::pmix_geometry_t) -> *mut libc::c_char) -> Option<&str> {
-        unsafe { let ptr = get(self.raw.assume_init_ref()); (!ptr.is_null()).then(|| std::ffi::CStr::from_ptr(ptr).to_str().ok()).flatten() }
+        // SAFETY: `self.raw` is initialized by `new` or `test_new`; the returned string
+        // slice borrows `self` and therefore cannot outlive the PMIx-owned C string.
+        unsafe {
+            let ptr = get(self.raw.assume_init_ref());
+            (!ptr.is_null())
+                .then(|| std::ffi::CStr::from_ptr(ptr).to_str().ok())
+                .flatten()
+        }
     }
 }
 impl Default for PmixGeometry { fn default() -> Self { Self::new() } }
@@ -2388,6 +2431,40 @@ mod tests {
         assert!(geometry.osname().is_none());
         assert_eq!(geometry.ncoords(), 0);
         assert!(geometry.coordinates().is_none());
+    }
+
+    #[test]
+    fn test_geometry_non_null_accessors_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut geometry = PmixGeometry::test_new();
+        let uuid = CString::new("geometry-uuid").unwrap();
+        let osname = CString::new("gpu0").unwrap();
+        let mut coords = [
+            ffi::pmix_coord_t {
+                view: 0,
+                coord: ptr::null_mut(),
+                dims: 0,
+            },
+            ffi::pmix_coord_t {
+                view: 1,
+                coord: ptr::null_mut(),
+                dims: 0,
+            },
+        ];
+
+        unsafe {
+            let raw = geometry.raw.assume_init_mut();
+            raw.uuid = uuid.as_ptr() as *mut _;
+            raw.osname = osname.as_ptr() as *mut _;
+            raw.coordinates = coords.as_mut_ptr();
+            raw.ncoords = coords.len();
+        }
+
+        assert_eq!(geometry.uuid(), Some("geometry-uuid"));
+        assert_eq!(geometry.osname(), Some("gpu0"));
+        assert_eq!(geometry.ncoords(), 2);
+        assert_eq!(geometry.coordinates().unwrap().len(), 2);
+        assert_eq!(geometry.coordinates().unwrap()[1].view, 1);
     }
 
     #[test]

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1700,6 +1700,17 @@ pub fn mock_cpuset_destruct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
     // No-op in mock
 }
 
+/// Mock implementation of `PMIx_Geometry_construct()`.
+pub fn mock_geometry_construct(geometry: *mut crate::ffi::pmix_geometry_t) {
+    // SAFETY: callers provide valid writable storage for the C struct.
+    unsafe { std::ptr::write_bytes(geometry, 0, 1) };
+}
+
+/// Mock implementation of `PMIx_Geometry_destruct()`.
+pub fn mock_geometry_destruct(_geometry: *mut crate::ffi::pmix_geometry_t) {
+    // No-op in mock; the zeroed mock has no C-owned allocations.
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock query/log FFI implementations
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #363

## Summary
- Adds the safe `PmixGeometry` RAII wrapper with accessors, `Default`, and test construction support.
- Wraps `PMIx_Geometry_construct` and `PMIx_Geometry_destruct`; places the API in `src/fabric.rs` alongside related fabric/topology wrappers.
- Adds mock FFI construct/destruct implementations for daemon-free tests.

## Test plan
- Local mock-based geometry unit tests cover construction, accessors, and Drop/destruct pairing.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build`
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib fabric::tests::test_geometry -- --test-threads=1`
- Daemon/DVM tests are not added; those remain CI-only.
