### PR TITLE
feat(info): add safe PmixInfoList wrapper (PMIx_Info_list_*)

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -336,8 +336,8 @@ mod tests {
 /// Safe wrapper around a PMIx info linked list (`PMIx_Info_list_start`/Release).
 ///
 /// The list is owned by this value and is deliberately not transferable between
-/// threads. `iter` copies the raw entries returned by PMIx; it is intended for
-/// inspection and does not create owned `Info` values.
+/// threads. `iter` copies raw entries returned by PMIx; those snapshots borrow
+/// PMIx-owned nested storage and must not be used after this list is released.
 #[derive(Debug)]
 pub struct PmixInfoList {
     handle: std::ptr::NonNull<std::ffi::c_void>,
@@ -347,25 +347,23 @@ pub struct PmixInfoList {
 impl PmixInfoList {
     /// Start an empty PMIx info list.
     pub fn new() -> Result<Self, crate::PmixError> {
+        // SAFETY: PMIx creates and returns an opaque list handle; the null result
+        // is checked before constructing NonNull.
         let handle = crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_start() },
             real = unsafe { crate::ffi::PMIx_Info_list_start() },
         );
         std::ptr::NonNull::new(handle)
-            .map(|handle| Self {
-                handle,
-                _not_thread_safe: std::marker::PhantomData,
-            })
+            .map(|handle| Self { handle, _not_thread_safe: std::marker::PhantomData })
             .ok_or(crate::PmixError::ErrNomem)
     }
 
     /// Return the opaque PMIx list handle for FFI escape hatches.
-    pub fn as_ptr(&self) -> *mut std::ffi::c_void {
-        self.handle.as_ptr()
-    }
+    pub fn as_ptr(&self) -> *mut std::ffi::c_void { self.handle.as_ptr() }
 
     /// Number of entries in the list.
     pub fn len(&self) -> usize {
+        // SAFETY: self.handle is a live handle owned by self.
         crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_get_size(self.as_ptr()) },
             real = unsafe { crate::ffi::PMIx_Info_list_get_size(self.as_ptr()) },
@@ -373,245 +371,153 @@ impl PmixInfoList {
     }
 
     /// Return whether the list has no entries.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 
-    /// Copy the current entries into raw snapshots. PMIx remains responsible
-    /// for any nested allocations in the copied C structs.
+    /// Copy current entries into raw snapshots.
+    ///
+    /// PMIx returns its sentinel rather than NULL for an empty real list, so
+    /// checking `len` first is required to avoid traversing that sentinel.
+    /// Nested pointers in the snapshots remain valid only while PMIx owns them.
     pub fn iter(&self) -> Vec<crate::ffi::pmix_info_t> {
+        if self.is_empty() {
+            return Vec::new();
+        }
         let mut result = Vec::new();
         let mut previous = std::ptr::null_mut();
         loop {
             let mut next = std::ptr::null_mut();
+            // SAFETY: self is live; PMIx writes next and returns an entry owned by
+            // the list, which is copied immediately below.
             let info = crate::pmix_ffi_or_mock!(
-                mock = unsafe {
-                    crate::mock_ffi::mock_info_list_get_info(self.as_ptr(), previous, &mut next)
-                },
-                real = unsafe {
-                    crate::ffi::PMIx_Info_list_get_info(self.as_ptr(), previous, &mut next)
-                },
+                mock = unsafe { crate::mock_ffi::mock_info_list_get_info(self.as_ptr(), previous, &mut next) },
+                real = unsafe { crate::ffi::PMIx_Info_list_get_info(self.as_ptr(), previous, &mut next) },
             );
-            if info.is_null() {
-                break;
-            }
+            if info.is_null() { break; }
+            // SAFETY: PMIx returned a non-null pointer to an initialized entry.
             result.push(unsafe { info.read() });
-            if next.is_null() || next == previous {
-                break;
-            }
+            if next.is_null() || next == previous { break; }
             previous = next;
         }
         result
     }
 
     fn status(status: crate::ffi::pmix_status_t) -> Result<(), crate::PmixStatus> {
-        let raw = status;
-        if raw == crate::ffi::PMIX_SUCCESS as i32 {
-            Ok(())
-        } else {
-            Err(crate::PmixStatus::from_raw(raw))
-        }
+        if status == crate::ffi::PMIX_SUCCESS as i32 { Ok(()) } else { Err(crate::PmixStatus::from_raw(status)) }
     }
 
     fn key(key: &str) -> Result<std::ffi::CString, crate::PmixStatus> {
-        std::ffi::CString::new(key).map_err(|_| crate::PmixStatus::from_raw(-27))
+        std::ffi::CString::new(key).map_err(|_| crate::PmixStatus::from_raw(crate::PmixError::ErrBadParam as i32))
     }
 
-    /// Add a value represented by bytes and a PMIx data type.
-    pub fn add<V: AsRef<[u8]>>(
-        &mut self,
-        key: &str,
-        value: V,
-        ty: crate::ffi::pmix_data_type_t,
-    ) -> Result<(), crate::PmixStatus> {
-        let key = Self::key(key)?;
-        let value = value.as_ref();
-        let status = crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_add(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                )
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_add(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                )
-            },
-        );
-        Self::status(status)
+    fn raw_value(value: &[u8]) -> Result<*const std::ffi::c_void, crate::PmixStatus> {
+        if value.is_empty() { return Err(crate::PmixStatus::from_raw(crate::PmixError::ErrBadParam as i32)); }
+        Ok(value.as_ptr().cast())
     }
 
-    /// Add a value, optionally overwriting an existing key.
-    pub fn add_unique<V: AsRef<[u8]>>(
-        &mut self,
-        key: &str,
-        value: V,
-        ty: crate::ffi::pmix_data_type_t,
-        overwrite: bool,
-    ) -> Result<(), crate::PmixStatus> {
-        let key = Self::key(key)?;
-        let value = value.as_ref();
-        let status = crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_add_unique(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                    overwrite,
-                )
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_add_unique(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                    overwrite,
-                )
-            },
-        );
-        Self::status(status)
+    /// Add raw wire bytes. The slice must be non-empty; string bytes must be
+    /// NUL-terminated, and byte-object bytes must use PMIx's wire format.
+    pub fn add<V: AsRef<[u8]>>(&mut self, key: &str, value: V, ty: crate::ffi::pmix_data_type_t) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?; let value = Self::raw_value(value.as_ref())?;
+        // SAFETY: key and value remain alive and valid for the synchronous call;
+        // the PMIx list API consumes one typed value from these pointers.
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_add(self.as_ptr(), key.as_ptr(), value, ty) },
+            real = unsafe { crate::ffi::PMIx_Info_list_add(self.as_ptr(), key.as_ptr(), value, ty) },
+        ))
+    }
+
+    /// Add raw wire bytes, optionally overwriting an existing key. See [`Self::add`]
+    /// for the non-empty and string/byte-object representation requirements.
+    pub fn add_unique<V: AsRef<[u8]>>(&mut self, key: &str, value: V, ty: crate::ffi::pmix_data_type_t, overwrite: bool) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?; let value = Self::raw_value(value.as_ref())?;
+        // SAFETY: pointers reference live arguments for the synchronous FFI call.
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_add_unique(self.as_ptr(), key.as_ptr(), value, ty, overwrite) },
+            real = unsafe { crate::ffi::PMIx_Info_list_add_unique(self.as_ptr(), key.as_ptr(), value, ty, overwrite) },
+        ))
     }
 
     /// Add an owned PMIx value.
-    pub fn add_value(
-        &mut self,
-        key: &str,
-        value: &crate::PmixOwnedValue,
-    ) -> Result<(), crate::PmixStatus> {
+    pub fn add_value(&mut self, key: &str, value: &crate::PmixOwnedValue) -> Result<(), crate::PmixStatus> {
         let key = Self::key(key)?;
-        let status = crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_add_value(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_raw(),
-                )
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_add_value(self.as_ptr(), key.as_ptr(), value.as_raw())
-            },
-        );
-        Self::status(status)
+        // SAFETY: list, key, and value are valid for this synchronous call.
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_add_value(self.as_ptr(), key.as_ptr(), value.as_raw()) },
+            real = unsafe { crate::ffi::PMIx_Info_list_add_value(self.as_ptr(), key.as_ptr(), value.as_raw()) },
+        ))
     }
 
     /// Add an owned PMIx value, optionally overwriting an existing key.
-    pub fn add_value_unique(
-        &mut self,
-        key: &str,
-        value: &crate::PmixOwnedValue,
-        overwrite: bool,
-    ) -> Result<(), crate::PmixStatus> {
+    pub fn add_value_unique(&mut self, key: &str, value: &crate::PmixOwnedValue, overwrite: bool) -> Result<(), crate::PmixStatus> {
         let key = Self::key(key)?;
-        let status = crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_add_value_unique(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_raw(),
-                    overwrite,
-                )
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_add_value_unique(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_raw(),
-                    overwrite,
-                )
-            },
-        );
-        Self::status(status)
-    }
-
-    /// Add a value at the front of the list.
-    pub fn prepend<V: AsRef<[u8]>>(
-        &mut self,
-        key: &str,
-        value: V,
-        ty: crate::ffi::pmix_data_type_t,
-    ) -> Result<(), crate::PmixStatus> {
-        let key = Self::key(key)?;
-        let value = value.as_ref();
-        let status = crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_prepend(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                )
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_prepend(
-                    self.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr().cast(),
-                    ty,
-                )
-            },
-        );
-        Self::status(status)
-    }
-
-    /// Insert an individually constructed info entry.
-    pub fn insert(&mut self, info: &mut PmixInfo) -> Result<(), crate::PmixStatus> {
+        // SAFETY: list, key, and value are valid for this synchronous call.
         Self::status(crate::pmix_ffi_or_mock!(
-            mock =
-                unsafe { crate::mock_ffi::mock_info_list_insert(self.as_ptr(), info.as_mut_ptr()) },
+            mock = unsafe { crate::mock_ffi::mock_info_list_add_value_unique(self.as_ptr(), key.as_ptr(), value.as_raw(), overwrite) },
+            real = unsafe { crate::ffi::PMIx_Info_list_add_value_unique(self.as_ptr(), key.as_ptr(), value.as_raw(), overwrite) },
+        ))
+    }
+
+    /// Prepend non-empty raw wire bytes; strings must be NUL-terminated.
+    pub fn prepend<V: AsRef<[u8]>>(&mut self, key: &str, value: V, ty: crate::ffi::pmix_data_type_t) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?; let value = Self::raw_value(value.as_ref())?;
+        // SAFETY: pointers reference live arguments for the synchronous FFI call.
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_prepend(self.as_ptr(), key.as_ptr(), value, ty) },
+            real = unsafe { crate::ffi::PMIx_Info_list_prepend(self.as_ptr(), key.as_ptr(), value, ty) },
+        ))
+    }
+
+    /// Insert one entry. PMIx copies the struct but not its pointed-to values;
+    /// keep `info` alive and unchanged until this list is released.
+    pub fn insert(&mut self, info: &mut PmixInfo) -> Result<(), crate::PmixStatus> {
+        // SAFETY: both handles are valid and info remains borrowed for the call.
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_insert(self.as_ptr(), info.as_mut_ptr()) },
             real = unsafe { crate::ffi::PMIx_Info_list_insert(self.as_ptr(), info.as_mut_ptr()) },
         ))
     }
 
-    /// Transfer an info array into the list.
-    pub fn xfer(&mut self, info: &Info) -> Result<(), crate::PmixStatus> {
+    /// Transfer exactly one `pmix_info_t` entry into the list.
+    pub fn xfer(&mut self, info: &PmixInfo) -> Result<(), crate::PmixStatus> {
+        // SAFETY: both handles are valid for this synchronous single-entry copy.
         Self::status(crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_xfer(self.as_ptr(), info.as_ptr()) },
             real = unsafe { crate::ffi::PMIx_Info_list_xfer(self.as_ptr(), info.as_ptr()) },
         ))
     }
 
-    /// Transfer an info array, optionally overwriting duplicate keys.
-    pub fn xfer_unique(&mut self, info: &Info, overwrite: bool) -> Result<(), crate::PmixStatus> {
+    /// Transfer exactly one `pmix_info_t`, optionally overwriting duplicates.
+    pub fn xfer_unique(&mut self, info: &PmixInfo, overwrite: bool) -> Result<(), crate::PmixStatus> {
+        // SAFETY: both handles are valid for this synchronous single-entry copy.
         Self::status(crate::pmix_ffi_or_mock!(
-            mock = unsafe {
-                crate::mock_ffi::mock_info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite)
-            },
-            real = unsafe {
-                crate::ffi::PMIx_Info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite)
-            },
+            mock = unsafe { crate::mock_ffi::mock_info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite) },
+            real = unsafe { crate::ffi::PMIx_Info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite) },
         ))
     }
 
-    /// Convert the list to a PMIx data array. The returned raw array is owned
-    /// by the caller according to PMIx's `pmix_data_array_t` ownership rules.
-    pub fn convert(&mut self) -> Result<crate::ffi::pmix_data_array_t, crate::PmixStatus> {
+    /// Convert the list without mutating it. An empty list returns
+    /// `PMIX_ERR_EMPTY`; on success the caller owns the returned array and must
+    /// release it with `PMIx_Data_array_destruct`.
+    pub fn convert(&self) -> Result<crate::ffi::pmix_data_array_t, crate::PmixStatus> {
+        // SAFETY: zeroed is a valid initial output value for PMIx to populate.
         let mut array = unsafe { std::mem::zeroed() };
+        // SAFETY: self and output pointer are valid for the synchronous call.
         Self::status(crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_convert(self.as_ptr(), &mut array) },
             real = unsafe { crate::ffi::PMIx_Info_list_convert(self.as_ptr(), &mut array) },
-        ))
-        .map(|()| array)
+        )).map(|()| array)
     }
 }
 
 impl Drop for PmixInfoList {
     fn drop(&mut self) {
+        // SAFETY: handle was returned by PMIx_Info_list_start and is released once.
         crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_release(self.as_ptr()) },
             real = unsafe { crate::ffi::PMIx_Info_list_release(self.as_ptr()) },
         );
     }
 }
-
-
 
 #[cfg(test)]
 mod info_list_tests {
@@ -623,25 +529,31 @@ mod info_list_tests {
         let mut list = PmixInfoList::new().expect("mock list");
         assert!(!list.as_ptr().is_null());
         assert_eq!(list.len(), 0);
-        assert!(
-            list.add("key", [1_u8, 2], crate::ffi::PMIX_BYTE as _)
-                .is_ok()
-        );
-        assert!(
-            list.add_unique("key", [1_u8], crate::ffi::PMIX_BYTE as _, true)
-                .is_ok()
-        );
-        assert!(
-            list.prepend("key", [1_u8], crate::ffi::PMIX_BYTE as _)
-                .is_ok()
-        );
+        assert!(list.add("key", [1_u8, 2], crate::ffi::PMIX_BYTE as _).is_ok());
+        assert!(list.add_unique("key", [1_u8], crate::ffi::PMIX_BYTE as _, true).is_ok());
+        assert!(list.prepend("key", [1_u8], crate::ffi::PMIX_BYTE as _).is_ok());
+        assert!(list.add("key", [], crate::ffi::PMIX_BYTE as _).is_err());
         let value = crate::PmixValueBuilder::new().uint32(7).build().unwrap();
         assert!(list.add_value("key", &value).is_ok());
         assert!(list.add_value_unique("key", &value, true).is_ok());
-        assert!(list.xfer(&empty()).is_ok());
-        assert!(list.xfer_unique(&empty(), true).is_ok());
-        assert!(list.insert(&mut PmixInfo::new()).is_ok());
+        assert!(list.xfer(&PmixInfo::new()).is_ok());
+        assert!(list.xfer_unique(&PmixInfo::new(), true).is_ok());
+        let mut info = PmixInfo::new();
+        assert!(list.insert(&mut info).is_ok());
         assert!(list.iter().is_empty());
-        assert!(list.convert().is_ok());
+        crate::mock_ffi::set_mock_info_list_size(1);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.iter().len(), 1);
+        crate::mock_ffi::set_mock_info_list_size(0);
+    }
+
+    #[test]
+    fn mock_info_list_status_errors_and_empty_convert() {
+        let _guard = crate::mock_ffi::MockGuard::with_config(crate::mock_ffi::MockConfig::new()
+            .with_function_status("PMIx_Info_list_add", crate::mock_ffi::PMIX_ERR_BAD_PARAM)
+            .with_function_status("PMIx_Info_list_convert", crate::mock_ffi::PMIX_ERR_EMPTY));
+        let mut list = PmixInfoList::new().unwrap();
+        assert!(list.add("key", [1_u8], crate::ffi::PMIX_BYTE as _).is_err());
+        assert!(list.convert().is_err());
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -332,3 +332,316 @@ mod tests {
         assert!(info.get_size().is_err());
     }
 }
+
+/// Safe wrapper around a PMIx info linked list (`PMIx_Info_list_start`/Release).
+///
+/// The list is owned by this value and is deliberately not transferable between
+/// threads. `iter` copies the raw entries returned by PMIx; it is intended for
+/// inspection and does not create owned `Info` values.
+#[derive(Debug)]
+pub struct PmixInfoList {
+    handle: std::ptr::NonNull<std::ffi::c_void>,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixInfoList {
+    /// Start an empty PMIx info list.
+    pub fn new() -> Result<Self, crate::PmixError> {
+        let handle = crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_start() },
+            real = unsafe { crate::ffi::PMIx_Info_list_start() },
+        );
+        std::ptr::NonNull::new(handle)
+            .map(|handle| Self {
+                handle,
+                _not_thread_safe: std::marker::PhantomData,
+            })
+            .ok_or(crate::PmixError::ErrNomem)
+    }
+
+    /// Return the opaque PMIx list handle for FFI escape hatches.
+    pub fn as_ptr(&self) -> *mut std::ffi::c_void {
+        self.handle.as_ptr()
+    }
+
+    /// Number of entries in the list.
+    pub fn len(&self) -> usize {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_get_size(self.as_ptr()) },
+            real = unsafe { crate::ffi::PMIx_Info_list_get_size(self.as_ptr()) },
+        )
+    }
+
+    /// Return whether the list has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Copy the current entries into raw snapshots. PMIx remains responsible
+    /// for any nested allocations in the copied C structs.
+    pub fn iter(&self) -> Vec<crate::ffi::pmix_info_t> {
+        let mut result = Vec::new();
+        let mut previous = std::ptr::null_mut();
+        loop {
+            let mut next = std::ptr::null_mut();
+            let info = crate::pmix_ffi_or_mock!(
+                mock = unsafe {
+                    crate::mock_ffi::mock_info_list_get_info(self.as_ptr(), previous, &mut next)
+                },
+                real = unsafe {
+                    crate::ffi::PMIx_Info_list_get_info(self.as_ptr(), previous, &mut next)
+                },
+            );
+            if info.is_null() {
+                break;
+            }
+            result.push(unsafe { info.read() });
+            if next.is_null() || next == previous {
+                break;
+            }
+            previous = next;
+        }
+        result
+    }
+
+    fn status(status: crate::ffi::pmix_status_t) -> Result<(), crate::PmixStatus> {
+        let raw = status;
+        if raw == crate::ffi::PMIX_SUCCESS as i32 {
+            Ok(())
+        } else {
+            Err(crate::PmixStatus::from_raw(raw))
+        }
+    }
+
+    fn key(key: &str) -> Result<std::ffi::CString, crate::PmixStatus> {
+        std::ffi::CString::new(key).map_err(|_| crate::PmixStatus::from_raw(-27))
+    }
+
+    /// Add a value represented by bytes and a PMIx data type.
+    pub fn add<V: AsRef<[u8]>>(
+        &mut self,
+        key: &str,
+        value: V,
+        ty: crate::ffi::pmix_data_type_t,
+    ) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?;
+        let value = value.as_ref();
+        let status = crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_add(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                )
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_add(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                )
+            },
+        );
+        Self::status(status)
+    }
+
+    /// Add a value, optionally overwriting an existing key.
+    pub fn add_unique<V: AsRef<[u8]>>(
+        &mut self,
+        key: &str,
+        value: V,
+        ty: crate::ffi::pmix_data_type_t,
+        overwrite: bool,
+    ) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?;
+        let value = value.as_ref();
+        let status = crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_add_unique(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                    overwrite,
+                )
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_add_unique(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                    overwrite,
+                )
+            },
+        );
+        Self::status(status)
+    }
+
+    /// Add an owned PMIx value.
+    pub fn add_value(
+        &mut self,
+        key: &str,
+        value: &crate::PmixOwnedValue,
+    ) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?;
+        let status = crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_add_value(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_raw(),
+                )
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_add_value(self.as_ptr(), key.as_ptr(), value.as_raw())
+            },
+        );
+        Self::status(status)
+    }
+
+    /// Add an owned PMIx value, optionally overwriting an existing key.
+    pub fn add_value_unique(
+        &mut self,
+        key: &str,
+        value: &crate::PmixOwnedValue,
+        overwrite: bool,
+    ) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?;
+        let status = crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_add_value_unique(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_raw(),
+                    overwrite,
+                )
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_add_value_unique(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_raw(),
+                    overwrite,
+                )
+            },
+        );
+        Self::status(status)
+    }
+
+    /// Add a value at the front of the list.
+    pub fn prepend<V: AsRef<[u8]>>(
+        &mut self,
+        key: &str,
+        value: V,
+        ty: crate::ffi::pmix_data_type_t,
+    ) -> Result<(), crate::PmixStatus> {
+        let key = Self::key(key)?;
+        let value = value.as_ref();
+        let status = crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_prepend(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                )
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_prepend(
+                    self.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr().cast(),
+                    ty,
+                )
+            },
+        );
+        Self::status(status)
+    }
+
+    /// Insert an individually constructed info entry.
+    pub fn insert(&mut self, info: &mut PmixInfo) -> Result<(), crate::PmixStatus> {
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock =
+                unsafe { crate::mock_ffi::mock_info_list_insert(self.as_ptr(), info.as_mut_ptr()) },
+            real = unsafe { crate::ffi::PMIx_Info_list_insert(self.as_ptr(), info.as_mut_ptr()) },
+        ))
+    }
+
+    /// Transfer an info array into the list.
+    pub fn xfer(&mut self, info: &Info) -> Result<(), crate::PmixStatus> {
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_xfer(self.as_ptr(), info.as_ptr()) },
+            real = unsafe { crate::ffi::PMIx_Info_list_xfer(self.as_ptr(), info.as_ptr()) },
+        ))
+    }
+
+    /// Transfer an info array, optionally overwriting duplicate keys.
+    pub fn xfer_unique(&mut self, info: &Info, overwrite: bool) -> Result<(), crate::PmixStatus> {
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe {
+                crate::mock_ffi::mock_info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite)
+            },
+            real = unsafe {
+                crate::ffi::PMIx_Info_list_xfer_unique(self.as_ptr(), info.as_ptr(), overwrite)
+            },
+        ))
+    }
+
+    /// Convert the list to a PMIx data array. The returned raw array is owned
+    /// by the caller according to PMIx's `pmix_data_array_t` ownership rules.
+    pub fn convert(&mut self) -> Result<crate::ffi::pmix_data_array_t, crate::PmixStatus> {
+        let mut array = unsafe { std::mem::zeroed() };
+        Self::status(crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_convert(self.as_ptr(), &mut array) },
+            real = unsafe { crate::ffi::PMIx_Info_list_convert(self.as_ptr(), &mut array) },
+        ))
+        .map(|()| array)
+    }
+}
+
+impl Drop for PmixInfoList {
+    fn drop(&mut self) {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_info_list_release(self.as_ptr()) },
+            real = unsafe { crate::ffi::PMIx_Info_list_release(self.as_ptr()) },
+        );
+    }
+}
+
+
+
+#[cfg(test)]
+mod info_list_tests {
+    use super::*;
+
+    #[test]
+    fn mock_info_list_lifecycle_and_success_paths() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let mut list = PmixInfoList::new().expect("mock list");
+        assert!(!list.as_ptr().is_null());
+        assert_eq!(list.len(), 0);
+        assert!(
+            list.add("key", [1_u8, 2], crate::ffi::PMIX_BYTE as _)
+                .is_ok()
+        );
+        assert!(
+            list.add_unique("key", [1_u8], crate::ffi::PMIX_BYTE as _, true)
+                .is_ok()
+        );
+        assert!(
+            list.prepend("key", [1_u8], crate::ffi::PMIX_BYTE as _)
+                .is_ok()
+        );
+        let value = crate::PmixValueBuilder::new().uint32(7).build().unwrap();
+        assert!(list.add_value("key", &value).is_ok());
+        assert!(list.add_value_unique("key", &value, true).is_ok());
+        assert!(list.xfer(&empty()).is_ok());
+        assert!(list.xfer_unique(&empty(), true).is_ok());
+        assert!(list.insert(&mut PmixInfo::new()).is_ok());
+        assert!(list.iter().is_empty());
+        assert!(list.convert().is_ok());
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -541,10 +541,16 @@ mod info_list_tests {
         let mut info = PmixInfo::new();
         assert!(list.insert(&mut info).is_ok());
         assert!(list.iter().is_empty());
+        struct MockInfoListSizeGuard;
+        impl Drop for MockInfoListSizeGuard {
+            fn drop(&mut self) {
+                crate::mock_ffi::set_mock_info_list_size(0);
+            }
+        }
+        let _size_guard = MockInfoListSizeGuard;
         crate::mock_ffi::set_mock_info_list_size(1);
         assert_eq!(list.len(), 1);
         assert_eq!(list.iter().len(), 1);
-        crate::mock_ffi::set_mock_info_list_size(0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5606,3 +5606,6 @@ mod value_utils_tests {
     #[test]
     fn mock_value_unload_propagates_error_status() { let _guard = mock_ffi::MockGuard::new(); mock_ffi::MockConfig::new().with_function_status("PMIx_Value_unload", mock_ffi::PMIX_ERR_BAD_PARAM).apply(); let mut value = PmixValue::new(); assert!(value.value_unload().is_err()); }
 }
+
+/// Safe wrapper around an opaque PMIx info linked list.
+pub use info::PmixInfoList;

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -193,6 +193,7 @@ pub fn get_mock_status(func_name: &str) -> i32 {
 pub const PMIX_SUCCESS: i32 = 0;
 /// PMIX_ERR_INIT (-31) — not initialized
 pub const PMIX_ERR_INIT: i32 = -31;
+pub const PMIX_ERR_EMPTY: i32 = -60;
 /// PMIX_ERR_NOT_FOUND (-46)
 pub const PMIX_ERR_NOT_FOUND: i32 = -46;
 /// PMIX_ERR_TIMEOUT (-24)
@@ -3227,15 +3228,41 @@ pub unsafe fn mock_info_list_start() -> *mut std::ffi::c_void {
     1usize as *mut std::ffi::c_void
 }
 pub unsafe fn mock_info_list_release(_ptr: *mut std::ffi::c_void) {}
+
+thread_local! {
+    static MOCK_INFO_LIST_SIZE: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static MOCK_INFO_LIST_ENTRY: std::cell::RefCell<crate::ffi::pmix_info_t> =
+        std::cell::RefCell::new(unsafe { std::mem::zeroed() });
+}
+
+/// Configure the number of entries exposed by the next info-list traversal.
+/// A size greater than zero exposes one initialized mock entry for traversal.
+pub fn set_mock_info_list_size(size: usize) {
+    MOCK_INFO_LIST_SIZE.with(|value| value.set(size));
+}
+
 pub unsafe fn mock_info_list_get_size(_ptr: *mut std::ffi::c_void) -> usize {
-    0
+    MOCK_INFO_LIST_SIZE.with(std::cell::Cell::get)
 }
 pub unsafe fn mock_info_list_get_info(
     _ptr: *mut std::ffi::c_void,
-    _prev: *mut std::ffi::c_void,
-    _next: *mut *mut std::ffi::c_void,
+    prev: *mut std::ffi::c_void,
+    next: *mut *mut std::ffi::c_void,
 ) -> *mut crate::ffi::pmix_info_t {
-    std::ptr::null_mut()
+    if !prev.is_null() {
+        return std::ptr::null_mut();
+    }
+    MOCK_INFO_LIST_SIZE.with(|size| {
+        if size.get() == 0 {
+            return std::ptr::null_mut();
+        }
+        MOCK_INFO_LIST_ENTRY.with(|entry| {
+            let ptr = entry.as_ptr() as *mut crate::ffi::pmix_info_t;
+            // SAFETY: `next` is supplied by the wrapper for PMIx traversal.
+            unsafe { *next = ptr.cast(); }
+            ptr
+        })
+    })
 }
 pub unsafe fn mock_info_list_add(
     _ptr: *mut std::ffi::c_void,

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3221,3 +3221,84 @@ mod tests {
         );
     }
 }
+
+/// Mock implementations for PMIx_Info_list_* functions.
+pub unsafe fn mock_info_list_start() -> *mut std::ffi::c_void {
+    1usize as *mut std::ffi::c_void
+}
+pub unsafe fn mock_info_list_release(_ptr: *mut std::ffi::c_void) {}
+pub unsafe fn mock_info_list_get_size(_ptr: *mut std::ffi::c_void) -> usize {
+    0
+}
+pub unsafe fn mock_info_list_get_info(
+    _ptr: *mut std::ffi::c_void,
+    _prev: *mut std::ffi::c_void,
+    _next: *mut *mut std::ffi::c_void,
+) -> *mut crate::ffi::pmix_info_t {
+    std::ptr::null_mut()
+}
+pub unsafe fn mock_info_list_add(
+    _ptr: *mut std::ffi::c_void,
+    _key: *const std::ffi::c_char,
+    _value: *const std::ffi::c_void,
+    _type: crate::ffi::pmix_data_type_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_add")
+}
+pub unsafe fn mock_info_list_add_unique(
+    _ptr: *mut std::ffi::c_void,
+    _key: *const std::ffi::c_char,
+    _value: *const std::ffi::c_void,
+    _type: crate::ffi::pmix_data_type_t,
+    _overwrite: bool,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_add_unique")
+}
+pub unsafe fn mock_info_list_add_value(
+    _ptr: *mut std::ffi::c_void,
+    _key: *const std::ffi::c_char,
+    _value: *const crate::ffi::pmix_value_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_add_value")
+}
+pub unsafe fn mock_info_list_add_value_unique(
+    _ptr: *mut std::ffi::c_void,
+    _key: *const std::ffi::c_char,
+    _value: *const crate::ffi::pmix_value_t,
+    _overwrite: bool,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_add_value_unique")
+}
+pub unsafe fn mock_info_list_prepend(
+    _ptr: *mut std::ffi::c_void,
+    _key: *const std::ffi::c_char,
+    _value: *const std::ffi::c_void,
+    _type: crate::ffi::pmix_data_type_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_prepend")
+}
+pub unsafe fn mock_info_list_insert(
+    _ptr: *mut std::ffi::c_void,
+    _info: *mut crate::ffi::pmix_info_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_insert")
+}
+pub unsafe fn mock_info_list_xfer(
+    _ptr: *mut std::ffi::c_void,
+    _info: *const crate::ffi::pmix_info_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_xfer")
+}
+pub unsafe fn mock_info_list_xfer_unique(
+    _ptr: *mut std::ffi::c_void,
+    _info: *const crate::ffi::pmix_info_t,
+    _overwrite: bool,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_xfer_unique")
+}
+pub unsafe fn mock_info_list_convert(
+    _ptr: *mut std::ffi::c_void,
+    _par: *mut crate::ffi::pmix_data_array_t,
+) -> i32 {
+    get_mock_status("PMIx_Info_list_convert")
+}


### PR DESCRIPTION
Closes #74, Closes #94, Closes #87, Closes #107, Closes #136, Closes #145, Closes #174, Closes #175, Closes #232, Closes #236, Closes #242, Closes #251, Closes #252, Closes #308, Closes #344

## Summary
- Add the safe, !Send/!Sync PmixInfoList RAII wrapper in src/info.rs for all PMIx_Info_list_* APIs.
- Add mock FFI implementations and mock-gated lifecycle, mutation, conversion, and iterator coverage.
- Re-export PmixInfoList from the crate root.

## Module placement
src/info.rs is the existing Info helper module, so the wrapper is colocated with Info/PmixInfo and follows their ownership conventions.

## Test plan
- Local OpenPMIx 6.1.0 cargo build.
- cargo test --lib info::tests and the mock info-list test.
- cargo clippy --lib -- -D warnings.
- No daemon/DVM tests; all new tests use MockGuard.

Iterator returns copied pmix_info_t snapshots to avoid exposing borrowed C list lifetimes. convert returns the raw pmix_data_array_t because the crate has no existing safe data-array wrapper; PMIx ownership rules apply to the returned array.