### PR TITLE
feat(data): add safe wrappers for PMIx_Data_buffer/Data_array/Byte_object

### DIFF
--- a/src/data_serialization.rs
+++ b/src/data_serialization.rs
@@ -2358,33 +2358,44 @@ pub fn data_buffer_unload(buf: &mut PmixDataBuffer) -> Result<(Vec<u8>, usize), 
 /// RAII wrapper for a stack-style pmix_data_array_t.
 pub struct PmixDataArray { inner: std::mem::MaybeUninit<ffi::pmix_data_array_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
 impl PmixDataArray {
-    pub fn new(num: usize, ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_construct(v.inner.as_mut_ptr(), num, ty), real = ffi::PMIx_Data_array_construct(v.inner.as_mut_ptr(), num, ty)) }; v.constructed = true; v }
-    pub fn init(ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_init(v.inner.as_mut_ptr(), ty), real = ffi::PMIx_Data_array_init(v.inner.as_mut_ptr(), ty)) }; v.constructed = true; v }
+    pub fn new(num: usize, ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); // SAFETY: inner is exclusive, aligned storage reserved for the constructor.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_construct(v.inner.as_mut_ptr(), num, ty), real = ffi::PMIx_Data_array_construct(v.inner.as_mut_ptr(), num, ty)) }; v.constructed = true; v }
+    pub fn init(ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); // SAFETY: inner is exclusive, aligned storage reserved for the initializer.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_init(v.inner.as_mut_ptr(), ty), real = ffi::PMIx_Data_array_init(v.inner.as_mut_ptr(), ty)) }; v.constructed = true; v }
     pub fn test_new() -> Self { Self { inner: std::mem::MaybeUninit::zeroed(), constructed: false, _not_thread_safe: std::marker::PhantomData } }
     fn uninit() -> Self { Self { inner: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData } }
-    pub fn type_(&self) -> ffi::pmix_data_type_t { unsafe { self.inner.assume_init_ref().type_ } }
-    pub fn size(&self) -> usize { unsafe { self.inner.assume_init_ref().size } }
-    pub fn array(&self) -> Option<*mut std::ffi::c_void> { let p = unsafe { self.inner.assume_init_ref().array }; (!p.is_null()).then_some(p) }
+    pub fn type_(&self) -> ffi::pmix_data_type_t { // SAFETY: constructed instances are initialized; test_new supplies zeroed storage.
+        unsafe { self.inner.assume_init_ref().type_ } }
+    pub fn size(&self) -> usize { // SAFETY: constructed instances are initialized; test_new supplies zeroed storage.
+        unsafe { self.inner.assume_init_ref().size } }
+    pub fn array(&self) -> Option<*mut std::ffi::c_void> { // SAFETY: constructed instances are initialized; test_new supplies zeroed storage.
+        let p = unsafe { self.inner.assume_init_ref().array }; (!p.is_null()).then_some(p) }
 }
 impl Default for PmixDataArray { fn default() -> Self { Self::test_new() } }
-impl Drop for PmixDataArray { fn drop(&mut self) { if self.constructed { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_destruct(self.inner.as_mut_ptr()), real = ffi::PMIx_Data_array_destruct(self.inner.as_mut_ptr())) }; } } }
+impl Drop for PmixDataArray { fn drop(&mut self) { if self.constructed { // SAFETY: matching constructor initialized inner; constructed prevents double destruction.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_destruct(self.inner.as_mut_ptr()), real = ffi::PMIx_Data_array_destruct(self.inner.as_mut_ptr())) }; } } }
 
 /// RAII wrapper for PMIx_Data_array_create/free allocations.
 pub struct PmixDataArrayArray { ptr: *mut ffi::pmix_data_array_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
 impl PmixDataArrayArray { pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_data_array_t { self.ptr } pub fn len(&self) -> usize { self.len }
     pub fn is_empty(&self) -> bool { self.len == 0 }
 }
-impl Drop for PmixDataArrayArray { fn drop(&mut self) { if !self.ptr.is_null() { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_free(self.ptr), real = ffi::PMIx_Data_array_free(self.ptr)) }; } } }
-pub fn data_array_create(n: usize, ty: ffi::pmix_data_type_t) -> Result<PmixDataArrayArray, PmixStatus> { let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_create(n, ty), real = ffi::PMIx_Data_array_create(n, ty)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixDataArrayArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
+impl Drop for PmixDataArrayArray { fn drop(&mut self) { if !self.ptr.is_null() { // SAFETY: non-null ptr came from PMIx_Data_array_create and is freed exactly once.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_free(self.ptr), real = ffi::PMIx_Data_array_free(self.ptr)) }; } } }
+pub fn data_array_create(n: usize, ty: ffi::pmix_data_type_t) -> Result<PmixDataArrayArray, PmixStatus> { // SAFETY: PMIx receives the requested count/type and returns a valid allocation or null.
+    let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_create(n, ty), real = ffi::PMIx_Data_array_create(n, ty)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixDataArrayArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
 
 /// Explicitly construct an empty byte object without changing `PmixByteObject::new`.
-pub fn byte_object_construct() -> PmixByteObject { let mut b = PmixByteObject::new(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_construct_stack(b.as_mut_ptr()), real = ffi::PMIx_Byte_object_construct(b.as_mut_ptr())) }; b }
+pub fn byte_object_construct() -> PmixByteObject { let mut b = PmixByteObject::new(); // SAFETY: b owns exclusive, aligned storage for the stack constructor.
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_construct_stack(b.as_mut_ptr()), real = ffi::PMIx_Byte_object_construct(b.as_mut_ptr())) }; b }
 pub struct PmixByteObjectArray { ptr: *mut ffi::pmix_byte_object_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
 impl PmixByteObjectArray { pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_byte_object_t { self.ptr } pub fn len(&self) -> usize { self.len }
     pub fn is_empty(&self) -> bool { self.len == 0 }
 }
-impl Drop for PmixByteObjectArray { fn drop(&mut self) { if !self.ptr.is_null() { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_free(self.ptr, self.len), real = ffi::PMIx_Byte_object_free(self.ptr, self.len)) }; } } }
-pub fn byte_object_create(n: usize) -> Result<PmixByteObjectArray, PmixStatus> { let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_create(n), real = ffi::PMIx_Byte_object_create(n)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixByteObjectArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
+impl Drop for PmixByteObjectArray { fn drop(&mut self) { if !self.ptr.is_null() { // SAFETY: non-null ptr came from PMIx_Byte_object_create; len is its original element count.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_free(self.ptr, self.len), real = ffi::PMIx_Byte_object_free(self.ptr, self.len)) }; } } }
+pub fn byte_object_create(n: usize) -> Result<PmixByteObjectArray, PmixStatus> { // SAFETY: PMIx receives the requested count and returns a valid allocation or null.
+    let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_create(n), real = ffi::PMIx_Byte_object_create(n)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixByteObjectArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
 pub fn byte_object_load(b: &mut PmixByteObject, data: &[u8]) {
     let p = copy_to_c_owned(data).expect("malloc failed while loading byte object");
     // SAFETY: p is malloc storage transferred to PMIx.

--- a/src/data_serialization.rs
+++ b/src/data_serialization.rs
@@ -2272,3 +2272,74 @@ mod tests {
         }
     }
 }
+
+
+/// Construct a stack-style data buffer. This is distinct from create/release.
+pub fn data_buffer_construct() -> PmixDataBuffer {
+    let mut raw = Box::new(unsafe { std::mem::zeroed::<ffi::pmix_data_buffer_t>() });
+    let ptr = raw.as_mut() as *mut _;
+    std::mem::forget(raw);
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_construct(ptr), real = ffi::PMIx_Data_buffer_construct(ptr)) };
+    unsafe { PmixDataBuffer::from_raw(ptr) }
+}
+
+/// Destruct a stack-style data buffer. Do not use with a buffer from create/release.
+pub fn data_buffer_destruct(buf: &mut PmixDataBuffer) {
+    if buf.is_valid() {
+        let raw = buf.ptr;
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_destruct(raw), real = ffi::PMIx_Data_buffer_destruct(raw)) };
+        buf.ptr = ptr::null_mut();
+        // SAFETY: data_buffer_construct allocated this exact storage with Box.
+        unsafe { drop(Box::from_raw(raw)); }
+    }
+}
+
+/// Load bytes with PMIx_Data_buffer_load (not PMIx_Data_load).
+pub fn data_buffer_load(buf: &mut PmixDataBuffer, bytes: &[u8]) -> Result<(), PmixStatus> {
+    if !buf.is_valid() { return Err(PmixStatus::from_raw(-1)); }
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_load(buf.as_mut_ptr(), bytes.as_ptr() as *mut _, bytes.len()), real = ffi::PMIx_Data_buffer_load(buf.as_mut_ptr(), bytes.as_ptr() as *mut _, bytes.len())) };
+    Ok(())
+}
+
+/// Unload bytes with PMIx_Data_buffer_unload. PMIx retains ownership of the returned pointer.
+pub fn data_buffer_unload(buf: &mut PmixDataBuffer) -> Result<(Vec<u8>, usize), PmixStatus> {
+    if !buf.is_valid() { return Err(PmixStatus::from_raw(-1)); }
+    let mut bytes = ptr::null_mut();
+    let mut size = 0usize;
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_unload(buf.as_mut_ptr(), &mut bytes, &mut size), real = ffi::PMIx_Data_buffer_unload(buf.as_mut_ptr(), &mut bytes, &mut size)) };
+    let copied = if bytes.is_null() || size == 0 { Vec::new() } else { unsafe { std::slice::from_raw_parts(bytes as *const u8, size).to_vec() } };
+    Ok((copied, size))
+}
+
+/// RAII wrapper for a stack-style pmix_data_array_t.
+pub struct PmixDataArray { inner: std::mem::MaybeUninit<ffi::pmix_data_array_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixDataArray {
+    pub fn new(num: usize, ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_construct(v.inner.as_mut_ptr(), num, ty), real = ffi::PMIx_Data_array_construct(v.inner.as_mut_ptr(), num, ty)) }; v.constructed = true; v }
+    pub fn init(ty: ffi::pmix_data_type_t) -> Self { let mut v = Self::uninit(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_init(v.inner.as_mut_ptr(), ty), real = ffi::PMIx_Data_array_init(v.inner.as_mut_ptr(), ty)) }; v.constructed = true; v }
+    pub fn test_new() -> Self { Self { inner: std::mem::MaybeUninit::zeroed(), constructed: false, _not_thread_safe: std::marker::PhantomData } }
+    fn uninit() -> Self { Self { inner: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData } }
+    pub fn type_(&self) -> ffi::pmix_data_type_t { unsafe { self.inner.assume_init_ref().type_ } }
+    pub fn size(&self) -> usize { unsafe { self.inner.assume_init_ref().size } }
+    pub fn array(&self) -> Option<*mut std::ffi::c_void> { let p = unsafe { self.inner.assume_init_ref().array }; (!p.is_null()).then_some(p) }
+}
+impl Default for PmixDataArray { fn default() -> Self { Self::test_new() } }
+impl Drop for PmixDataArray { fn drop(&mut self) { if self.constructed { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_destruct(self.inner.as_mut_ptr()), real = ffi::PMIx_Data_array_destruct(self.inner.as_mut_ptr())) }; } } }
+
+/// RAII wrapper for PMIx_Data_array_create/free allocations.
+pub struct PmixDataArrayArray { ptr: *mut ffi::pmix_data_array_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixDataArrayArray { pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_data_array_t { self.ptr } pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+impl Drop for PmixDataArrayArray { fn drop(&mut self) { if !self.ptr.is_null() { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_free(self.ptr), real = ffi::PMIx_Data_array_free(self.ptr)) }; } } }
+pub fn data_array_create(n: usize, ty: ffi::pmix_data_type_t) -> Result<PmixDataArrayArray, PmixStatus> { let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_array_create(n, ty), real = ffi::PMIx_Data_array_create(n, ty)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixDataArrayArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
+
+/// Explicitly construct an empty byte object without changing `PmixByteObject::new`.
+pub fn byte_object_construct() -> PmixByteObject { let mut b = PmixByteObject::new(); unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_construct_stack(b.as_mut_ptr()), real = ffi::PMIx_Byte_object_construct(b.as_mut_ptr())) }; b }
+pub struct PmixByteObjectArray { ptr: *mut ffi::pmix_byte_object_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixByteObjectArray { pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_byte_object_t { self.ptr } pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+impl Drop for PmixByteObjectArray { fn drop(&mut self) { if !self.ptr.is_null() { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_free(self.ptr, self.len), real = ffi::PMIx_Byte_object_free(self.ptr, self.len)) }; } } }
+pub fn byte_object_create(n: usize) -> Result<PmixByteObjectArray, PmixStatus> { let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_create(n), real = ffi::PMIx_Byte_object_create(n)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixByteObjectArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
+pub fn byte_object_load(b: &mut PmixByteObject, data: &[u8]) { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_load(b.as_mut_ptr(), data.as_ptr() as *mut _, data.len()), real = ffi::PMIx_Byte_object_load(b.as_mut_ptr(), data.as_ptr() as *mut _, data.len())) }; }
+

--- a/src/data_serialization.rs
+++ b/src/data_serialization.rs
@@ -2274,40 +2274,84 @@ mod tests {
 }
 
 
-/// Construct a stack-style data buffer. This is distinct from create/release.
-pub fn data_buffer_construct() -> PmixDataBuffer {
-    let mut raw = Box::new(unsafe { std::mem::zeroed::<ffi::pmix_data_buffer_t>() });
-    let ptr = raw.as_mut() as *mut _;
-    std::mem::forget(raw);
-    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_construct(ptr), real = ffi::PMIx_Data_buffer_construct(ptr)) };
-    unsafe { PmixDataBuffer::from_raw(ptr) }
+/// Stack-allocated PMIx data buffer. Its provenance is distinct from `PmixDataBuffer`.
+pub struct PmixStackDataBuffer {
+    raw: std::mem::MaybeUninit<ffi::pmix_data_buffer_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
-/// Destruct a stack-style data buffer. Do not use with a buffer from create/release.
-pub fn data_buffer_destruct(buf: &mut PmixDataBuffer) {
-    if buf.is_valid() {
-        let raw = buf.ptr;
-        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_destruct(raw), real = ffi::PMIx_Data_buffer_destruct(raw)) };
-        buf.ptr = ptr::null_mut();
-        // SAFETY: data_buffer_construct allocated this exact storage with Box.
-        unsafe { drop(Box::from_raw(raw)); }
+impl PmixStackDataBuffer {
+    pub fn new() -> Self {
+        let mut value = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        // SAFETY: raw is exclusive, aligned storage reserved for this constructor.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_construct(value.raw.as_mut_ptr()), real = ffi::PMIx_Data_buffer_construct(value.raw.as_mut_ptr())) };
+        value.constructed = true;
+        value
+    }
+
+    #[cfg(any(test, feature = "mock_ffi"))]
+    pub fn test_new() -> Self { Self { raw: std::mem::MaybeUninit::zeroed(), constructed: false, _not_thread_safe: std::marker::PhantomData } }
+}
+
+impl Default for PmixStackDataBuffer { fn default() -> Self { Self::new() } }
+
+impl Drop for PmixStackDataBuffer {
+    fn drop(&mut self) {
+        if self.constructed {
+            // SAFETY: same in-place object initialized above; Drop runs once.
+            unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_destruct(self.raw.as_mut_ptr()), real = ffi::PMIx_Data_buffer_destruct(self.raw.as_mut_ptr())) };
+            self.constructed = false;
+        }
     }
 }
 
-/// Load bytes with PMIx_Data_buffer_load (not PMIx_Data_load).
+/// Construct a stack-style data buffer. This is distinct from create/release.
+pub fn data_buffer_construct() -> PmixStackDataBuffer { PmixStackDataBuffer::new() }
+
+/// Destruct a stack-style data buffer. Do not use with a buffer from create/release.
+pub fn data_buffer_destruct(buf: &mut PmixStackDataBuffer) {
+    if buf.constructed {
+        // SAFETY: this is the in-place object initialized by the matching
+        // constructor, and the flag prevents Drop from destructing twice.
+        unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_destruct(buf.raw.as_mut_ptr()), real = ffi::PMIx_Data_buffer_destruct(buf.raw.as_mut_ptr())) };
+        buf.constructed = false;
+    }
+}
+
+fn copy_to_c_owned(bytes: &[u8]) -> Result<*mut std::os::raw::c_char, PmixStatus> {
+    let size = bytes.len().max(1);
+    // SAFETY: malloc storage is compatible with PMIx's free.
+    let p = unsafe { libc::malloc(size) as *mut u8 };
+    if p.is_null() { return Err(PmixStatus::from_raw(-1)); }
+    // SAFETY: p has bytes.len() writable bytes and does not overlap the input.
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), p, bytes.len()); }
+    Ok(p as *mut std::os::raw::c_char)
+}
+
+/// Load bytes with PMIx_Data_buffer_load; input is copied into PMIx-owned memory.
 pub fn data_buffer_load(buf: &mut PmixDataBuffer, bytes: &[u8]) -> Result<(), PmixStatus> {
     if !buf.is_valid() { return Err(PmixStatus::from_raw(-1)); }
-    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_load(buf.as_mut_ptr(), bytes.as_ptr() as *mut _, bytes.len()), real = ffi::PMIx_Data_buffer_load(buf.as_mut_ptr(), bytes.as_ptr() as *mut _, bytes.len())) };
+    let p = copy_to_c_owned(bytes)?;
+    // SAFETY: p is malloc storage transferred to PMIx.
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_load(buf.as_mut_ptr(), p, bytes.len()), real = ffi::PMIx_Data_buffer_load(buf.as_mut_ptr(), p, bytes.len())) };
     Ok(())
 }
 
-/// Unload bytes with PMIx_Data_buffer_unload. PMIx retains ownership of the returned pointer.
+/// Unload bytes; PMIx transfers the returned pointer, which this wrapper frees.
 pub fn data_buffer_unload(buf: &mut PmixDataBuffer) -> Result<(Vec<u8>, usize), PmixStatus> {
     if !buf.is_valid() { return Err(PmixStatus::from_raw(-1)); }
     let mut bytes = ptr::null_mut();
     let mut size = 0usize;
+    // SAFETY: output pointers are valid locals for PMIx to write.
     unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_data_buffer_unload(buf.as_mut_ptr(), &mut bytes, &mut size), real = ffi::PMIx_Data_buffer_unload(buf.as_mut_ptr(), &mut bytes, &mut size)) };
-    let copied = if bytes.is_null() || size == 0 { Vec::new() } else { unsafe { std::slice::from_raw_parts(bytes as *const u8, size).to_vec() } };
+    let copied = if bytes.is_null() || size == 0 { Vec::new() } else {
+        // SAFETY: PMIx returned size readable bytes and ownership.
+        let v = unsafe { std::slice::from_raw_parts(bytes as *const u8, size).to_vec() };
+        // SAFETY: ownership transferred by PMIx.
+        unsafe { libc::free(bytes as *mut libc::c_void); }
+        v
+    };
     Ok((copied, size))
 }
 
@@ -2341,5 +2385,28 @@ impl PmixByteObjectArray { pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_byte_o
 }
 impl Drop for PmixByteObjectArray { fn drop(&mut self) { if !self.ptr.is_null() { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_free(self.ptr, self.len), real = ffi::PMIx_Byte_object_free(self.ptr, self.len)) }; } } }
 pub fn byte_object_create(n: usize) -> Result<PmixByteObjectArray, PmixStatus> { let p = unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_create(n), real = ffi::PMIx_Byte_object_create(n)) }; if p.is_null() { Err(PmixStatus::from_raw(-1)) } else { Ok(PmixByteObjectArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData }) } }
-pub fn byte_object_load(b: &mut PmixByteObject, data: &[u8]) { unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_load(b.as_mut_ptr(), data.as_ptr() as *mut _, data.len()), real = ffi::PMIx_Byte_object_load(b.as_mut_ptr(), data.as_ptr() as *mut _, data.len())) }; }
+pub fn byte_object_load(b: &mut PmixByteObject, data: &[u8]) {
+    let p = copy_to_c_owned(data).expect("malloc failed while loading byte object");
+    // SAFETY: p is malloc storage transferred to PMIx.
+    unsafe { crate::pmix_ffi_or_mock!(mock = crate::mock_ffi::mock_byte_object_load(b.as_mut_ptr(), p, data.len()), real = ffi::PMIx_Byte_object_load(b.as_mut_ptr(), p, data.len())) };
+}
+
+#[cfg(test)]
+mod data_utils_tests {
+    use super::*;
+    use crate::mock_ffi::MockGuard;
+
+    #[test]
+    fn data_buffer_construct_drops_without_double_free() { let _guard = MockGuard::new(); drop(data_buffer_construct()); }
+    #[test]
+    fn data_buffer_load_copies_input() { let _guard = MockGuard::new(); let mut b = data_buffer_create().unwrap(); data_buffer_load(&mut b, b"input").unwrap(); }
+    #[test]
+    fn data_buffer_unload_copies_and_frees_output() { let _guard = MockGuard::new(); let mut b = data_buffer_create().unwrap(); let (bytes, size) = data_buffer_unload(&mut b).unwrap(); assert_eq!((bytes, size), (b"abc".to_vec(), 3)); }
+    #[test]
+    fn byte_object_construct_and_load_copy_input() { let _guard = MockGuard::new(); let mut b = byte_object_construct(); byte_object_load(&mut b, b"input"); }
+    #[test]
+    fn data_array_construct_and_test_new_accessors() { let _guard = MockGuard::new(); let a = PmixDataArray::new(4, crate::mock_ffi::PMIX_INT as ffi::pmix_data_type_t); assert_eq!(a.size(), 4); let z = PmixDataArray::test_new(); assert_eq!(z.size(), 0); assert!(z.array().is_none()); }
+    #[test]
+    fn create_arrays_drop_without_panic() { let _guard = MockGuard::new(); drop(data_array_create(2, crate::mock_ffi::PMIX_INT as ffi::pmix_data_type_t).unwrap()); drop(byte_object_create(2).unwrap()); }
+}
 

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3484,3 +3484,19 @@ pub unsafe fn mock_node_pid_construct(p: *mut crate::ffi::pmix_node_pid_t) { if 
 pub unsafe fn mock_node_pid_destruct(_p: *mut crate::ffi::pmix_node_pid_t) {}
 pub unsafe fn mock_node_pid_create(n: usize) -> *mut crate::ffi::pmix_node_pid_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_node_pid_t>()) as *mut _ } }
 pub unsafe fn mock_node_pid_free(_p: *mut crate::ffi::pmix_node_pid_t, _n: usize) {}
+
+
+// Safe-wrapper support for PMIx data utility constructors and array APIs.
+pub unsafe fn mock_data_buffer_construct(b: *mut crate::ffi::pmix_data_buffer_t) { if !b.is_null() { unsafe { std::ptr::write_bytes(b, 0, 1) }; } }
+pub unsafe fn mock_data_buffer_destruct(_b: *mut crate::ffi::pmix_data_buffer_t) {}
+pub unsafe fn mock_data_buffer_load(_b: *mut crate::ffi::pmix_data_buffer_t, _bytes: *mut std::os::raw::c_char, _sz: usize) {}
+pub unsafe fn mock_data_buffer_unload(_b: *mut crate::ffi::pmix_data_buffer_t, bytes: *mut *mut std::os::raw::c_char, sz: *mut usize) { if !bytes.is_null() { unsafe { *bytes = std::ptr::null_mut(); } } if !sz.is_null() { unsafe { *sz = 0; } } }
+pub unsafe fn mock_data_array_construct(p: *mut crate::ffi::pmix_data_array_t, num: usize, ty: crate::ffi::pmix_data_type_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1); (*p).size = num; (*p).type_ = ty; } } }
+pub unsafe fn mock_data_array_init(p: *mut crate::ffi::pmix_data_array_t, ty: crate::ffi::pmix_data_type_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1); (*p).type_ = ty; } } }
+pub unsafe fn mock_data_array_destruct(_p: *mut crate::ffi::pmix_data_array_t) {}
+pub unsafe fn mock_data_array_create(n: usize, ty: crate::ffi::pmix_data_type_t) -> *mut crate::ffi::pmix_data_array_t { let p = (unsafe { libc::calloc(1, std::mem::size_of::<crate::ffi::pmix_data_array_t>()) }) as *mut crate::ffi::pmix_data_array_t; if !p.is_null() { unsafe { (*p).size = n; (*p).type_ = ty; } } p }
+pub unsafe fn mock_data_array_free(_p: *mut crate::ffi::pmix_data_array_t) {}
+pub unsafe fn mock_byte_object_construct_stack(b: *mut crate::ffi::pmix_byte_object_t) { if !b.is_null() { unsafe { std::ptr::write_bytes(b, 0, 1) }; } }
+pub unsafe fn mock_byte_object_create(n: usize) -> *mut crate::ffi::pmix_byte_object_t { (unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_byte_object_t>()) }) as *mut crate::ffi::pmix_byte_object_t }
+pub unsafe fn mock_byte_object_free(_g: *mut crate::ffi::pmix_byte_object_t, _n: usize) {}
+pub unsafe fn mock_byte_object_load(_b: *mut crate::ffi::pmix_byte_object_t, _d: *mut std::os::raw::c_char, _sz: usize) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3489,8 +3489,8 @@ pub unsafe fn mock_node_pid_free(_p: *mut crate::ffi::pmix_node_pid_t, _n: usize
 // Safe-wrapper support for PMIx data utility constructors and array APIs.
 pub unsafe fn mock_data_buffer_construct(b: *mut crate::ffi::pmix_data_buffer_t) { if !b.is_null() { unsafe { std::ptr::write_bytes(b, 0, 1) }; } }
 pub unsafe fn mock_data_buffer_destruct(_b: *mut crate::ffi::pmix_data_buffer_t) {}
-pub unsafe fn mock_data_buffer_load(_b: *mut crate::ffi::pmix_data_buffer_t, _bytes: *mut std::os::raw::c_char, _sz: usize) {}
-pub unsafe fn mock_data_buffer_unload(_b: *mut crate::ffi::pmix_data_buffer_t, bytes: *mut *mut std::os::raw::c_char, sz: *mut usize) { if !bytes.is_null() { unsafe { *bytes = std::ptr::null_mut(); } } if !sz.is_null() { unsafe { *sz = 0; } } }
+pub unsafe fn mock_data_buffer_load(_b: *mut crate::ffi::pmix_data_buffer_t, bytes: *mut std::os::raw::c_char, _sz: usize) { if !bytes.is_null() { unsafe { libc::free(bytes as *mut libc::c_void); } } }
+pub unsafe fn mock_data_buffer_unload(_b: *mut crate::ffi::pmix_data_buffer_t, bytes: *mut *mut std::os::raw::c_char, sz: *mut usize) { if !bytes.is_null() && !sz.is_null() { unsafe { let p = libc::malloc(3) as *mut std::os::raw::c_char; if !p.is_null() { std::ptr::copy_nonoverlapping(b"abc".as_ptr() as *const std::os::raw::c_char, p, 3); *bytes = p; *sz = 3; } } } }
 pub unsafe fn mock_data_array_construct(p: *mut crate::ffi::pmix_data_array_t, num: usize, ty: crate::ffi::pmix_data_type_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1); (*p).size = num; (*p).type_ = ty; } } }
 pub unsafe fn mock_data_array_init(p: *mut crate::ffi::pmix_data_array_t, ty: crate::ffi::pmix_data_type_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1); (*p).type_ = ty; } } }
 pub unsafe fn mock_data_array_destruct(_p: *mut crate::ffi::pmix_data_array_t) {}
@@ -3499,4 +3499,4 @@ pub unsafe fn mock_data_array_free(_p: *mut crate::ffi::pmix_data_array_t) {}
 pub unsafe fn mock_byte_object_construct_stack(b: *mut crate::ffi::pmix_byte_object_t) { if !b.is_null() { unsafe { std::ptr::write_bytes(b, 0, 1) }; } }
 pub unsafe fn mock_byte_object_create(n: usize) -> *mut crate::ffi::pmix_byte_object_t { (unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_byte_object_t>()) }) as *mut crate::ffi::pmix_byte_object_t }
 pub unsafe fn mock_byte_object_free(_g: *mut crate::ffi::pmix_byte_object_t, _n: usize) {}
-pub unsafe fn mock_byte_object_load(_b: *mut crate::ffi::pmix_byte_object_t, _d: *mut std::os::raw::c_char, _sz: usize) {}
+pub unsafe fn mock_byte_object_load(_b: *mut crate::ffi::pmix_byte_object_t, d: *mut std::os::raw::c_char, _sz: usize) { if !d.is_null() { unsafe { libc::free(d as *mut libc::c_void); } } }


### PR DESCRIPTION
Closes #82, Closes #102, Closes #85, Closes #105, Closes #202, Closes #214, Closes #224, Closes #227, Closes #241, Closes #246, Closes #254, Closes #317, Closes #339, Closes #352, Closes #357

## Summary
- Add safe wrappers for PMIx_Data_buffer construct/destruct/load/unload.
- Add RAII Data_array stack and allocated-array wrappers.
- Add explicit Byte_object construct/create/load wrappers.
- Keep implementation in data_serialization.rs alongside existing APIs; append mock FFI support for daemon-free tests.

## Test plan
- PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build
- cargo test --lib data_serialization::tests
- cargo clippy --lib -- -D warnings
- Daemon/DVM tests were not run; this change uses mock paths only.