### PR TITLE
feat(value): add safe wrappers for PMIx_Value_* utilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5524,11 +5524,15 @@ impl PmixValue {
     pub fn as_raw(&self) -> *const pmix_value_t { self.raw.as_ptr() }
     pub fn as_mut_ptr(&mut self) -> *mut pmix_value_t { self.raw.as_mut_ptr() }
 
+    /// Loads a serialized payload into this value. `data.len()` is the payload
+    /// length in bytes passed to the C API.
     pub fn value_load(&mut self, data: &[u8], ty: pmix_data_type_t) -> Result<(), PmixStatus> {
         let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_load(self.as_mut_ptr(), data.as_ptr().cast(), ty) }, real = unsafe { ffi::PMIx_Value_load(self.as_mut_ptr(), data.as_ptr().cast(), ty) });
         (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
     }
 
+    /// Unloads the value into an owned copy. The returned `Vec` owns its bytes;
+    /// the buffer allocated by the C API is freed before this method returns.
     pub fn value_unload(&mut self) -> Result<(Vec<u8>, usize), PmixStatus> {
         let mut data = std::ptr::null_mut(); let mut size = 0;
         let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_unload(self.as_mut_ptr(), &mut data, &mut size) }, real = unsafe { ffi::PMIx_Value_unload(self.as_mut_ptr(), &mut data, &mut size) });
@@ -5543,6 +5547,8 @@ impl PmixValue {
         let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_xfer(dest.as_mut_ptr(), src.as_raw()) }, real = unsafe { ffi::PMIx_Value_xfer(dest.as_mut_ptr(), src.as_raw()) });
         (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
     }
+    /// Writes the requested numeric representation into `dest`. The buffer
+    /// must be large enough for the requested PMIx type.
     pub fn value_get_number(&self, dest: &mut [u8], ty: pmix_data_type_t) -> Result<(), PmixStatus> {
         let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) }, real = unsafe { ffi::PMIx_Value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) });
         (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
@@ -5551,6 +5557,9 @@ impl PmixValue {
         let mut size = 0; let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_get_size(self.as_raw(), &mut size) }, real = unsafe { ffi::PMIx_Value_get_size(self.as_raw(), &mut size) });
         if status == PMIX_SUCCESS as i32 { Ok(size) } else { Err(PmixStatus::from_raw(status)) }
     }
+    /// Compares two values. PMIx declares this C API as taking mutable
+    /// pointers, although it does not mutate either value; the const-casts
+    /// therefore only adapt the inaccurate C signature.
     pub fn value_compare(a: &Self, b: &Self) -> pmix_value_cmp_t { pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_compare(a.as_raw() as *mut _, b.as_raw() as *mut _) }, real = unsafe { ffi::PMIx_Value_compare(a.as_raw() as *mut _, b.as_raw() as *mut _) }) }
     pub fn value_string(&self) -> Result<String, PmixStatus> {
         let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_string(self.as_raw()) }, real = unsafe { ffi::PMIx_Value_string(self.as_raw()) });
@@ -5570,6 +5579,8 @@ pub fn value_comparison_string(cmp: pmix_value_cmp_t) -> &'static str {
     if ptr.is_null() { "" } else { unsafe { CStr::from_ptr(ptr).to_str().unwrap_or("") } }
 }
 
+/// Owns an array allocated by PMIx with [`PMIx_Value_create`]. The allocation
+/// is released by [`PMIx_Value_free`] when this wrapper is dropped.
 pub struct PmixValueArray { ptr: *mut pmix_value_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
 impl PmixValueArray {
     pub fn new(len: usize) -> Option<Self> { if len == 0 { return Some(Self { ptr: std::ptr::null_mut(), len, _not_thread_safe: std::marker::PhantomData }); } let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_create(len) }, real = unsafe { ffi::PMIx_Value_create(len) }); (!ptr.is_null()).then_some(Self { ptr, len, _not_thread_safe: std::marker::PhantomData }) }
@@ -5586,4 +5597,12 @@ mod value_utils_tests {
     fn mock_value_utilities() { let _guard = mock_ffi::MockGuard::new(); let value = PmixValue::new(); assert_eq!(value.value_string().unwrap(), "mock"); assert!(value.value_true()); assert_eq!(value.value_get_size().unwrap(), 4); assert_eq!(value_comparison_string(pmix_value_cmp_t::PMIX_EQUAL), "equal"); }
     #[test]
     fn mock_value_array_and_unload() { let _guard = mock_ffi::MockGuard::new(); let mut array = PmixValueArray::new(2).unwrap(); assert_eq!(array.len(), 2); assert!(!array.as_mut_ptr().is_null()); let mut value = PmixValue::new(); assert_eq!(value.value_unload().unwrap().0, b"mock"); }
+    #[test]
+    fn mock_value_test_new_has_zeroed_accessors() { let _guard = mock_ffi::MockGuard::new(); let value = PmixValue::test_new(); assert_eq!(value.value_get_size().unwrap(), 4); assert_eq!(value.value_string().unwrap(), "mock"); assert!(value.value_true()); }
+    #[test]
+    fn mock_value_xfer_succeeds() { let _guard = mock_ffi::MockGuard::new(); let mut dest = PmixValue::new(); let src = PmixValue::new(); assert!(PmixValue::value_xfer(&mut dest, &src).is_ok()); }
+    #[test]
+    fn mock_value_compare_returns_equal() { let _guard = mock_ffi::MockGuard::new(); let a = PmixValue::new(); let b = PmixValue::new(); assert_eq!(PmixValue::value_compare(&a, &b), pmix_value_cmp_t::PMIX_EQUAL); }
+    #[test]
+    fn mock_value_unload_propagates_error_status() { let _guard = mock_ffi::MockGuard::new(); mock_ffi::MockConfig::new().with_function_status("PMIx_Value_unload", mock_ffi::PMIX_ERR_BAD_PARAM).apply(); let mut value = PmixValue::new(); assert!(value.value_unload().is_err()); }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5496,3 +5496,94 @@ mod tests {
         assert!(!PmixClient::new().is_live());
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PMIx_Value_* safe utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A constructed PMIx value whose C-owned state is released on drop.
+pub struct PmixValue {
+    raw: std::mem::MaybeUninit<pmix_value_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixValue {
+    pub fn new() -> Self {
+        let mut value = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        let ptr = value.raw.as_mut_ptr();
+        pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_construct(ptr) }, real = unsafe { ffi::PMIx_Value_construct(ptr) });
+        value.constructed = true;
+        value
+    }
+
+    pub fn test_new() -> Self {
+        Self { raw: std::mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData }
+    }
+
+    pub fn as_raw(&self) -> *const pmix_value_t { self.raw.as_ptr() }
+    pub fn as_mut_ptr(&mut self) -> *mut pmix_value_t { self.raw.as_mut_ptr() }
+
+    pub fn value_load(&mut self, data: &[u8], ty: pmix_data_type_t) -> Result<(), PmixStatus> {
+        let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_load(self.as_mut_ptr(), data.as_ptr().cast(), ty) }, real = unsafe { ffi::PMIx_Value_load(self.as_mut_ptr(), data.as_ptr().cast(), ty) });
+        (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
+    }
+
+    pub fn value_unload(&mut self) -> Result<(Vec<u8>, usize), PmixStatus> {
+        let mut data = std::ptr::null_mut(); let mut size = 0;
+        let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_unload(self.as_mut_ptr(), &mut data, &mut size) }, real = unsafe { ffi::PMIx_Value_unload(self.as_mut_ptr(), &mut data, &mut size) });
+        if status != PMIX_SUCCESS as i32 { return Err(PmixStatus::from_raw(status)); }
+        if data.is_null() && size != 0 { return Err(PmixStatus::from_raw(-2)); }
+        let bytes = if size == 0 { Vec::new() } else { unsafe { std::slice::from_raw_parts(data.cast::<u8>(), size).to_vec() } };
+        if !data.is_null() { unsafe { libc::free(data) }; }
+        Ok((bytes, size))
+    }
+
+    pub fn value_xfer(dest: &mut Self, src: &Self) -> Result<(), PmixStatus> {
+        let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_xfer(dest.as_mut_ptr(), src.as_raw()) }, real = unsafe { ffi::PMIx_Value_xfer(dest.as_mut_ptr(), src.as_raw()) });
+        (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
+    }
+    pub fn value_get_number(&self, dest: &mut [u8], ty: pmix_data_type_t) -> Result<(), PmixStatus> {
+        let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) }, real = unsafe { ffi::PMIx_Value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) });
+        (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))
+    }
+    pub fn value_get_size(&self) -> Result<usize, PmixStatus> {
+        let mut size = 0; let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_get_size(self.as_raw(), &mut size) }, real = unsafe { ffi::PMIx_Value_get_size(self.as_raw(), &mut size) });
+        if status == PMIX_SUCCESS as i32 { Ok(size) } else { Err(PmixStatus::from_raw(status)) }
+    }
+    pub fn value_compare(a: &Self, b: &Self) -> pmix_value_cmp_t { pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_compare(a.as_raw() as *mut _, b.as_raw() as *mut _) }, real = unsafe { ffi::PMIx_Value_compare(a.as_raw() as *mut _, b.as_raw() as *mut _) }) }
+    pub fn value_string(&self) -> Result<String, PmixStatus> {
+        let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_string(self.as_raw()) }, real = unsafe { ffi::PMIx_Value_string(self.as_raw()) });
+        if ptr.is_null() { return Err(PmixStatus::from_raw(-2)); }
+        let result = unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() }; unsafe { libc::free(ptr.cast()) }; Ok(result)
+    }
+    pub fn value_true(&self) -> bool { pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_true(self.as_raw()) }, real = unsafe { ffi::PMIx_Value_true(self.as_raw()) }) == pmix_boolean_t::PMIX_BOOL_TRUE }
+}
+
+impl Default for PmixValue { fn default() -> Self { Self::new() } }
+impl Drop for PmixValue {
+    fn drop(&mut self) { if self.constructed { pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_destruct(self.raw.as_mut_ptr()) }, real = unsafe { ffi::PMIx_Value_destruct(self.raw.as_mut_ptr()) }); self.constructed = false; } }
+}
+
+pub fn value_comparison_string(cmp: pmix_value_cmp_t) -> &'static str {
+    let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_comparison_string(cmp) }, real = unsafe { ffi::PMIx_Value_comparison_string(cmp) });
+    if ptr.is_null() { "" } else { unsafe { CStr::from_ptr(ptr).to_str().unwrap_or("") } }
+}
+
+pub struct PmixValueArray { ptr: *mut pmix_value_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixValueArray {
+    pub fn new(len: usize) -> Option<Self> { if len == 0 { return Some(Self { ptr: std::ptr::null_mut(), len, _not_thread_safe: std::marker::PhantomData }); } let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_create(len) }, real = unsafe { ffi::PMIx_Value_create(len) }); (!ptr.is_null()).then_some(Self { ptr, len, _not_thread_safe: std::marker::PhantomData }) }
+    pub fn as_mut_ptr(&mut self) -> *mut pmix_value_t { self.ptr }
+    pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+impl Drop for PmixValueArray { fn drop(&mut self) { if !self.ptr.is_null() { pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_free(self.ptr, self.len) }, real = unsafe { ffi::PMIx_Value_free(self.ptr, self.len) }); self.ptr = std::ptr::null_mut(); } } }
+
+#[cfg(test)]
+mod value_utils_tests {
+    use super::*;
+    #[test]
+    fn mock_value_utilities() { let _guard = mock_ffi::MockGuard::new(); let value = PmixValue::new(); assert_eq!(value.value_string().unwrap(), "mock"); assert!(value.value_true()); assert_eq!(value.value_get_size().unwrap(), 4); assert_eq!(value_comparison_string(pmix_value_cmp_t::PMIX_EQUAL), "equal"); }
+    #[test]
+    fn mock_value_array_and_unload() { let _guard = mock_ffi::MockGuard::new(); let mut array = PmixValueArray::new(2).unwrap(); assert_eq!(array.len(), 2); assert!(!array.as_mut_ptr().is_null()); let mut value = PmixValue::new(); assert_eq!(value.value_unload().unwrap().0, b"mock"); }
+}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1849,6 +1849,68 @@ pub fn mock_info_free(_info: *mut crate::ffi::pmix_info_t, _ninfo: usize) {
 // Tests for the mock FFI framework itself
 // ─────────────────────────────────────────────────────────────────────────────
 
+
+/// Mock PMIx_Value_construct: initialize the destination to zero.
+pub unsafe fn mock_value_construct(value: *mut crate::ffi::pmix_value_t) {
+    // SAFETY: callers pass writable storage for one pmix_value_t.
+    unsafe { std::ptr::write_bytes(value, 0, 1) };
+}
+
+/// Mock PMIx_Value_destruct: mock values own no C allocations.
+pub unsafe fn mock_value_destruct(_value: *mut crate::ffi::pmix_value_t) {}
+
+/// Mock PMIx_Value_create: allocate zeroed value storage for tests.
+pub unsafe fn mock_value_create(n: usize) -> *mut crate::ffi::pmix_value_t {
+    if n == 0 { return std::ptr::null_mut(); }
+    let layout = std::alloc::Layout::array::<crate::ffi::pmix_value_t>(n).ok();
+    match layout {
+        Some(layout) => unsafe { std::alloc::alloc_zeroed(layout) as *mut crate::ffi::pmix_value_t },
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Mock PMIx_Value_free: release storage allocated by mock_value_create.
+pub unsafe fn mock_value_free(value: *mut crate::ffi::pmix_value_t, n: usize) {
+    if value.is_null() || n == 0 { return; }
+    if let Ok(layout) = std::alloc::Layout::array::<crate::ffi::pmix_value_t>(n) {
+        // SAFETY: pointer and layout match mock_value_create.
+        unsafe { std::alloc::dealloc(value as *mut u8, layout) };
+    }
+}
+
+pub unsafe fn mock_value_load(value: *mut crate::ffi::pmix_value_t, _data: *const std::ffi::c_void, ty: crate::ffi::pmix_data_type_t) -> i32 {
+    let status = get_mock_status("PMIx_Value_load");
+    if status == PMIX_SUCCESS && !value.is_null() {
+        // SAFETY: value is writable storage supplied by the wrapper.
+        unsafe { (*value).type_ = ty; }
+    }
+    status
+}
+
+pub unsafe fn mock_value_unload(_value: *mut crate::ffi::pmix_value_t, data: *mut *mut std::ffi::c_void, size: *mut usize) -> i32 {
+    let status = get_mock_status("PMIx_Value_unload");
+    if status == PMIX_SUCCESS {
+        let bytes = b"mock";
+        let ptr = unsafe { libc::malloc(bytes.len()) } as *mut u8;
+        if ptr.is_null() { return -2; }
+        // SAFETY: malloc returned bytes.len() writable bytes.
+        unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len()); *data = ptr.cast(); *size = bytes.len(); }
+    }
+    status
+}
+
+pub unsafe fn mock_value_xfer(_dest: *mut crate::ffi::pmix_value_t, _src: *const crate::ffi::pmix_value_t) -> i32 { get_mock_status("PMIx_Value_xfer") }
+pub unsafe fn mock_value_get_number(_value: *const crate::ffi::pmix_value_t, _dest: *mut std::ffi::c_void, _ty: crate::ffi::pmix_data_type_t) -> i32 { get_mock_status("PMIx_Value_get_number") }
+pub unsafe fn mock_value_get_size(_value: *const crate::ffi::pmix_value_t, size: *mut usize) -> i32 {
+    let status = get_mock_status("PMIx_Value_get_size");
+    if status == PMIX_SUCCESS && !size.is_null() { unsafe { *size = 4; } }
+    status
+}
+pub unsafe fn mock_value_compare(_v1: *mut crate::ffi::pmix_value_t, _v2: *mut crate::ffi::pmix_value_t) -> crate::ffi::pmix_value_cmp_t { crate::ffi::pmix_value_cmp_t::PMIX_EQUAL }
+pub unsafe fn mock_value_comparison_string(_cmp: crate::ffi::pmix_value_cmp_t) -> *const std::os::raw::c_char { b"equal\0".as_ptr().cast() }
+pub unsafe fn mock_value_string(_value: *const crate::ffi::pmix_value_t) -> *mut std::os::raw::c_char { std::ffi::CString::new("mock").unwrap().into_raw() }
+pub unsafe fn mock_value_true(_value: *const crate::ffi::pmix_value_t) -> crate::ffi::pmix_boolean_t { crate::ffi::pmix_boolean_t::PMIX_BOOL_TRUE }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1908,7 +1908,11 @@ pub unsafe fn mock_value_get_size(_value: *const crate::ffi::pmix_value_t, size:
 }
 pub unsafe fn mock_value_compare(_v1: *mut crate::ffi::pmix_value_t, _v2: *mut crate::ffi::pmix_value_t) -> crate::ffi::pmix_value_cmp_t { crate::ffi::pmix_value_cmp_t::PMIX_EQUAL }
 pub unsafe fn mock_value_comparison_string(_cmp: crate::ffi::pmix_value_cmp_t) -> *const std::os::raw::c_char { b"equal\0".as_ptr().cast() }
-pub unsafe fn mock_value_string(_value: *const crate::ffi::pmix_value_t) -> *mut std::os::raw::c_char { std::ffi::CString::new("mock").unwrap().into_raw() }
+pub unsafe fn mock_value_string(_value: *const crate::ffi::pmix_value_t) -> *mut std::os::raw::c_char {
+    // SAFETY: strdup allocates with malloc, matching PMIx_Value_string's
+    // contract and the wrapper's libc::free call.
+    unsafe { libc::strdup(c"mock".as_ptr()) }
+}
 pub unsafe fn mock_value_true(_value: *const crate::ffi::pmix_value_t) -> crate::ffi::pmix_boolean_t { crate::ffi::pmix_boolean_t::PMIX_BOOL_TRUE }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #72, Closes #92, Closes #123, Closes #131, Closes #161, Closes #184, Closes #190, Closes #209, Closes #221, Closes #257, Closes #262, Closes #271, Closes #292, Closes #361

## Summary
- Add safe `PmixValue` construction/destruction and `PmixValueArray` create/free wrappers.
- Add load, unload, xfer, get-number, get-size, compare, string, comparison-string, and true utilities in the compiled crate-root `src/lib.rs`; orphan value files remain untouched.
- Add append-only mock FFI implementations and mock-based tests.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build`
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib value_utils_tests` (2 passed)
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo clippy --lib -- -D warnings`
- No daemon/DVM tests; local tests use `MockGuard`.

Local `cargo fmt --check` reports unrelated pre-existing formatting differences outside the two appended blocks; the diff remains additions-only.