### PR TITLE
feat(fabric): add safe wrappers for Coord/Device/DeviceDistance and array create/free families

### DIFF
--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -2670,3 +2670,188 @@ mod tests {
         assert!(fabric.is_registered());
     }
 }
+
+
+// Additional safe wrappers for PMIx fabric-related type families.
+
+/// Construct a PMIx fabric object with the C constructor.
+pub fn fabric_construct() -> PmixFabric {
+    let mut fabric = PmixFabric::new(None).expect("None cannot contain a NUL");
+    let raw = fabric.raw.as_mut_ptr();
+    #[cfg(any(test, feature = "mock_ffi"))]
+    if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_fabric_construct(raw); } } else { unsafe { ffi::PMIx_Fabric_construct(raw); } }
+    #[cfg(not(any(test, feature = "mock_ffi")))]
+    unsafe { ffi::PMIx_Fabric_construct(raw); }
+    fabric
+}
+
+/// Construct a PMIx topology object with the C constructor.
+pub fn topology_construct() -> PmixTopology {
+    let mut topology = PmixTopology::new(None).expect("None cannot contain a NUL");
+    let raw = topology.raw.as_mut_ptr();
+    #[cfg(any(test, feature = "mock_ffi"))]
+    if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_topology_construct(raw); } } else { unsafe { ffi::PMIx_Topology_construct(raw); } }
+    #[cfg(not(any(test, feature = "mock_ffi")))]
+    unsafe { ffi::PMIx_Topology_construct(raw); }
+    topology
+}
+
+/// RAII wrapper around a calloc-allocated PMIx array.
+macro_rules! pmix_array {
+    ($name:ident, $raw:ty, $create:ident, $free:ident, $mock_create:ident, $mock_free:ident $(, $extra:expr)*) => {
+        #[derive(Debug)]
+        pub struct $name { ptr: *mut $raw, len: usize }
+        impl $name {
+            /// Allocate `len` zeroed C objects. The pointer is freed on drop.
+            pub fn create(len: usize) -> Result<Self, PmixError> {
+                let ptr = {
+                    #[cfg(any(test, feature = "mock_ffi"))]
+                    { if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::$mock_create($($extra,)* len) } } else { unsafe { ffi::$create($($extra,)* len) } } }
+                    #[cfg(not(any(test, feature = "mock_ffi")))]
+                    { unsafe { ffi::$create($($extra,)* len) } }
+                };
+                if ptr.is_null() { Err(PmixError::ErrNomem) } else { Ok(Self { ptr, len }) }
+            }
+            /// Return the owned C array pointer.
+            pub fn as_mut_ptr(&self) -> *mut $raw { self.ptr }
+            /// Return the number of C objects in the array.
+            pub fn len(&self) -> usize { self.len }
+            /// Return whether the C array is empty.
+            pub fn is_empty(&self) -> bool { self.len == 0 }
+        }
+        impl Drop for $name {
+            fn drop(&mut self) {
+                if self.ptr.is_null() { return; }
+                #[cfg(any(test, feature = "mock_ffi"))]
+                if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::$mock_free(self.ptr, self.len); } } else { unsafe { ffi::$free(self.ptr, self.len); } }
+                #[cfg(not(any(test, feature = "mock_ffi")))]
+                unsafe { ffi::$free(self.ptr, self.len); }
+            }
+        }
+    };
+}
+
+pmix_array!(PmixGeometryArray, ffi::pmix_geometry_t, PMIx_Geometry_create, PMIx_Geometry_free, mock_geometry_create, mock_geometry_free);
+pmix_array!(PmixTopologyArray, ffi::pmix_topology_t, PMIx_Topology_create, PMIx_Topology_free, mock_topology_create, mock_topology_free);
+pmix_array!(PmixCpusetArray, ffi::pmix_cpuset_t, PMIx_Cpuset_create, PMIx_Cpuset_free, mock_cpuset_create, mock_cpuset_free);
+pmix_array!(PmixEndpointArray, ffi::pmix_endpoint_t, PMIx_Endpoint_create, PMIx_Endpoint_free, mock_endpoint_create, mock_endpoint_free);
+pmix_array!(PmixDeviceArray, ffi::pmix_device_t, PMIx_Device_create, PMIx_Device_free, mock_device_create, mock_device_free);
+pmix_array!(PmixDeviceDistanceArray, ffi::pmix_device_distance_t, PMIx_Device_distance_create, PMIx_Device_distance_free, mock_device_distance_create, mock_device_distance_free);
+pmix_array!(PmixCoordArray, ffi::pmix_coord_t, PMIx_Coord_create, PMIx_Coord_free, mock_coord_create, mock_coord_free, 0);
+
+macro_rules! c_string_accessor {
+    ($name:ident, $field:ident) => {
+        pub fn $name(&self) -> Option<&str> {
+            // SAFETY: raw is initialized by new/test_new and the returned slice borrows self.
+            unsafe { let p = self.raw.assume_init_ref().$field; (!p.is_null()).then(|| CStr::from_ptr(p).to_str().ok()).flatten() }
+        }
+    };
+}
+
+/// Safe RAII wrapper around `pmix_coord_t`.
+#[derive(Debug)]
+pub struct PmixCoord { raw: MaybeUninit<ffi::pmix_coord_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixCoord {
+    pub fn new() -> Self { let mut this = Self { raw: MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData }; let p = this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_coord_construct(p); } } else { unsafe { ffi::PMIx_Coord_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Coord_construct(p); } this.constructed = true; this }
+    pub fn test_new() -> Self { Self { raw: MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
+    pub fn view(&self) -> ffi::pmix_coord_view_t { unsafe { self.raw.assume_init_ref().view } }
+    pub fn coord(&self) -> Option<&[u32]> { unsafe { let r = self.raw.assume_init_ref(); (!r.coord.is_null()).then(|| std::slice::from_raw_parts(r.coord, r.dims)) } }
+    pub fn dims(&self) -> usize { unsafe { self.raw.assume_init_ref().dims } }
+}
+impl Default for PmixCoord { fn default() -> Self { Self::new() } }
+impl Drop for PmixCoord { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_coord_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr()); } self.constructed = false; } } }
+
+/// Safe RAII wrapper around `pmix_device_t`.
+#[derive(Debug)]
+pub struct PmixDevice { raw: MaybeUninit<ffi::pmix_device_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixDevice {
+    pub fn new() -> Self { let mut this = Self { raw: MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData }; let p=this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_construct(p); } } else { unsafe { ffi::PMIx_Device_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_construct(p); } this.constructed=true; this }
+    pub fn test_new() -> Self { Self { raw: MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
+    c_string_accessor!(uuid, uuid); c_string_accessor!(osname, osname);
+    pub fn device_type(&self) -> ffi::pmix_device_type_t { unsafe { self.raw.assume_init_ref().type_ } }
+}
+impl Default for PmixDevice { fn default() -> Self { Self::new() } }
+impl Drop for PmixDevice { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Device_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_destruct(self.raw.as_mut_ptr()); } self.constructed=false; } } }
+
+/// Safe RAII wrapper around `pmix_device_distance_t`.
+#[derive(Debug)]
+pub struct PmixDeviceDistanceObject { raw: MaybeUninit<ffi::pmix_device_distance_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixDeviceDistanceObject {
+    pub fn new() -> Self { let mut this=Self { raw:MaybeUninit::uninit(), constructed:false, _not_thread_safe:std::marker::PhantomData }; let p=this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_distance_construct(p); } } else { unsafe { ffi::PMIx_Device_distance_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_distance_construct(p); } this.constructed=true; this }
+    pub fn test_new() -> Self { Self { raw:MaybeUninit::zeroed(), constructed:true, _not_thread_safe:std::marker::PhantomData } }
+    c_string_accessor!(uuid, uuid); c_string_accessor!(osname, osname);
+    pub fn device_type(&self) -> ffi::pmix_device_type_t { unsafe { self.raw.assume_init_ref().type_ } }
+    pub fn min_distance(&self) -> u16 { unsafe { self.raw.assume_init_ref().mindist } }
+    pub fn max_distance(&self) -> u16 { unsafe { self.raw.assume_init_ref().maxdist } }
+}
+impl Default for PmixDeviceDistanceObject { fn default()->Self { Self::new() } }
+impl Drop for PmixDeviceDistanceObject { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_distance_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr()); } self.constructed=false; } } }
+
+
+#[cfg(test)]
+mod added_type_tests {
+    use super::*;
+
+    #[test]
+    fn construct_wrappers_and_arrays_use_mock_ffi() {
+        let _guard = mock_ffi::MockGuard::new();
+        let _fabric = fabric_construct();
+        let _topology = topology_construct();
+        let _coord = PmixCoord::new();
+        let _device = PmixDevice::new();
+        let _distance = PmixDeviceDistanceObject::new();
+        assert_eq!(PmixGeometryArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixTopologyArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixCpusetArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixEndpointArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixCoordArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixDeviceArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixDeviceDistanceArray::create(2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_new_accessors_are_zeroed_and_safe() {
+        let _guard = mock_ffi::MockGuard::new();
+        let coord = PmixCoord::test_new();
+        assert_eq!(coord.view(), 0);
+        assert_eq!(coord.dims(), 0);
+        assert!(coord.coord().is_none());
+        let device = PmixDevice::test_new();
+        assert!(device.uuid().is_none());
+        assert!(device.osname().is_none());
+        assert_eq!(device.device_type(), 0);
+        let distance = PmixDeviceDistanceObject::test_new();
+        assert!(distance.uuid().is_none());
+        assert!(distance.osname().is_none());
+        assert_eq!(distance.device_type(), 0);
+        assert_eq!(distance.min_distance(), 0);
+        assert_eq!(distance.max_distance(), 0);
+    }
+
+    #[test]
+    fn non_null_accessors_read_c_fields() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut coord = PmixCoord::test_new();
+        let values = [10_u32, 20, 30];
+        unsafe {
+            let raw = coord.raw.assume_init_mut();
+            raw.view = 7;
+            raw.coord = values.as_ptr() as *mut _;
+            raw.dims = values.len();
+        }
+        assert_eq!(coord.view(), 7);
+        assert_eq!(coord.coord(), Some(values.as_slice()));
+        let mut device = PmixDevice::test_new();
+        let uuid = CString::new("dev-uuid").unwrap();
+        let osname = CString::new("gpu0").unwrap();
+        unsafe {
+            let raw = device.raw.assume_init_mut();
+            raw.uuid = uuid.as_ptr() as *mut _;
+            raw.osname = osname.as_ptr() as *mut _;
+            raw.type_ = 9;
+        }
+        assert_eq!(device.uuid(), Some("dev-uuid"));
+        assert_eq!(device.osname(), Some("gpu0"));
+        assert_eq!(device.device_type(), 9);
+    }
+}

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -960,7 +960,7 @@ impl PmixCpuset {
                 #[cfg(any(test, feature = "mock_ffi"))]
         {
             if mock_ffi::is_mock_enabled() {
-                unsafe { mock_ffi::mock_cpuset_construct(raw_ptr) };
+                mock_ffi::mock_cpuset_construct(raw_ptr);
             } else {
                 unsafe { ffi::PMIx_Cpuset_construct(raw_ptr) };
             }
@@ -2888,7 +2888,9 @@ impl PmixCoordArray {
         if ptr.is_null() {
             return Err(PmixError::ErrNomem);
         }
-        for index in 0..len {
+        // PMIx_Coord_create constructs element zero and initializes its
+        // dimension buffer; reconstructing it would leak that buffer.
+        for index in 1..len {
             // SAFETY: PMIx returned `len` contiguous coordinate objects.
             let element = unsafe { ptr.add(index) };
             #[cfg(any(test, feature = "mock_ffi"))]
@@ -2975,10 +2977,12 @@ impl PmixCoord {
             // SAFETY: p points to this object's uninitialized storage.
             unsafe { mock_ffi::mock_coord_construct(p) };
         } else {
+            // SAFETY: p points to this object's uninitialized storage.
             unsafe { ffi::PMIx_Coord_construct(p) };
         }
         #[cfg(not(any(test, feature = "mock_ffi")))]
         {
+            // SAFETY: p points to this object's uninitialized storage.
             unsafe { ffi::PMIx_Coord_construct(p) };
         }
         this.constructed = true;
@@ -2994,10 +2998,12 @@ impl PmixCoord {
     }
     /// Return the coordinate view value.
     pub fn view(&self) -> ffi::pmix_coord_view_t {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().view }
     }
     /// Return the coordinate values, if present.
     pub fn coord(&self) -> Option<&[u32]> {
+        // SAFETY: raw is initialized by new or test_new; coord and dims are a PMIx pair.
         unsafe {
             let r = self.raw.assume_init_ref();
             (!r.coord.is_null()).then(|| std::slice::from_raw_parts(r.coord, r.dims))
@@ -3005,6 +3011,7 @@ impl PmixCoord {
     }
     /// Return the number of dimensions.
     pub fn dims(&self) -> usize {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().dims }
     }
 }
@@ -3018,15 +3025,18 @@ impl Drop for PmixCoord {
         if self.constructed {
             #[cfg(any(test, feature = "mock_ffi"))]
             if mock_ffi::is_mock_enabled() {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     mock_ffi::mock_coord_destruct(self.raw.as_mut_ptr());
                 }
             } else {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr());
                 }
             }
             #[cfg(not(any(test, feature = "mock_ffi")))]
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr());
             }
@@ -3053,15 +3063,18 @@ impl PmixDevice {
         let p = this.raw.as_mut_ptr();
         #[cfg(any(test, feature = "mock_ffi"))]
         if mock_ffi::is_mock_enabled() {
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 mock_ffi::mock_device_construct(p);
             }
         } else {
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 ffi::PMIx_Device_construct(p);
             }
         }
         #[cfg(not(any(test, feature = "mock_ffi")))]
+        // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
         unsafe {
             ffi::PMIx_Device_construct(p);
         }
@@ -3080,6 +3093,7 @@ impl PmixDevice {
     c_string_accessor!(osname, osname);
     /// Return the PMIx device type.
     pub fn device_type(&self) -> ffi::pmix_device_type_t {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().type_ }
     }
 }
@@ -3093,15 +3107,18 @@ impl Drop for PmixDevice {
         if self.constructed {
             #[cfg(any(test, feature = "mock_ffi"))]
             if mock_ffi::is_mock_enabled() {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     mock_ffi::mock_device_destruct(self.raw.as_mut_ptr());
                 }
             } else {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     ffi::PMIx_Device_destruct(self.raw.as_mut_ptr());
                 }
             }
             #[cfg(not(any(test, feature = "mock_ffi")))]
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 ffi::PMIx_Device_destruct(self.raw.as_mut_ptr());
             }
@@ -3111,7 +3128,8 @@ impl Drop for PmixDevice {
 }
 
 /// RAII wrapper for a PMIx device-distance object. This is distinct from the
-/// pure-Rust `PmixDeviceDistance` parsed snapshot type.
+/// pure-Rust `PmixDeviceDistance` parsed snapshot type. PMIx initializes both
+/// `mindist` and `maxdist` to 65535 (`u16::MAX`).
 #[derive(Debug)]
 pub struct PmixDeviceDistanceObject {
     raw: MaybeUninit<ffi::pmix_device_distance_t>,
@@ -3129,15 +3147,18 @@ impl PmixDeviceDistanceObject {
         let p = this.raw.as_mut_ptr();
         #[cfg(any(test, feature = "mock_ffi"))]
         if mock_ffi::is_mock_enabled() {
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 mock_ffi::mock_device_distance_construct(p);
             }
         } else {
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 ffi::PMIx_Device_distance_construct(p);
             }
         }
         #[cfg(not(any(test, feature = "mock_ffi")))]
+        // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
         unsafe {
             ffi::PMIx_Device_distance_construct(p);
         }
@@ -3156,14 +3177,17 @@ impl PmixDeviceDistanceObject {
     c_string_accessor!(osname, osname);
     /// Return the PMIx device type.
     pub fn device_type(&self) -> ffi::pmix_device_type_t {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().type_ }
     }
     /// Return the minimum distance.
     pub fn min_distance(&self) -> u16 {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().mindist }
     }
     /// Return the maximum distance.
     pub fn max_distance(&self) -> u16 {
+        // SAFETY: raw is initialized by new or test_new.
         unsafe { self.raw.assume_init_ref().maxdist }
     }
 }
@@ -3177,15 +3201,18 @@ impl Drop for PmixDeviceDistanceObject {
         if self.constructed {
             #[cfg(any(test, feature = "mock_ffi"))]
             if mock_ffi::is_mock_enabled() {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     mock_ffi::mock_device_distance_destruct(self.raw.as_mut_ptr());
                 }
             } else {
+                // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
                 unsafe {
                     ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr());
                 }
             }
             #[cfg(not(any(test, feature = "mock_ffi")))]
+            // SAFETY: the raw object is initialized by PMIx or test_new and belongs to self.
             unsafe {
                 ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr());
             }
@@ -3228,7 +3255,7 @@ mod added_type_tests {
         let array = PmixCoordArray::create(3, 2).unwrap();
         assert_eq!(array.len(), 2);
         unsafe {
-            assert_eq!((*array.as_mut_ptr()).dims, 0);
+            assert_eq!((*array.as_mut_ptr()).dims, 3);
             assert_eq!((*array.as_mut_ptr().add(1)).dims, 0);
         }
     }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -756,7 +756,7 @@ impl PmixGeometry {
         #[cfg(any(test, feature = "mock_ffi"))]
         {
             if mock_ffi::is_mock_enabled() {
-                mock_ffi::mock_geometry_construct(raw_ptr);
+                unsafe { mock_ffi::mock_geometry_construct(raw_ptr) };
             } else {
                 unsafe { ffi::PMIx_Geometry_construct(raw_ptr) };
             }
@@ -857,7 +857,7 @@ impl PmixEndpoint {
         #[cfg(any(test, feature = "mock_ffi"))]
         {
             if mock_ffi::is_mock_enabled() {
-                mock_ffi::mock_endpoint_construct(raw_ptr);
+                unsafe { mock_ffi::mock_endpoint_construct(raw_ptr) };
             } else {
                 unsafe { ffi::PMIx_Endpoint_construct(raw_ptr) };
             }
@@ -960,7 +960,7 @@ impl PmixCpuset {
                 #[cfg(any(test, feature = "mock_ffi"))]
         {
             if mock_ffi::is_mock_enabled() {
-                mock_ffi::mock_cpuset_construct(raw_ptr);
+                unsafe { mock_ffi::mock_cpuset_construct(raw_ptr) };
             } else {
                 unsafe { ffi::PMIx_Cpuset_construct(raw_ptr) };
             }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -2675,13 +2675,25 @@ mod tests {
 // Additional safe wrappers for PMIx fabric-related type families.
 
 /// Construct a PMIx fabric object with the C constructor.
+///
+/// The C-constructed result is valid only through the raw handle. `PmixFabric`
+/// manages its Rust-owned fields separately and does not drop this raw struct.
 pub fn fabric_construct() -> PmixFabric {
     let mut fabric = PmixFabric::new(None).expect("None cannot contain a NUL");
     let raw = fabric.raw.as_mut_ptr();
     #[cfg(any(test, feature = "mock_ffi"))]
-    if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_fabric_construct(raw); } } else { unsafe { ffi::PMIx_Fabric_construct(raw); } }
+    if mock_ffi::is_mock_enabled() {
+        // SAFETY: `raw` points to the initialized storage owned by `fabric`.
+        unsafe { mock_ffi::mock_fabric_construct(raw) };
+    } else {
+        // SAFETY: `raw` points to the initialized storage owned by `fabric`.
+        unsafe { ffi::PMIx_Fabric_construct(raw) };
+    }
     #[cfg(not(any(test, feature = "mock_ffi")))]
-    unsafe { ffi::PMIx_Fabric_construct(raw); }
+    {
+        // SAFETY: `raw` points to the initialized storage owned by `fabric`.
+        unsafe { ffi::PMIx_Fabric_construct(raw) };
+    }
     fabric
 }
 
@@ -2690,28 +2702,76 @@ pub fn topology_construct() -> PmixTopology {
     let mut topology = PmixTopology::new(None).expect("None cannot contain a NUL");
     let raw = topology.raw.as_mut_ptr();
     #[cfg(any(test, feature = "mock_ffi"))]
-    if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_topology_construct(raw); } } else { unsafe { ffi::PMIx_Topology_construct(raw); } }
+    if mock_ffi::is_mock_enabled() {
+        // SAFETY: `raw` points to the initialized storage owned by `topology`.
+        unsafe { mock_ffi::mock_topology_construct(raw) };
+    } else {
+        // SAFETY: `raw` points to the initialized storage owned by `topology`.
+        unsafe { ffi::PMIx_Topology_construct(raw) };
+    }
     #[cfg(not(any(test, feature = "mock_ffi")))]
-    unsafe { ffi::PMIx_Topology_construct(raw); }
+    {
+        // SAFETY: `raw` points to the initialized storage owned by `topology`.
+        unsafe { ffi::PMIx_Topology_construct(raw) };
+    }
     topology
 }
 
-/// RAII wrapper around a calloc-allocated PMIx array.
+/// RAII wrapper around a PMIx array allocated by its C API.
 macro_rules! pmix_array {
-    ($name:ident, $raw:ty, $create:ident, $free:ident, $mock_create:ident, $mock_free:ident $(, $extra:expr)*) => {
+    ($name:ident, $raw:ty, $create:ident, $free:ident, $construct:ident,
+        $mock_create:ident, $mock_free:ident, $mock_construct:ident $(, $extra:expr)*) => {
         #[derive(Debug)]
         pub struct $name { ptr: *mut $raw, len: usize }
+
         impl $name {
-            /// Allocate `len` zeroed C objects. The pointer is freed on drop.
+            /// Allocate and construct `len` C objects. A zero-length request
+            /// returns `ErrNomem`, matching PMIx 6.1's NULL result.
             pub fn create(len: usize) -> Result<Self, PmixError> {
+                Self::create_with_args(len)
+            }
+
+            fn create_with_args(len: usize) -> Result<Self, PmixError> {
                 let ptr = {
                     #[cfg(any(test, feature = "mock_ffi"))]
-                    { if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::$mock_create($($extra,)* len) } } else { unsafe { ffi::$create($($extra,)* len) } } }
+                    if mock_ffi::is_mock_enabled() {
+                        // SAFETY: the mock receives the requested count and returns
+                        // either a fresh allocation or NULL.
+                        unsafe { mock_ffi::$mock_create($($extra,)* len) }
+                    } else {
+                        // SAFETY: PMIx allocates an array of `len` raw objects.
+                        unsafe { ffi::$create($($extra,)* len) }
+                    }
                     #[cfg(not(any(test, feature = "mock_ffi")))]
-                    { unsafe { ffi::$create($($extra,)* len) } }
+                    {
+                        // SAFETY: PMIx allocates an array of `len` raw objects.
+                        unsafe { ffi::$create($($extra,)* len) }
+                    }
                 };
-                if ptr.is_null() { Err(PmixError::ErrNomem) } else { Ok(Self { ptr, len }) }
+                if ptr.is_null() {
+                    return Err(PmixError::ErrNomem);
+                }
+                for index in 0..len {
+                    // SAFETY: PMIx returned storage for `len` contiguous elements;
+                    // each element is constructed exactly once before Drop frees it.
+                    let element = unsafe { ptr.add(index) };
+                    #[cfg(any(test, feature = "mock_ffi"))]
+                    if mock_ffi::is_mock_enabled() {
+                        // SAFETY: `element` points into the PMIx allocation.
+                        unsafe { mock_ffi::$mock_construct(element) };
+                    } else {
+                        // SAFETY: `element` points into the PMIx allocation.
+                        unsafe { ffi::$construct(element) };
+                    }
+                    #[cfg(not(any(test, feature = "mock_ffi")))]
+                    {
+                        // SAFETY: `element` points into the PMIx allocation.
+                        unsafe { ffi::$construct(element) };
+                    }
+                }
+                Ok(Self { ptr, len })
             }
+
             /// Return the owned C array pointer.
             pub fn as_mut_ptr(&self) -> *mut $raw { self.ptr }
             /// Return the number of C objects in the array.
@@ -2719,74 +2779,420 @@ macro_rules! pmix_array {
             /// Return whether the C array is empty.
             pub fn is_empty(&self) -> bool { self.len == 0 }
         }
+
         impl Drop for $name {
             fn drop(&mut self) {
                 if self.ptr.is_null() { return; }
                 #[cfg(any(test, feature = "mock_ffi"))]
-                if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::$mock_free(self.ptr, self.len); } } else { unsafe { ffi::$free(self.ptr, self.len); } }
+                if mock_ffi::is_mock_enabled() {
+                    // SAFETY: pointer and length are the values returned by PMIx.
+                    unsafe { mock_ffi::$mock_free(self.ptr, self.len) };
+                } else {
+                    // SAFETY: pointer and length are the values returned by PMIx.
+                    unsafe { ffi::$free(self.ptr, self.len) };
+                }
                 #[cfg(not(any(test, feature = "mock_ffi")))]
-                unsafe { ffi::$free(self.ptr, self.len); }
+                {
+                    // SAFETY: pointer and length are the values returned by PMIx.
+                    unsafe { ffi::$free(self.ptr, self.len) };
+                }
             }
         }
     };
 }
 
-pmix_array!(PmixGeometryArray, ffi::pmix_geometry_t, PMIx_Geometry_create, PMIx_Geometry_free, mock_geometry_create, mock_geometry_free);
-pmix_array!(PmixTopologyArray, ffi::pmix_topology_t, PMIx_Topology_create, PMIx_Topology_free, mock_topology_create, mock_topology_free);
-pmix_array!(PmixCpusetArray, ffi::pmix_cpuset_t, PMIx_Cpuset_create, PMIx_Cpuset_free, mock_cpuset_create, mock_cpuset_free);
-pmix_array!(PmixEndpointArray, ffi::pmix_endpoint_t, PMIx_Endpoint_create, PMIx_Endpoint_free, mock_endpoint_create, mock_endpoint_free);
-pmix_array!(PmixDeviceArray, ffi::pmix_device_t, PMIx_Device_create, PMIx_Device_free, mock_device_create, mock_device_free);
-pmix_array!(PmixDeviceDistanceArray, ffi::pmix_device_distance_t, PMIx_Device_distance_create, PMIx_Device_distance_free, mock_device_distance_create, mock_device_distance_free);
-pmix_array!(PmixCoordArray, ffi::pmix_coord_t, PMIx_Coord_create, PMIx_Coord_free, mock_coord_create, mock_coord_free, 0);
+pmix_array!(
+    PmixGeometryArray,
+    ffi::pmix_geometry_t,
+    PMIx_Geometry_create,
+    PMIx_Geometry_free,
+    PMIx_Geometry_construct,
+    mock_geometry_create,
+    mock_geometry_free,
+    mock_geometry_construct
+);
+pmix_array!(
+    PmixTopologyArray,
+    ffi::pmix_topology_t,
+    PMIx_Topology_create,
+    PMIx_Topology_free,
+    PMIx_Topology_construct,
+    mock_topology_create,
+    mock_topology_free,
+    mock_topology_construct
+);
+pmix_array!(
+    PmixCpusetArray,
+    ffi::pmix_cpuset_t,
+    PMIx_Cpuset_create,
+    PMIx_Cpuset_free,
+    PMIx_Cpuset_construct,
+    mock_cpuset_create,
+    mock_cpuset_free,
+    mock_cpuset_construct
+);
+pmix_array!(
+    PmixEndpointArray,
+    ffi::pmix_endpoint_t,
+    PMIx_Endpoint_create,
+    PMIx_Endpoint_free,
+    PMIx_Endpoint_construct,
+    mock_endpoint_create,
+    mock_endpoint_free,
+    mock_endpoint_construct
+);
+pmix_array!(
+    PmixDeviceArray,
+    ffi::pmix_device_t,
+    PMIx_Device_create,
+    PMIx_Device_free,
+    PMIx_Device_construct,
+    mock_device_create,
+    mock_device_free,
+    mock_device_construct
+);
+pmix_array!(
+    PmixDeviceDistanceArray,
+    ffi::pmix_device_distance_t,
+    PMIx_Device_distance_create,
+    PMIx_Device_distance_free,
+    PMIx_Device_distance_construct,
+    mock_device_distance_create,
+    mock_device_distance_free,
+    mock_device_distance_construct
+);
+
+/// An array of coordinate objects; `dims` is passed to PMIx_Coord_create.
+#[derive(Debug)]
+pub struct PmixCoordArray {
+    ptr: *mut ffi::pmix_coord_t,
+    len: usize,
+}
+impl PmixCoordArray {
+    /// Allocate and construct `len` coordinate objects with `dims` dimensions.
+    pub fn create(dims: usize, len: usize) -> Result<Self, PmixError> {
+        let ptr = {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                // SAFETY: mock allocation is parameterized by dimensions and count.
+                unsafe { mock_ffi::mock_coord_create(dims, len) }
+            } else {
+                // SAFETY: PMIx allocates an array of coordinate objects.
+                unsafe { ffi::PMIx_Coord_create(dims, len) }
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                unsafe { ffi::PMIx_Coord_create(dims, len) }
+            }
+        };
+        if ptr.is_null() {
+            return Err(PmixError::ErrNomem);
+        }
+        for index in 0..len {
+            // SAFETY: PMIx returned `len` contiguous coordinate objects.
+            let element = unsafe { ptr.add(index) };
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                // SAFETY: element belongs to the mock allocation.
+                unsafe { mock_ffi::mock_coord_construct(element) };
+            } else {
+                // SAFETY: element belongs to the PMIx allocation.
+                unsafe { ffi::PMIx_Coord_construct(element) };
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                unsafe { ffi::PMIx_Coord_construct(element) };
+            }
+        }
+        Ok(Self { ptr, len })
+    }
+    /// Return the owned C array pointer.
+    pub fn as_mut_ptr(&self) -> *mut ffi::pmix_coord_t {
+        self.ptr
+    }
+    /// Return the number of coordinates.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    /// Return whether no coordinates were allocated.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+impl Drop for PmixCoordArray {
+    fn drop(&mut self) {
+        if self.ptr.is_null() {
+            return;
+        }
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            // SAFETY: pointer and length are the values returned by PMIx.
+            unsafe { mock_ffi::mock_coord_free(self.ptr, self.len) };
+        } else {
+            // SAFETY: pointer and length are the values returned by PMIx.
+            unsafe { ffi::PMIx_Coord_free(self.ptr, self.len) };
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            unsafe { ffi::PMIx_Coord_free(self.ptr, self.len) };
+        }
+    }
+}
 
 macro_rules! c_string_accessor {
     ($name:ident, $field:ident) => {
+        /// Return the C string field as UTF-8, if present.
         pub fn $name(&self) -> Option<&str> {
             // SAFETY: raw is initialized by new/test_new and the returned slice borrows self.
-            unsafe { let p = self.raw.assume_init_ref().$field; (!p.is_null()).then(|| CStr::from_ptr(p).to_str().ok()).flatten() }
+            unsafe {
+                let p = self.raw.assume_init_ref().$field;
+                (!p.is_null())
+                    .then(|| CStr::from_ptr(p).to_str().ok())
+                    .flatten()
+            }
         }
     };
 }
 
 /// Safe RAII wrapper around `pmix_coord_t`.
 #[derive(Debug)]
-pub struct PmixCoord { raw: MaybeUninit<ffi::pmix_coord_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
-impl PmixCoord {
-    pub fn new() -> Self { let mut this = Self { raw: MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData }; let p = this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_coord_construct(p); } } else { unsafe { ffi::PMIx_Coord_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Coord_construct(p); } this.constructed = true; this }
-    pub fn test_new() -> Self { Self { raw: MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
-    pub fn view(&self) -> ffi::pmix_coord_view_t { unsafe { self.raw.assume_init_ref().view } }
-    pub fn coord(&self) -> Option<&[u32]> { unsafe { let r = self.raw.assume_init_ref(); (!r.coord.is_null()).then(|| std::slice::from_raw_parts(r.coord, r.dims)) } }
-    pub fn dims(&self) -> usize { unsafe { self.raw.assume_init_ref().dims } }
+pub struct PmixCoord {
+    raw: MaybeUninit<ffi::pmix_coord_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
-impl Default for PmixCoord { fn default() -> Self { Self::new() } }
-impl Drop for PmixCoord { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_coord_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr()); } self.constructed = false; } } }
+impl PmixCoord {
+    /// Construct a coordinate with PMIx defaults.
+    pub fn new() -> Self {
+        let mut this = Self {
+            raw: MaybeUninit::uninit(),
+            constructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        };
+        let p = this.raw.as_mut_ptr();
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            // SAFETY: p points to this object's uninitialized storage.
+            unsafe { mock_ffi::mock_coord_construct(p) };
+        } else {
+            unsafe { ffi::PMIx_Coord_construct(p) };
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        {
+            unsafe { ffi::PMIx_Coord_construct(p) };
+        }
+        this.constructed = true;
+        this
+    }
+    /// Construct a zeroed test object without C-owned allocations.
+    pub fn test_new() -> Self {
+        Self {
+            raw: MaybeUninit::zeroed(),
+            constructed: true,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
+    /// Return the coordinate view value.
+    pub fn view(&self) -> ffi::pmix_coord_view_t {
+        unsafe { self.raw.assume_init_ref().view }
+    }
+    /// Return the coordinate values, if present.
+    pub fn coord(&self) -> Option<&[u32]> {
+        unsafe {
+            let r = self.raw.assume_init_ref();
+            (!r.coord.is_null()).then(|| std::slice::from_raw_parts(r.coord, r.dims))
+        }
+    }
+    /// Return the number of dimensions.
+    pub fn dims(&self) -> usize {
+        unsafe { self.raw.assume_init_ref().dims }
+    }
+}
+impl Default for PmixCoord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl Drop for PmixCoord {
+    fn drop(&mut self) {
+        if self.constructed {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                unsafe {
+                    mock_ffi::mock_coord_destruct(self.raw.as_mut_ptr());
+                }
+            } else {
+                unsafe {
+                    ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr());
+                }
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            unsafe {
+                ffi::PMIx_Coord_destruct(self.raw.as_mut_ptr());
+            }
+            self.constructed = false;
+        }
+    }
+}
 
 /// Safe RAII wrapper around `pmix_device_t`.
 #[derive(Debug)]
-pub struct PmixDevice { raw: MaybeUninit<ffi::pmix_device_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+pub struct PmixDevice {
+    raw: MaybeUninit<ffi::pmix_device_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
 impl PmixDevice {
-    pub fn new() -> Self { let mut this = Self { raw: MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData }; let p=this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_construct(p); } } else { unsafe { ffi::PMIx_Device_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_construct(p); } this.constructed=true; this }
-    pub fn test_new() -> Self { Self { raw: MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
-    c_string_accessor!(uuid, uuid); c_string_accessor!(osname, osname);
-    pub fn device_type(&self) -> ffi::pmix_device_type_t { unsafe { self.raw.assume_init_ref().type_ } }
+    /// Construct a device with PMIx defaults.
+    pub fn new() -> Self {
+        let mut this = Self {
+            raw: MaybeUninit::uninit(),
+            constructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        };
+        let p = this.raw.as_mut_ptr();
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            unsafe {
+                mock_ffi::mock_device_construct(p);
+            }
+        } else {
+            unsafe {
+                ffi::PMIx_Device_construct(p);
+            }
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe {
+            ffi::PMIx_Device_construct(p);
+        }
+        this.constructed = true;
+        this
+    }
+    /// Construct a zeroed test object without C-owned allocations.
+    pub fn test_new() -> Self {
+        Self {
+            raw: MaybeUninit::zeroed(),
+            constructed: true,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
+    c_string_accessor!(uuid, uuid);
+    c_string_accessor!(osname, osname);
+    /// Return the PMIx device type.
+    pub fn device_type(&self) -> ffi::pmix_device_type_t {
+        unsafe { self.raw.assume_init_ref().type_ }
+    }
 }
-impl Default for PmixDevice { fn default() -> Self { Self::new() } }
-impl Drop for PmixDevice { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Device_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_destruct(self.raw.as_mut_ptr()); } self.constructed=false; } } }
+impl Default for PmixDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl Drop for PmixDevice {
+    fn drop(&mut self) {
+        if self.constructed {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                unsafe {
+                    mock_ffi::mock_device_destruct(self.raw.as_mut_ptr());
+                }
+            } else {
+                unsafe {
+                    ffi::PMIx_Device_destruct(self.raw.as_mut_ptr());
+                }
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            unsafe {
+                ffi::PMIx_Device_destruct(self.raw.as_mut_ptr());
+            }
+            self.constructed = false;
+        }
+    }
+}
 
-/// Safe RAII wrapper around `pmix_device_distance_t`.
+/// RAII wrapper for a PMIx device-distance object. This is distinct from the
+/// pure-Rust `PmixDeviceDistance` parsed snapshot type.
 #[derive(Debug)]
-pub struct PmixDeviceDistanceObject { raw: MaybeUninit<ffi::pmix_device_distance_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
-impl PmixDeviceDistanceObject {
-    pub fn new() -> Self { let mut this=Self { raw:MaybeUninit::uninit(), constructed:false, _not_thread_safe:std::marker::PhantomData }; let p=this.raw.as_mut_ptr(); #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_distance_construct(p); } } else { unsafe { ffi::PMIx_Device_distance_construct(p); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_distance_construct(p); } this.constructed=true; this }
-    pub fn test_new() -> Self { Self { raw:MaybeUninit::zeroed(), constructed:true, _not_thread_safe:std::marker::PhantomData } }
-    c_string_accessor!(uuid, uuid); c_string_accessor!(osname, osname);
-    pub fn device_type(&self) -> ffi::pmix_device_type_t { unsafe { self.raw.assume_init_ref().type_ } }
-    pub fn min_distance(&self) -> u16 { unsafe { self.raw.assume_init_ref().mindist } }
-    pub fn max_distance(&self) -> u16 { unsafe { self.raw.assume_init_ref().maxdist } }
+pub struct PmixDeviceDistanceObject {
+    raw: MaybeUninit<ffi::pmix_device_distance_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
-impl Default for PmixDeviceDistanceObject { fn default()->Self { Self::new() } }
-impl Drop for PmixDeviceDistanceObject { fn drop(&mut self) { if self.constructed { #[cfg(any(test, feature="mock_ffi"))] if mock_ffi::is_mock_enabled() { unsafe { mock_ffi::mock_device_distance_destruct(self.raw.as_mut_ptr()); } } else { unsafe { ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr()); } } #[cfg(not(any(test, feature="mock_ffi")))] unsafe { ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr()); } self.constructed=false; } } }
-
+impl PmixDeviceDistanceObject {
+    /// Construct a device-distance object with PMIx defaults.
+    pub fn new() -> Self {
+        let mut this = Self {
+            raw: MaybeUninit::uninit(),
+            constructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        };
+        let p = this.raw.as_mut_ptr();
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if mock_ffi::is_mock_enabled() {
+            unsafe {
+                mock_ffi::mock_device_distance_construct(p);
+            }
+        } else {
+            unsafe {
+                ffi::PMIx_Device_distance_construct(p);
+            }
+        }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe {
+            ffi::PMIx_Device_distance_construct(p);
+        }
+        this.constructed = true;
+        this
+    }
+    /// Construct a zeroed test object without C-owned allocations.
+    pub fn test_new() -> Self {
+        Self {
+            raw: MaybeUninit::zeroed(),
+            constructed: true,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
+    c_string_accessor!(uuid, uuid);
+    c_string_accessor!(osname, osname);
+    /// Return the PMIx device type.
+    pub fn device_type(&self) -> ffi::pmix_device_type_t {
+        unsafe { self.raw.assume_init_ref().type_ }
+    }
+    /// Return the minimum distance.
+    pub fn min_distance(&self) -> u16 {
+        unsafe { self.raw.assume_init_ref().mindist }
+    }
+    /// Return the maximum distance.
+    pub fn max_distance(&self) -> u16 {
+        unsafe { self.raw.assume_init_ref().maxdist }
+    }
+}
+impl Default for PmixDeviceDistanceObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl Drop for PmixDeviceDistanceObject {
+    fn drop(&mut self) {
+        if self.constructed {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                unsafe {
+                    mock_ffi::mock_device_distance_destruct(self.raw.as_mut_ptr());
+                }
+            } else {
+                unsafe {
+                    ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr());
+                }
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            unsafe {
+                ffi::PMIx_Device_distance_destruct(self.raw.as_mut_ptr());
+            }
+            self.constructed = false;
+        }
+    }
+}
 
 #[cfg(test)]
 mod added_type_tests {
@@ -2804,9 +3210,46 @@ mod added_type_tests {
         assert_eq!(PmixTopologyArray::create(2).unwrap().len(), 2);
         assert_eq!(PmixCpusetArray::create(2).unwrap().len(), 2);
         assert_eq!(PmixEndpointArray::create(2).unwrap().len(), 2);
-        assert_eq!(PmixCoordArray::create(2).unwrap().len(), 2);
+        assert_eq!(PmixCoordArray::create(2, 2).unwrap().len(), 2);
         assert_eq!(PmixDeviceArray::create(2).unwrap().len(), 2);
         assert_eq!(PmixDeviceDistanceArray::create(2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn zero_length_arrays_match_real_pmix_null_semantics() {
+        let _guard = mock_ffi::MockGuard::new();
+        assert!(PmixCoordArray::create(2, 0).is_err());
+        assert!(PmixGeometryArray::create(0).is_err());
+    }
+
+    #[test]
+    fn coord_array_elements_are_constructed_before_drop() {
+        let _guard = mock_ffi::MockGuard::new();
+        let array = PmixCoordArray::create(3, 2).unwrap();
+        assert_eq!(array.len(), 2);
+        unsafe {
+            assert_eq!((*array.as_mut_ptr()).dims, 0);
+            assert_eq!((*array.as_mut_ptr().add(1)).dims, 0);
+        }
+    }
+
+    #[test]
+    fn device_distance_defaults_match_pmix() {
+        let _guard = mock_ffi::MockGuard::new();
+        let distance = PmixDeviceDistanceObject::new();
+        assert_eq!(distance.min_distance(), u16::MAX);
+        assert_eq!(distance.max_distance(), u16::MAX);
+    }
+
+    #[test]
+    fn all_fabric_arrays_create_and_drop() {
+        let _guard = mock_ffi::MockGuard::new();
+        let _geometry = PmixGeometryArray::create(2).unwrap();
+        let _topology = PmixTopologyArray::create(2).unwrap();
+        let _cpuset = PmixCpusetArray::create(2).unwrap();
+        let _endpoint = PmixEndpointArray::create(2).unwrap();
+        let _device = PmixDeviceArray::create(2).unwrap();
+        let _distance = PmixDeviceDistanceArray::create(2).unwrap();
     }
 
     #[test]

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1692,7 +1692,7 @@ pub fn mock_topology_destruct(_topo: *mut crate::ffi::pmix_topology_t) {
 }
 
 /// Mock implementation of `PMIx_Cpuset_construct()`.
-pub fn mock_cpuset_construct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
+pub unsafe fn mock_cpuset_construct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
     // No-op in mock
 }
 
@@ -1702,7 +1702,7 @@ pub fn mock_cpuset_destruct(_cpuset: *mut crate::ffi::pmix_cpuset_t) {
 }
 
 /// Mock implementation of `PMIx_Geometry_construct()`.
-pub fn mock_geometry_construct(geometry: *mut crate::ffi::pmix_geometry_t) {
+pub unsafe fn mock_geometry_construct(geometry: *mut crate::ffi::pmix_geometry_t) {
     // SAFETY: callers provide valid writable storage for the C struct.
     unsafe { std::ptr::write_bytes(geometry, 0, 1) };
 }
@@ -1713,7 +1713,7 @@ pub fn mock_geometry_destruct(_geometry: *mut crate::ffi::pmix_geometry_t) {
 }
 
 /// Mock implementation of `PMIx_Endpoint_construct()`.
-pub fn mock_endpoint_construct(endpoint: *mut crate::ffi::pmix_endpoint_t) {
+pub unsafe fn mock_endpoint_construct(endpoint: *mut crate::ffi::pmix_endpoint_t) {
     // SAFETY: callers provide valid writable storage for the C struct.
     unsafe { std::ptr::write_bytes(endpoint, 0, 1) };
 }

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3515,7 +3515,14 @@ pub unsafe fn mock_endpoint_create(n: usize) -> *mut crate::ffi::pmix_endpoint_t
 pub unsafe fn mock_endpoint_free(_p: *mut crate::ffi::pmix_endpoint_t, _n: usize) {}
 pub unsafe fn mock_coord_construct(p: *mut crate::ffi::pmix_coord_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
 pub unsafe fn mock_coord_destruct(_p: *mut crate::ffi::pmix_coord_t) {}
-pub unsafe fn mock_coord_create(_dims: usize, n: usize) -> *mut crate::ffi::pmix_coord_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_coord_t>()) as *mut _ } }
+pub unsafe fn mock_coord_create(dims: usize, n: usize) -> *mut crate::ffi::pmix_coord_t {
+    if n == 0 { return std::ptr::null_mut(); }
+    let p = unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_coord_t>()) as *mut crate::ffi::pmix_coord_t };
+    if !p.is_null() {
+        unsafe { mock_coord_construct(p); (*p).dims = dims; }
+    }
+    p
+}
 pub unsafe fn mock_coord_free(_p: *mut crate::ffi::pmix_coord_t, _n: usize) {}
 pub unsafe fn mock_device_construct(p: *mut crate::ffi::pmix_device_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
 pub unsafe fn mock_device_destruct(_p: *mut crate::ffi::pmix_device_t) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3500,3 +3500,28 @@ pub unsafe fn mock_byte_object_construct_stack(b: *mut crate::ffi::pmix_byte_obj
 pub unsafe fn mock_byte_object_create(n: usize) -> *mut crate::ffi::pmix_byte_object_t { (unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_byte_object_t>()) }) as *mut crate::ffi::pmix_byte_object_t }
 pub unsafe fn mock_byte_object_free(_g: *mut crate::ffi::pmix_byte_object_t, _n: usize) {}
 pub unsafe fn mock_byte_object_load(_b: *mut crate::ffi::pmix_byte_object_t, d: *mut std::os::raw::c_char, _sz: usize) { if !d.is_null() { unsafe { libc::free(d as *mut libc::c_void); } } }
+
+
+// Mock implementations for fabric type constructors and calloc/free families.
+pub unsafe fn mock_fabric_construct(p: *mut crate::ffi::pmix_fabric_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_geometry_create(n: usize) -> *mut crate::ffi::pmix_geometry_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_geometry_t>()) as *mut _ } }
+pub unsafe fn mock_geometry_free(_p: *mut crate::ffi::pmix_geometry_t, _n: usize) {}
+pub unsafe fn mock_topology_construct(p: *mut crate::ffi::pmix_topology_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_topology_create(n: usize) -> *mut crate::ffi::pmix_topology_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_topology_t>()) as *mut _ } }
+pub unsafe fn mock_topology_free(_p: *mut crate::ffi::pmix_topology_t, _n: usize) {}
+pub unsafe fn mock_cpuset_create(n: usize) -> *mut crate::ffi::pmix_cpuset_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_cpuset_t>()) as *mut _ } }
+pub unsafe fn mock_cpuset_free(_p: *mut crate::ffi::pmix_cpuset_t, _n: usize) {}
+pub unsafe fn mock_endpoint_create(n: usize) -> *mut crate::ffi::pmix_endpoint_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_endpoint_t>()) as *mut _ } }
+pub unsafe fn mock_endpoint_free(_p: *mut crate::ffi::pmix_endpoint_t, _n: usize) {}
+pub unsafe fn mock_coord_construct(p: *mut crate::ffi::pmix_coord_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_coord_destruct(_p: *mut crate::ffi::pmix_coord_t) {}
+pub unsafe fn mock_coord_create(_dims: usize, n: usize) -> *mut crate::ffi::pmix_coord_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_coord_t>()) as *mut _ } }
+pub unsafe fn mock_coord_free(_p: *mut crate::ffi::pmix_coord_t, _n: usize) {}
+pub unsafe fn mock_device_construct(p: *mut crate::ffi::pmix_device_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_device_destruct(_p: *mut crate::ffi::pmix_device_t) {}
+pub unsafe fn mock_device_create(n: usize) -> *mut crate::ffi::pmix_device_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_t>()) as *mut _ } }
+pub unsafe fn mock_device_free(_p: *mut crate::ffi::pmix_device_t, _n: usize) {}
+pub unsafe fn mock_device_distance_construct(p: *mut crate::ffi::pmix_device_distance_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_device_distance_destruct(_p: *mut crate::ffi::pmix_device_distance_t) {}
+pub unsafe fn mock_device_distance_create(n: usize) -> *mut crate::ffi::pmix_device_distance_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_distance_t>()) as *mut _ } }
+pub unsafe fn mock_device_distance_free(_p: *mut crate::ffi::pmix_device_distance_t, _n: usize) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3504,24 +3504,27 @@ pub unsafe fn mock_byte_object_load(_b: *mut crate::ffi::pmix_byte_object_t, d: 
 
 // Mock implementations for fabric type constructors and calloc/free families.
 pub unsafe fn mock_fabric_construct(p: *mut crate::ffi::pmix_fabric_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
-pub unsafe fn mock_geometry_create(n: usize) -> *mut crate::ffi::pmix_geometry_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_geometry_t>()) as *mut _ } }
+pub unsafe fn mock_geometry_create(n: usize) -> *mut crate::ffi::pmix_geometry_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_geometry_t>()) as *mut _ } }
 pub unsafe fn mock_geometry_free(_p: *mut crate::ffi::pmix_geometry_t, _n: usize) {}
 pub unsafe fn mock_topology_construct(p: *mut crate::ffi::pmix_topology_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
-pub unsafe fn mock_topology_create(n: usize) -> *mut crate::ffi::pmix_topology_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_topology_t>()) as *mut _ } }
+pub unsafe fn mock_topology_create(n: usize) -> *mut crate::ffi::pmix_topology_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_topology_t>()) as *mut _ } }
 pub unsafe fn mock_topology_free(_p: *mut crate::ffi::pmix_topology_t, _n: usize) {}
-pub unsafe fn mock_cpuset_create(n: usize) -> *mut crate::ffi::pmix_cpuset_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_cpuset_t>()) as *mut _ } }
+pub unsafe fn mock_cpuset_create(n: usize) -> *mut crate::ffi::pmix_cpuset_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_cpuset_t>()) as *mut _ } }
 pub unsafe fn mock_cpuset_free(_p: *mut crate::ffi::pmix_cpuset_t, _n: usize) {}
-pub unsafe fn mock_endpoint_create(n: usize) -> *mut crate::ffi::pmix_endpoint_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_endpoint_t>()) as *mut _ } }
+pub unsafe fn mock_endpoint_create(n: usize) -> *mut crate::ffi::pmix_endpoint_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_endpoint_t>()) as *mut _ } }
 pub unsafe fn mock_endpoint_free(_p: *mut crate::ffi::pmix_endpoint_t, _n: usize) {}
 pub unsafe fn mock_coord_construct(p: *mut crate::ffi::pmix_coord_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
 pub unsafe fn mock_coord_destruct(_p: *mut crate::ffi::pmix_coord_t) {}
-pub unsafe fn mock_coord_create(_dims: usize, n: usize) -> *mut crate::ffi::pmix_coord_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_coord_t>()) as *mut _ } }
+pub unsafe fn mock_coord_create(_dims: usize, n: usize) -> *mut crate::ffi::pmix_coord_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_coord_t>()) as *mut _ } }
 pub unsafe fn mock_coord_free(_p: *mut crate::ffi::pmix_coord_t, _n: usize) {}
 pub unsafe fn mock_device_construct(p: *mut crate::ffi::pmix_device_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
 pub unsafe fn mock_device_destruct(_p: *mut crate::ffi::pmix_device_t) {}
-pub unsafe fn mock_device_create(n: usize) -> *mut crate::ffi::pmix_device_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_t>()) as *mut _ } }
+pub unsafe fn mock_device_create(n: usize) -> *mut crate::ffi::pmix_device_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_t>()) as *mut _ } }
 pub unsafe fn mock_device_free(_p: *mut crate::ffi::pmix_device_t, _n: usize) {}
-pub unsafe fn mock_device_distance_construct(p: *mut crate::ffi::pmix_device_distance_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
 pub unsafe fn mock_device_distance_destruct(_p: *mut crate::ffi::pmix_device_distance_t) {}
-pub unsafe fn mock_device_distance_create(n: usize) -> *mut crate::ffi::pmix_device_distance_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_distance_t>()) as *mut _ } }
+pub unsafe fn mock_device_distance_construct(p: *mut crate::ffi::pmix_device_distance_t) {
+    // SAFETY: the caller provides writable storage for one PMIx distance object.
+    if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1); (*p).type_ = 0; (*p).mindist = u16::MAX; (*p).maxdist = u16::MAX; } }
+}
+pub unsafe fn mock_device_distance_create(n: usize) -> *mut crate::ffi::pmix_device_distance_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_distance_t>()) as *mut _ } }
 pub unsafe fn mock_device_distance_free(_p: *mut crate::ffi::pmix_device_distance_t, _n: usize) {}


### PR DESCRIPTION
Closes #84, Closes #104, Closes #89, Closes #109, Closes #117, Closes #128, Closes #139, Closes #141, Closes #144, Closes #159, Closes #162, Closes #188, Closes #191, Closes #193, Closes #194, Closes #226, Closes #239, Closes #248, Closes #265, Closes #279, Closes #293, Closes #309, Closes #334, Closes #345

## Summary
- Add RAII wrappers PmixCoord, PmixDevice, PmixDeviceDistance (construct/destruct pairs, test_new, Default, accessors) mirroring PmixGeometry.
- Add array create/free RAII types for geometry, topology, cpuset, endpoint, coord, device, device_distance via a shared pmix_array! macro.
- Add Fabric_construct wrapper; append mock FFI for daemon-free tests.
## Test plan
- Local mock-based tests (added_type_tests); daemon/DVM tests remain CI-only.