### PR TITLE
feat(argv): add safe wrappers for PMIx_Argv_* utilities

### DIFF
--- a/src/argv.rs
+++ b/src/argv.rs
@@ -61,7 +61,9 @@ fn to_c_argv(argv: &[String]) -> Result<CArgv, PmixError> {
 fn free_c_argv(argv: *mut *mut c_char) {
     if !argv.is_null() {
         crate::pmix_ffi_or_mock!(
+            // SAFETY: argv is non-null and points to a PMIx-compatible NULL-terminated array.
             mock = unsafe { mock_ffi::mock_argv_free(argv) },
+            // SAFETY: argv is non-null and points to a PMIx-compatible NULL-terminated array.
             real = unsafe { ffi::PMIx_Argv_free(argv) },
         );
     }
@@ -94,6 +96,7 @@ fn read_c_argv(argv: *mut *mut c_char) -> Result<Vec<String>, PmixError> {
 fn split_impl(src: &str, delimiter: char, kind: SplitKind) -> Result<Vec<String>, PmixError> {
     let source = CString::new(src).map_err(invalid_argument)?;
     let raw = crate::pmix_ffi_or_mock!(
+        // SAFETY: source is a live NUL-terminated CString and the delimiter is a valid C int.
         mock = unsafe {
             match kind {
                 SplitKind::Normal => mock_ffi::mock_argv_split(source.as_ptr(), delimiter as c_int),
@@ -107,6 +110,7 @@ fn split_impl(src: &str, delimiter: char, kind: SplitKind) -> Result<Vec<String>
                 ),
             }
         },
+        // SAFETY: source is a live NUL-terminated CString and the delimiter is a valid C int.
         real = unsafe {
             match kind {
                 SplitKind::Normal => ffi::PMIx_Argv_split(source.as_ptr(), delimiter as c_int),
@@ -162,16 +166,20 @@ pub fn split_inter(
 pub fn join(argv: &[String], delimiter: char) -> Result<String, PmixError> {
     let cargv = to_c_argv(argv)?;
     let joined = crate::pmix_ffi_or_mock!(
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         mock = unsafe { mock_ffi::mock_argv_join(cargv.ptr, delimiter as c_int) },
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         real = unsafe { ffi::PMIx_Argv_join(cargv.ptr, delimiter as c_int) },
     );
     if joined.is_null() {
         return Err(PmixError::Error);
     }
+    // SAFETY: joined was checked non-null and is the NUL-terminated allocation returned by PMIx.
     let result = unsafe { CStr::from_ptr(joined) }
         .to_str()
         .map(str::to_owned)
         .map_err(|_| PmixError::Error);
+    // SAFETY: joined is the allocation returned by PMIx_Argv_join and is freed exactly once.
     unsafe { libc::free(joined.cast()) };
     result
 }
@@ -180,7 +188,9 @@ pub fn join(argv: &[String], delimiter: char) -> Result<String, PmixError> {
 pub fn copy(argv: &[String]) -> Result<Vec<String>, PmixError> {
     let cargv = to_c_argv(argv)?;
     let copied = crate::pmix_ffi_or_mock!(
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         mock = unsafe { mock_ffi::mock_argv_copy(cargv.ptr) },
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         real = unsafe { ffi::PMIx_Argv_copy(cargv.ptr) },
     );
     let result = read_c_argv(copied);
@@ -194,7 +204,9 @@ pub fn count(argv: &[String]) -> usize {
         return 0;
     };
     let count = crate::pmix_ffi_or_mock!(
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         mock = unsafe { mock_ffi::mock_argv_count(cargv.ptr) },
+        // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
         real = unsafe { ffi::PMIx_Argv_count(cargv.ptr) },
     );
     usize::try_from(count).unwrap_or(0)
@@ -221,7 +233,9 @@ where
 pub fn append(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
     update_with(argv, arg, |ptr, value| {
         crate::pmix_ffi_or_mock!(
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             mock = unsafe { mock_ffi::mock_argv_append_nosize(ptr, value) },
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             real = unsafe { ffi::PMIx_Argv_append_nosize(ptr, value) },
         )
     })
@@ -231,7 +245,9 @@ pub fn append(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
 pub fn append_unique(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
     update_with(argv, arg, |ptr, value| {
         crate::pmix_ffi_or_mock!(
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             mock = unsafe { mock_ffi::mock_argv_append_unique_nosize(ptr, value) },
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             real = unsafe { ffi::PMIx_Argv_append_unique_nosize(ptr, value) },
         )
     })
@@ -241,7 +257,9 @@ pub fn append_unique(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus
 pub fn prepend(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
     update_with(argv, arg, |ptr, value| {
         crate::pmix_ffi_or_mock!(
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             mock = unsafe { mock_ffi::mock_argv_prepend_nosize(ptr, value) },
+            // SAFETY: ptr references the live owned argv pointer and value is a live CString.
             real = unsafe { ffi::PMIx_Argv_prepend_nosize(ptr, value) },
         )
     })

--- a/src/argv.rs
+++ b/src/argv.rs
@@ -24,6 +24,8 @@ fn invalid_argument(_: NulError) -> PmixError {
 }
 
 fn to_c_argv(argv: &[String]) -> Result<CArgv, PmixError> {
+    // SAFETY: calloc returns aligned storage for the pointers plus a zeroed
+    // NULL terminator; ownership is released by free_c_argv on every path.
     let array = unsafe {
         libc::calloc(
             argv.len().saturating_add(1),
@@ -38,15 +40,19 @@ fn to_c_argv(argv: &[String]) -> Result<CArgv, PmixError> {
         let cvalue = match CString::new(value.as_str()) {
             Ok(value) => value,
             Err(error) => {
-                unsafe { ffi::PMIx_Argv_free(array) };
+                free_c_argv(array);
                 return Err(invalid_argument(error));
             }
         };
+        // SAFETY: cvalue is a live NUL-terminated CString and strdup creates
+        // an independently allocated entry owned by the argv array.
         let duplicate = unsafe { libc::strdup(cvalue.as_ptr()) };
         if duplicate.is_null() {
-            unsafe { ffi::PMIx_Argv_free(array) };
+            free_c_argv(array);
             return Err(PmixError::ErrNomem);
         }
+        // SAFETY: index is within the calloc'd array and each slot is written
+        // once while constructing the NULL-terminated argv.
         unsafe { *array.add(index) = duplicate };
     }
     Ok(CArgv { ptr: array })
@@ -68,10 +74,13 @@ fn read_c_argv(argv: *mut *mut c_char) -> Result<Vec<String>, PmixError> {
     let mut result = Vec::new();
     let mut index = 0;
     loop {
+        // SAFETY: argv is a valid NULL-terminated array and index advances only
+        // over entries read before the terminator.
         let entry = unsafe { *argv.add(index) };
         if entry.is_null() {
             break;
         }
+        // SAFETY: entry is a non-NULL pointer to a valid NUL-terminated string.
         let value = unsafe { CStr::from_ptr(entry) }
             .to_str()
             .map_err(|_| PmixError::Error)?
@@ -122,16 +131,25 @@ enum SplitKind {
 }
 
 /// Split a string using PMIx's argv parser.
+///
+/// Only single-byte (ASCII/Latin-1) delimiters are supported. Splitting an
+/// empty string returns `Err(PmixError::Error)`, matching PMIx's NULL result.
 pub fn split(src: &str, delimiter: char) -> Result<Vec<String>, PmixError> {
     split_impl(src, delimiter, SplitKind::Normal)
 }
 
 /// Split a string while retaining empty fields.
+///
+/// Only single-byte (ASCII/Latin-1) delimiters are supported. An empty source
+/// returns `Err(PmixError::Error)`, matching PMIx's NULL result.
 pub fn split_with_empty(src: &str, delimiter: char) -> Result<Vec<String>, PmixError> {
     split_impl(src, delimiter, SplitKind::WithEmpty)
 }
 
 /// Split a string, optionally retaining empty fields.
+///
+/// Only single-byte (ASCII/Latin-1) delimiters are supported. An empty source
+/// returns `Err(PmixError::Error)`, matching PMIx's NULL result.
 pub fn split_inter(
     src: &str,
     delimiter: char,
@@ -187,7 +205,7 @@ where
     F: FnOnce(*mut *mut *mut c_char, *const c_char) -> i32,
 {
     let mut cargv = to_c_argv(argv).map_err(PmixStatus::from)?;
-    let carg = CString::new(arg).map_err(|_| PmixStatus::from_raw(-27))?;
+    let carg = CString::new(arg).map_err(|_| PmixStatus::from(PmixError::ErrBadParam))?;
     let mut raw = cargv.ptr;
     let status = call(&mut raw, carg.as_ptr());
     cargv.ptr = raw;
@@ -246,7 +264,7 @@ mod tests {
         assert_eq!(split_inter("one,two", ',', true).unwrap(), vec!["a"]);
         assert_eq!(copy(&values).unwrap(), values);
         assert_eq!(join(&values, ',').unwrap(), "joined");
-        assert_eq!(count(&values), 0);
+        assert_eq!(count(&values), 2);
     }
 
     #[test]
@@ -256,7 +274,7 @@ mod tests {
         append(&mut values, "two").unwrap();
         append_unique(&mut values, "two").unwrap();
         prepend(&mut values, "zero").unwrap();
-        assert_eq!(values, vec!["one"]);
+        assert_eq!(values, vec!["zero", "one", "two"]);
         free(&values);
     }
 }

--- a/src/argv.rs
+++ b/src/argv.rs
@@ -1,0 +1,262 @@
+//! Safe wrappers for PMIx `PMIx_Argv_*` string-array utilities.
+
+use crate::ffi;
+use crate::{PmixError, PmixStatus};
+use std::ffi::{CStr, CString, NulError};
+use std::os::raw::{c_char, c_int};
+use std::ptr;
+
+#[cfg(any(test, feature = "mock_ffi"))]
+use crate::mock_ffi;
+
+struct CArgv {
+    ptr: *mut *mut c_char,
+}
+
+impl Drop for CArgv {
+    fn drop(&mut self) {
+        free_c_argv(self.ptr);
+    }
+}
+
+fn invalid_argument(_: NulError) -> PmixError {
+    PmixError::Error
+}
+
+fn to_c_argv(argv: &[String]) -> Result<CArgv, PmixError> {
+    let array = unsafe {
+        libc::calloc(
+            argv.len().saturating_add(1),
+            std::mem::size_of::<*mut c_char>(),
+        ) as *mut *mut c_char
+    };
+    if array.is_null() {
+        return Err(PmixError::ErrNomem);
+    }
+
+    for (index, value) in argv.iter().enumerate() {
+        let cvalue = match CString::new(value.as_str()) {
+            Ok(value) => value,
+            Err(error) => {
+                unsafe { ffi::PMIx_Argv_free(array) };
+                return Err(invalid_argument(error));
+            }
+        };
+        let duplicate = unsafe { libc::strdup(cvalue.as_ptr()) };
+        if duplicate.is_null() {
+            unsafe { ffi::PMIx_Argv_free(array) };
+            return Err(PmixError::ErrNomem);
+        }
+        unsafe { *array.add(index) = duplicate };
+    }
+    Ok(CArgv { ptr: array })
+}
+
+fn free_c_argv(argv: *mut *mut c_char) {
+    if !argv.is_null() {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_argv_free(argv) },
+            real = unsafe { ffi::PMIx_Argv_free(argv) },
+        );
+    }
+}
+
+fn read_c_argv(argv: *mut *mut c_char) -> Result<Vec<String>, PmixError> {
+    if argv.is_null() {
+        return Err(PmixError::Error);
+    }
+    let mut result = Vec::new();
+    let mut index = 0;
+    loop {
+        let entry = unsafe { *argv.add(index) };
+        if entry.is_null() {
+            break;
+        }
+        let value = unsafe { CStr::from_ptr(entry) }
+            .to_str()
+            .map_err(|_| PmixError::Error)?
+            .to_owned();
+        result.push(value);
+        index += 1;
+    }
+    Ok(result)
+}
+
+fn split_impl(src: &str, delimiter: char, kind: SplitKind) -> Result<Vec<String>, PmixError> {
+    let source = CString::new(src).map_err(invalid_argument)?;
+    let raw = crate::pmix_ffi_or_mock!(
+        mock = unsafe {
+            match kind {
+                SplitKind::Normal => mock_ffi::mock_argv_split(source.as_ptr(), delimiter as c_int),
+                SplitKind::WithEmpty => {
+                    mock_ffi::mock_argv_split_with_empty(source.as_ptr(), delimiter as c_int)
+                }
+                SplitKind::Inter(include_empty) => mock_ffi::mock_argv_split_inter(
+                    source.as_ptr(),
+                    delimiter as c_int,
+                    include_empty,
+                ),
+            }
+        },
+        real = unsafe {
+            match kind {
+                SplitKind::Normal => ffi::PMIx_Argv_split(source.as_ptr(), delimiter as c_int),
+                SplitKind::WithEmpty => {
+                    ffi::PMIx_Argv_split_with_empty(source.as_ptr(), delimiter as c_int)
+                }
+                SplitKind::Inter(include_empty) => {
+                    ffi::PMIx_Argv_split_inter(source.as_ptr(), delimiter as c_int, include_empty)
+                }
+            }
+        },
+    );
+    let result = read_c_argv(raw);
+    free_c_argv(raw);
+    result
+}
+
+enum SplitKind {
+    Normal,
+    WithEmpty,
+    Inter(bool),
+}
+
+/// Split a string using PMIx's argv parser.
+pub fn split(src: &str, delimiter: char) -> Result<Vec<String>, PmixError> {
+    split_impl(src, delimiter, SplitKind::Normal)
+}
+
+/// Split a string while retaining empty fields.
+pub fn split_with_empty(src: &str, delimiter: char) -> Result<Vec<String>, PmixError> {
+    split_impl(src, delimiter, SplitKind::WithEmpty)
+}
+
+/// Split a string, optionally retaining empty fields.
+pub fn split_inter(
+    src: &str,
+    delimiter: char,
+    include_empty: bool,
+) -> Result<Vec<String>, PmixError> {
+    split_impl(src, delimiter, SplitKind::Inter(include_empty))
+}
+
+/// Join strings with PMIx's argv join utility.
+pub fn join(argv: &[String], delimiter: char) -> Result<String, PmixError> {
+    let cargv = to_c_argv(argv)?;
+    let joined = crate::pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_argv_join(cargv.ptr, delimiter as c_int) },
+        real = unsafe { ffi::PMIx_Argv_join(cargv.ptr, delimiter as c_int) },
+    );
+    if joined.is_null() {
+        return Err(PmixError::Error);
+    }
+    let result = unsafe { CStr::from_ptr(joined) }
+        .to_str()
+        .map(str::to_owned)
+        .map_err(|_| PmixError::Error);
+    unsafe { libc::free(joined.cast()) };
+    result
+}
+
+/// Deep-copy an argv string array.
+pub fn copy(argv: &[String]) -> Result<Vec<String>, PmixError> {
+    let cargv = to_c_argv(argv)?;
+    let copied = crate::pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_argv_copy(cargv.ptr) },
+        real = unsafe { ffi::PMIx_Argv_copy(cargv.ptr) },
+    );
+    let result = read_c_argv(copied);
+    free_c_argv(copied);
+    result
+}
+
+/// Count entries. For a Rust slice this is equal to `argv.len()`.
+pub fn count(argv: &[String]) -> usize {
+    let Ok(cargv) = to_c_argv(argv) else {
+        return 0;
+    };
+    let count = crate::pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_argv_count(cargv.ptr) },
+        real = unsafe { ffi::PMIx_Argv_count(cargv.ptr) },
+    );
+    usize::try_from(count).unwrap_or(0)
+}
+
+fn update_with<F>(argv: &mut Vec<String>, arg: &str, call: F) -> Result<(), PmixStatus>
+where
+    F: FnOnce(*mut *mut *mut c_char, *const c_char) -> i32,
+{
+    let mut cargv = to_c_argv(argv).map_err(PmixStatus::from)?;
+    let carg = CString::new(arg).map_err(|_| PmixStatus::from_raw(-27))?;
+    let mut raw = cargv.ptr;
+    let status = call(&mut raw, carg.as_ptr());
+    cargv.ptr = raw;
+    if status != 0 {
+        return Err(PmixStatus::from_raw(status));
+    }
+    let updated = read_c_argv(cargv.ptr).map_err(PmixStatus::from)?;
+    *argv = updated;
+    Ok(())
+}
+
+/// Append `arg`, even when it is already present.
+pub fn append(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
+    update_with(argv, arg, |ptr, value| {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_argv_append_nosize(ptr, value) },
+            real = unsafe { ffi::PMIx_Argv_append_nosize(ptr, value) },
+        )
+    })
+}
+
+/// Append `arg` only when it is not already present.
+pub fn append_unique(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
+    update_with(argv, arg, |ptr, value| {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_argv_append_unique_nosize(ptr, value) },
+            real = unsafe { ffi::PMIx_Argv_append_unique_nosize(ptr, value) },
+        )
+    })
+}
+
+/// Prepend `arg` to the array.
+pub fn prepend(argv: &mut Vec<String>, arg: &str) -> Result<(), PmixStatus> {
+    update_with(argv, arg, |ptr, value| {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_argv_prepend_nosize(ptr, value) },
+            real = unsafe { ffi::PMIx_Argv_prepend_nosize(ptr, value) },
+        )
+    })
+}
+
+/// No-op for Rust-owned slices; provided for API completeness.
+pub fn free(_argv: &[String]) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_ffi::MockGuard;
+
+    #[test]
+    fn split_copy_join_and_count_use_deterministic_mocks() {
+        let _guard = MockGuard::new();
+        let values = vec!["one".to_owned(), "two".to_owned()];
+        assert_eq!(split("one,two", ',').unwrap(), vec!["a"]);
+        assert_eq!(split_with_empty("one,two", ',').unwrap(), vec!["a"]);
+        assert_eq!(split_inter("one,two", ',', true).unwrap(), vec!["a"]);
+        assert_eq!(copy(&values).unwrap(), values);
+        assert_eq!(join(&values, ',').unwrap(), "joined");
+        assert_eq!(count(&values), 0);
+    }
+
+    #[test]
+    fn mutation_and_free_are_safe_with_mocks() {
+        let _guard = MockGuard::new();
+        let mut values = vec!["one".to_owned()];
+        append(&mut values, "two").unwrap();
+        append_unique(&mut values, "two").unwrap();
+        prepend(&mut values, "zero").unwrap();
+        assert_eq!(values, vec!["one"]);
+        free(&values);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //!
 use std::fmt::Debug;
 pub mod allocation;
+pub mod argv;
 pub mod cpu_locality;
 pub mod cbdata;
 pub mod data_ops;

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3331,6 +3331,7 @@ pub unsafe fn mock_info_list_convert(
 }
 
 // PMIx_Argv_* mocks used by the safe argv wrappers.
+#[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn mock_argv_split(
     _src: *const std::ffi::c_char,
     _delimiter: std::ffi::c_int,
@@ -3350,10 +3351,18 @@ pub unsafe fn mock_argv_split_inter(
 ) -> *mut *mut std::ffi::c_char {
     unsafe { mock_argv_one() }
 }
-pub unsafe fn mock_argv_count(_argv: *mut *mut std::ffi::c_char) -> std::ffi::c_int {
-    0
+pub unsafe fn mock_argv_count(argv: *mut *mut std::ffi::c_char) -> std::ffi::c_int {
+    let mut count = 0;
+    if argv.is_null() { return 0; }
+    while !(*argv.add(count as usize)).is_null() { count += 1; }
+    count
 }
-pub unsafe fn mock_argv_free(_argv: *mut *mut std::ffi::c_char) {}
+pub unsafe fn mock_argv_free(argv: *mut *mut std::ffi::c_char) {
+    if argv.is_null() { return; }
+    let mut index = 0;
+    while !(*argv.add(index)).is_null() { libc::free((*argv.add(index)).cast()); index += 1; }
+    libc::free(argv.cast());
+}
 pub unsafe fn mock_argv_join(
     _argv: *mut *mut std::ffi::c_char,
     _delimiter: std::ffi::c_int,
@@ -3361,29 +3370,48 @@ pub unsafe fn mock_argv_join(
     unsafe { libc::strdup(b"joined\0".as_ptr().cast()) }
 }
 pub unsafe fn mock_argv_copy(argv: *mut *mut std::ffi::c_char) -> *mut *mut std::ffi::c_char {
-    argv
+    // SAFETY: PMIx_Argv_copy returns a new deep copy; the mock mirrors that contract.
+    let count = mock_argv_count(argv) as usize;
+    let out = libc::calloc(count + 1, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+    if out.is_null() { return std::ptr::null_mut(); }
+    for i in 0..count { *out.add(i) = libc::strdup(*argv.add(i)); }
+    out
 }
 pub unsafe fn mock_argv_append_nosize(
-    _argv: *mut *mut *mut std::ffi::c_char,
-    _arg: *const std::ffi::c_char,
+    argv: *mut *mut *mut std::ffi::c_char,
+    arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    0
+    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+    let old = *argv; let count = mock_argv_count(old) as usize;
+    let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+    if out.is_null() { return -32; }
+    for i in 0..count { *out.add(i) = libc::strdup(*old.add(i)); }
+    *out.add(count) = libc::strdup(arg);
+    libc::free(old.cast()); *argv = out; 0
 }
 pub unsafe fn mock_argv_append_unique_nosize(
-    _argv: *mut *mut *mut std::ffi::c_char,
-    _arg: *const std::ffi::c_char,
+    argv: *mut *mut *mut std::ffi::c_char,
+    arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    0
+    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+    let old = *argv; let count = mock_argv_count(old) as usize;
+    for i in 0..count { if libc::strcmp(*old.add(i), arg) == 0 { return 0; } }
+    mock_argv_append_nosize(argv, arg)
 }
 pub unsafe fn mock_argv_prepend_nosize(
-    _argv: *mut *mut *mut std::ffi::c_char,
-    _arg: *const std::ffi::c_char,
+    argv: *mut *mut *mut std::ffi::c_char,
+    arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    0
+    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+    let old = *argv; let count = mock_argv_count(old) as usize;
+    let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+    if out.is_null() { return -32; }
+    *out = libc::strdup(arg); for i in 0..count { *out.add(i + 1) = libc::strdup(*old.add(i)); }
+    libc::free(old.cast()); *argv = out; 0
 }
 
 fn mock_argv_one() -> *mut *mut std::ffi::c_char {
-    let entry = b"a\0".as_ptr().cast_mut().cast();
+    let entry = unsafe { libc::strdup(b"a\0".as_ptr().cast()) };
     let argv: Box<[*mut std::ffi::c_char; 2]> = Box::new([entry, std::ptr::null_mut()]);
     Box::into_raw(argv).cast()
 }

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3329,3 +3329,63 @@ pub unsafe fn mock_info_list_convert(
 ) -> i32 {
     get_mock_status("PMIx_Info_list_convert")
 }
+
+// PMIx_Argv_* mocks used by the safe argv wrappers.
+pub unsafe fn mock_argv_split(
+    _src: *const std::ffi::c_char,
+    _delimiter: std::ffi::c_int,
+) -> *mut *mut std::ffi::c_char {
+    unsafe { mock_argv_one() }
+}
+pub unsafe fn mock_argv_split_with_empty(
+    _src: *const std::ffi::c_char,
+    _delimiter: std::ffi::c_int,
+) -> *mut *mut std::ffi::c_char {
+    unsafe { mock_argv_one() }
+}
+pub unsafe fn mock_argv_split_inter(
+    _src: *const std::ffi::c_char,
+    _delimiter: std::ffi::c_int,
+    _include_empty: bool,
+) -> *mut *mut std::ffi::c_char {
+    unsafe { mock_argv_one() }
+}
+pub unsafe fn mock_argv_count(_argv: *mut *mut std::ffi::c_char) -> std::ffi::c_int {
+    0
+}
+pub unsafe fn mock_argv_free(_argv: *mut *mut std::ffi::c_char) {}
+pub unsafe fn mock_argv_join(
+    _argv: *mut *mut std::ffi::c_char,
+    _delimiter: std::ffi::c_int,
+) -> *mut std::ffi::c_char {
+    unsafe { libc::strdup(b"joined\0".as_ptr().cast()) }
+}
+pub unsafe fn mock_argv_copy(argv: *mut *mut std::ffi::c_char) -> *mut *mut std::ffi::c_char {
+    argv
+}
+pub unsafe fn mock_argv_append_nosize(
+    _argv: *mut *mut *mut std::ffi::c_char,
+    _arg: *const std::ffi::c_char,
+) -> crate::ffi::pmix_status_t {
+    0
+}
+pub unsafe fn mock_argv_append_unique_nosize(
+    _argv: *mut *mut *mut std::ffi::c_char,
+    _arg: *const std::ffi::c_char,
+) -> crate::ffi::pmix_status_t {
+    0
+}
+pub unsafe fn mock_argv_prepend_nosize(
+    _argv: *mut *mut *mut std::ffi::c_char,
+    _arg: *const std::ffi::c_char,
+) -> crate::ffi::pmix_status_t {
+    0
+}
+
+fn mock_argv_one() -> *mut *mut std::ffi::c_char {
+    let entry = b"a\0".as_ptr().cast_mut().cast();
+    let argv: Box<[*mut std::ffi::c_char; 2]> = Box::new([entry, std::ptr::null_mut()]);
+    Box::into_raw(argv).cast()
+}
+
+// END PMIx_Argv_* mocks

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3331,37 +3331,45 @@ pub unsafe fn mock_info_list_convert(
 }
 
 // PMIx_Argv_* mocks used by the safe argv wrappers.
-#[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn mock_argv_split(
     _src: *const std::ffi::c_char,
     _delimiter: std::ffi::c_int,
 ) -> *mut *mut std::ffi::c_char {
-    unsafe { mock_argv_one() }
+    mock_argv_one()
 }
 pub unsafe fn mock_argv_split_with_empty(
     _src: *const std::ffi::c_char,
     _delimiter: std::ffi::c_int,
 ) -> *mut *mut std::ffi::c_char {
-    unsafe { mock_argv_one() }
+    mock_argv_one()
 }
 pub unsafe fn mock_argv_split_inter(
     _src: *const std::ffi::c_char,
     _delimiter: std::ffi::c_int,
     _include_empty: bool,
 ) -> *mut *mut std::ffi::c_char {
-    unsafe { mock_argv_one() }
+    mock_argv_one()
 }
 pub unsafe fn mock_argv_count(argv: *mut *mut std::ffi::c_char) -> std::ffi::c_int {
-    let mut count = 0;
     if argv.is_null() { return 0; }
-    while !(*argv.add(count as usize)).is_null() { count += 1; }
-    count
+    unsafe {
+        let mut count = 0;
+        while !(*argv.add(count as usize)).is_null() { count += 1; }
+        count
+    }
 }
 pub unsafe fn mock_argv_free(argv: *mut *mut std::ffi::c_char) {
     if argv.is_null() { return; }
-    let mut index = 0;
-    while !(*argv.add(index)).is_null() { libc::free((*argv.add(index)).cast()); index += 1; }
-    libc::free(argv.cast());
+    unsafe {
+        let mut index = 0;
+        while !(*argv.add(index)).is_null() {
+            // SAFETY: each entry is a strdup allocation owned by argv.
+            libc::free((*argv.add(index)).cast());
+            index += 1;
+        }
+        // SAFETY: argv is the calloc/Box allocation owning the entry pointers.
+        libc::free(argv.cast());
+    }
 }
 pub unsafe fn mock_argv_join(
     _argv: *mut *mut std::ffi::c_char,
@@ -3370,44 +3378,56 @@ pub unsafe fn mock_argv_join(
     unsafe { libc::strdup(b"joined\0".as_ptr().cast()) }
 }
 pub unsafe fn mock_argv_copy(argv: *mut *mut std::ffi::c_char) -> *mut *mut std::ffi::c_char {
-    // SAFETY: PMIx_Argv_copy returns a new deep copy; the mock mirrors that contract.
-    let count = mock_argv_count(argv) as usize;
-    let out = libc::calloc(count + 1, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
-    if out.is_null() { return std::ptr::null_mut(); }
-    for i in 0..count { *out.add(i) = libc::strdup(*argv.add(i)); }
-    out
+    let count = unsafe { mock_argv_count(argv) } as usize;
+    unsafe {
+        let out = libc::calloc(count + 1, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+        if out.is_null() { return std::ptr::null_mut(); }
+        for i in 0..count {
+            // SAFETY: argv is a valid NULL-terminated array and each entry is a valid C string.
+            *out.add(i) = libc::strdup(*argv.add(i));
+        }
+        out
+    }
 }
 pub unsafe fn mock_argv_append_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
-    let old = *argv; let count = mock_argv_count(old) as usize;
-    let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
-    if out.is_null() { return -32; }
-    for i in 0..count { *out.add(i) = libc::strdup(*old.add(i)); }
-    *out.add(count) = libc::strdup(arg);
-    libc::free(old.cast()); *argv = out; 0
+    unsafe {
+        if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+        let old = *argv; let count = mock_argv_count(old) as usize;
+        let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+        if out.is_null() { return -32; }
+        for i in 0..count { *out.add(i) = libc::strdup(*old.add(i)); }
+        *out.add(count) = libc::strdup(arg);
+        for i in 0..count { libc::free((*old.add(i)).cast()); }
+        libc::free(old.cast()); *argv = out; 0
+    }
 }
 pub unsafe fn mock_argv_append_unique_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
-    let old = *argv; let count = mock_argv_count(old) as usize;
-    for i in 0..count { if libc::strcmp(*old.add(i), arg) == 0 { return 0; } }
-    mock_argv_append_nosize(argv, arg)
+    unsafe {
+        if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+        let old = *argv; let count = mock_argv_count(old) as usize;
+        for i in 0..count { if libc::strcmp(*old.add(i), arg) == 0 { return 0; } }
+        mock_argv_append_nosize(argv, arg)
+    }
 }
 pub unsafe fn mock_argv_prepend_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
-    if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
-    let old = *argv; let count = mock_argv_count(old) as usize;
-    let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
-    if out.is_null() { return -32; }
-    *out = libc::strdup(arg); for i in 0..count { *out.add(i + 1) = libc::strdup(*old.add(i)); }
-    libc::free(old.cast()); *argv = out; 0
+    unsafe {
+        if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
+        let old = *argv; let count = mock_argv_count(old) as usize;
+        let out = libc::calloc(count + 2, std::mem::size_of::<*mut std::ffi::c_char>()) as *mut *mut std::ffi::c_char;
+        if out.is_null() { return -32; }
+        *out = libc::strdup(arg); for i in 0..count { *out.add(i + 1) = libc::strdup(*old.add(i)); }
+        for i in 0..count { libc::free((*old.add(i)).cast()); }
+        libc::free(old.cast()); *argv = out; 0
+    }
 }
 
 fn mock_argv_one() -> *mut *mut std::ffi::c_char {

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3352,6 +3352,7 @@ pub unsafe fn mock_argv_split_inter(
 }
 pub unsafe fn mock_argv_count(argv: *mut *mut std::ffi::c_char) -> std::ffi::c_int {
     if argv.is_null() { return 0; }
+    // SAFETY: argv is non-null and points to a valid NULL-terminated argv array.
     unsafe {
         let mut count = 0;
         while !(*argv.add(count as usize)).is_null() { count += 1; }
@@ -3375,7 +3376,7 @@ pub unsafe fn mock_argv_join(
     _argv: *mut *mut std::ffi::c_char,
     _delimiter: std::ffi::c_int,
 ) -> *mut std::ffi::c_char {
-    unsafe { libc::strdup(b"joined\0".as_ptr().cast()) }
+    unsafe { libc::strdup(c"joined".as_ptr()) }
 }
 pub unsafe fn mock_argv_copy(argv: *mut *mut std::ffi::c_char) -> *mut *mut std::ffi::c_char {
     let count = unsafe { mock_argv_count(argv) } as usize;
@@ -3393,6 +3394,7 @@ pub unsafe fn mock_argv_append_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
+    // SAFETY: the caller provides PMIx-compatible argv and argument pointers.
     unsafe {
         if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
         let old = *argv; let count = mock_argv_count(old) as usize;
@@ -3408,6 +3410,7 @@ pub unsafe fn mock_argv_append_unique_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
+    // SAFETY: the caller provides PMIx-compatible argv and argument pointers.
     unsafe {
         if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
         let old = *argv; let count = mock_argv_count(old) as usize;
@@ -3419,6 +3422,7 @@ pub unsafe fn mock_argv_prepend_nosize(
     argv: *mut *mut *mut std::ffi::c_char,
     arg: *const std::ffi::c_char,
 ) -> crate::ffi::pmix_status_t {
+    // SAFETY: the caller provides PMIx-compatible argv and argument pointers.
     unsafe {
         if argv.is_null() || (*argv).is_null() || arg.is_null() { return -27; }
         let old = *argv; let count = mock_argv_count(old) as usize;
@@ -3431,9 +3435,19 @@ pub unsafe fn mock_argv_prepend_nosize(
 }
 
 fn mock_argv_one() -> *mut *mut std::ffi::c_char {
-    let entry = unsafe { libc::strdup(b"a\0".as_ptr().cast()) };
-    let argv: Box<[*mut std::ffi::c_char; 2]> = Box::new([entry, std::ptr::null_mut()]);
-    Box::into_raw(argv).cast()
+    let entry = unsafe { libc::strdup(c"a".as_ptr()) };
+    // SAFETY: calloc allocates space for two pointer slots, which are initialized
+    // before returning; the allocation is released by libc::free in mock_argv_free.
+    let argv = unsafe {
+        libc::calloc(2, std::mem::size_of::<*mut std::ffi::c_char>())
+            as *mut *mut std::ffi::c_char
+    };
+    if argv.is_null() {
+        unsafe { libc::free(entry.cast()) };
+        return std::ptr::null_mut();
+    }
+    unsafe { *argv = entry };
+    argv
 }
 
 // END PMIx_Argv_* mocks


### PR DESCRIPTION
Closes #83, Closes #103, Closes #86, Closes #106, Closes #113, Closes #120, Closes #148, Closes #238, Closes #256, Closes #264, Closes #283, Closes #305

## Summary
- Add safe Vec/String wrappers for the ten PMIx_Argv_* utilities in src/argv.rs.
- Add matching mock FFI functions and no-daemon unit tests.

## Test plan
- cargo build
- cargo test --lib argv::tests
- cargo clippy --lib -- -D warnings
- cargo fmt -- --check for the added module
