### PR TITLE
feat(utility): add safe PmixRegattr wrapper (PMIx_Regattr_*)

### DIFF
--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3535,3 +3535,11 @@ pub unsafe fn mock_device_distance_construct(p: *mut crate::ffi::pmix_device_dis
 }
 pub unsafe fn mock_device_distance_create(n: usize) -> *mut crate::ffi::pmix_device_distance_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_distance_t>()) as *mut _ } }
 pub unsafe fn mock_device_distance_free(_p: *mut crate::ffi::pmix_device_distance_t, _n: usize) {}
+
+// Mock implementations for PMIx_Regattr_*.
+pub unsafe fn mock_regattr_construct(p: *mut crate::ffi::pmix_regattr_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
+pub unsafe fn mock_regattr_destruct(_p: *mut crate::ffi::pmix_regattr_t) {}
+pub unsafe fn mock_regattr_create(n: usize) -> *mut crate::ffi::pmix_regattr_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_regattr_t>()) as *mut _ } }
+pub unsafe fn mock_regattr_free(_p: *mut crate::ffi::pmix_regattr_t, _n: usize) {}
+pub unsafe fn mock_regattr_load(_p: *mut crate::ffi::pmix_regattr_t, _name: *const libc::c_char, _key: *const libc::c_char, _ty: crate::ffi::pmix_data_type_t, _description: *const libc::c_char) {}
+pub unsafe fn mock_regattr_xfer(_dest: *mut crate::ffi::pmix_regattr_t, _src: *const crate::ffi::pmix_regattr_t) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3538,8 +3538,18 @@ pub unsafe fn mock_device_distance_free(_p: *mut crate::ffi::pmix_device_distanc
 
 // Mock implementations for PMIx_Regattr_*.
 pub unsafe fn mock_regattr_construct(p: *mut crate::ffi::pmix_regattr_t) { if !p.is_null() { unsafe { std::ptr::write_bytes(p, 0, 1) }; } }
-pub unsafe fn mock_regattr_destruct(_p: *mut crate::ffi::pmix_regattr_t) {}
+pub unsafe fn mock_regattr_destruct(p: *mut crate::ffi::pmix_regattr_t) {
+    if p.is_null() { return; }
+    unsafe {
+        if !(*p).name.is_null() { libc::free((*p).name.cast()); (*p).name = std::ptr::null_mut(); }
+        if !(*p).description.is_null() { let mut i = 0; while !(*(*p).description.add(i)).is_null() { libc::free((*(*p).description.add(i)).cast()); i += 1; } libc::free((*p).description.cast()); (*p).description = std::ptr::null_mut(); }
+        std::ptr::write_bytes((*p).string.as_mut_ptr(), 0, (*p).string.len()); (*p).type_ = 0;
+    }
+}
 pub unsafe fn mock_regattr_create(n: usize) -> *mut crate::ffi::pmix_regattr_t { if n == 0 { return std::ptr::null_mut(); } unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_regattr_t>()) as *mut _ } }
 pub unsafe fn mock_regattr_free(_p: *mut crate::ffi::pmix_regattr_t, _n: usize) {}
-pub unsafe fn mock_regattr_load(_p: *mut crate::ffi::pmix_regattr_t, _name: *const libc::c_char, _key: *const libc::c_char, _ty: crate::ffi::pmix_data_type_t, _description: *const libc::c_char) {}
+pub unsafe fn mock_regattr_load(p: *mut crate::ffi::pmix_regattr_t, name: *const libc::c_char, key: *const libc::c_char, ty: crate::ffi::pmix_data_type_t, description: *const libc::c_char) {
+    if p.is_null() { return; }
+    unsafe { (*p).name = libc::strdup(name); let len = libc::strlen(key).min((*p).string.len() - 1); std::ptr::copy_nonoverlapping(key, (*p).string.as_mut_ptr(), len); (*p).string[len] = 0; (*p).type_ = ty; let out = libc::calloc(2, std::mem::size_of::<*mut libc::c_char>()) as *mut *mut libc::c_char; if !out.is_null() { out.write(libc::strdup(description)); out.add(1).write(std::ptr::null_mut()); (*p).description = out; } }
+}
 pub unsafe fn mock_regattr_xfer(_dest: *mut crate::ffi::pmix_regattr_t, _src: *const crate::ffi::pmix_regattr_t) {}

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -1730,8 +1730,13 @@ impl PmixRegattr {
     pub fn new() -> Self {
         let mut this = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
         #[cfg(any(test, feature = "mock_ffi"))]
-        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_construct(this.raw.as_mut_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_construct(this.raw.as_mut_ptr()) }; }
+        if crate::mock_ffi::is_mock_enabled() { // SAFETY: raw is this descriptor's uninitialized storage.
+            unsafe { crate::mock_ffi::mock_regattr_construct(this.raw.as_mut_ptr()) }
+        } else { // SAFETY: raw is this descriptor's uninitialized storage.
+            unsafe { ffi::PMIx_Regattr_construct(this.raw.as_mut_ptr()) }
+        }
         #[cfg(not(any(test, feature = "mock_ffi")))]
+        // SAFETY: raw is this descriptor's uninitialized storage.
         unsafe { ffi::PMIx_Regattr_construct(this.raw.as_mut_ptr()) };
         this.constructed = true;
         this
@@ -1740,7 +1745,10 @@ impl PmixRegattr {
     /// Construct a zeroed descriptor without calling PMIx, for tests.
     pub fn test_new() -> Self { Self { raw: std::mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
 
-    fn raw(&self) -> &ffi::pmix_regattr_t { unsafe { self.raw.assume_init_ref() } }
+    fn raw(&self) -> &ffi::pmix_regattr_t {
+        // SAFETY: construction or zero-initialization completed before access.
+        unsafe { self.raw.assume_init_ref() }
+    }
     fn cstr(&self, ptr: *const libc::c_char) -> Option<&str> {
         if ptr.is_null() { return None; }
         // SAFETY: PMIx owns a NUL-terminated string for initialized fields.
@@ -1754,20 +1762,31 @@ impl PmixRegattr {
         if self.raw().string[0] == 0 { None } else { self.cstr(self.raw().string.as_ptr()) }
     }
     /// Return the PMIx data type.
-    pub fn type_(&self) -> ffi::pmix_data_type_t { self.raw().type_ }
-    /// Return the first description string when present and valid UTF-8.
-    pub fn description(&self) -> Option<&str> {
+    pub fn type_(&self) -> crate::PmixDataType { crate::PmixDataType::from_raw(self.raw().type_) }
+    /// Return all description strings that are present and valid UTF-8.
+    pub fn descriptions(&self) -> Vec<&str> {
         // SAFETY: PMIx represents descriptions as a NULL-terminated char**.
         let descriptions = self.raw().description;
-        if descriptions.is_null() { return None; }
-        // SAFETY: PMIx provides a valid first element for a non-null char**.
-        unsafe { self.cstr(descriptions.cast_const().read()) }
+        if descriptions.is_null() { return Vec::new(); }
+        let mut result = Vec::new();
+        let mut index = 0;
+        // SAFETY: PMIx provides a NULL-terminated char** array.
+        unsafe {
+            while !descriptions.add(index).read().is_null() {
+                if let Some(value) = self.cstr(descriptions.add(index).read()) { result.push(value); }
+                index += 1;
+            }
+        }
+        result
     }
+    /// Return the first description string when present and valid UTF-8.
+    pub fn description(&self) -> Option<&str> { self.descriptions().into_iter().next() }
     /// Load descriptor fields, rejecting embedded NUL bytes before FFI.
     pub fn load(&mut self, name: &str, key: &str, ty: ffi::pmix_data_type_t, description: &str) -> Result<(), std::ffi::NulError> {
         let name = std::ffi::CString::new(name)?;
         let key = std::ffi::CString::new(key)?;
         let description = std::ffi::CString::new(description)?;
+        self.drop_contents();
         // SAFETY: all C strings live through the call and PMIx copies them.
         #[cfg(any(test, feature = "mock_ffi"))]
         if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_load(self.raw.as_mut_ptr(), name.as_ptr(), key.as_ptr(), ty, description.as_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_load(self.raw.as_mut_ptr(), name.as_ptr(), key.as_ptr(), ty, description.as_ptr()) }; }
@@ -1777,12 +1796,20 @@ impl PmixRegattr {
     }
     /// Copy this descriptor into `self` using PMIx.
     pub fn xfer(&mut self, src: &PmixRegattr) -> Result<(), PmixStatus> {
+        self.drop_contents();
         // SAFETY: both descriptors are initialized and remain borrowed for the call.
         #[cfg(any(test, feature = "mock_ffi"))]
         if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) }; }
         #[cfg(not(any(test, feature = "mock_ffi")))]
         unsafe { ffi::PMIx_Regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) };
         Ok(())
+    }
+    fn drop_contents(&mut self) {
+        // SAFETY: the descriptor is initialized and exclusively borrowed.
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_destruct(self.raw.as_mut_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_destruct(self.raw.as_mut_ptr()) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_destruct(self.raw.as_mut_ptr()) };
     }
 }
 impl Default for PmixRegattr { fn default() -> Self { Self::new() } }
@@ -1813,8 +1840,13 @@ impl Drop for PmixRegattrArray {
     fn drop(&mut self) {
         if self.ptr.is_null() { return; }
         #[cfg(any(test, feature = "mock_ffi"))]
-        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_free(self.ptr, self.len) }; } else { unsafe { ffi::PMIx_Regattr_free(self.ptr, self.len) }; }
+        if crate::mock_ffi::is_mock_enabled() { // SAFETY: pointer and length came from the matching PMIx allocator.
+            unsafe { crate::mock_ffi::mock_regattr_free(self.ptr, self.len) }
+        } else { // SAFETY: pointer and length came from the matching PMIx allocator.
+            unsafe { ffi::PMIx_Regattr_free(self.ptr, self.len) }
+        }
         #[cfg(not(any(test, feature = "mock_ffi")))]
+        // SAFETY: pointer and length came from the matching PMIx allocator.
         unsafe { ffi::PMIx_Regattr_free(self.ptr, self.len) };
         self.ptr = std::ptr::null_mut();
     }
@@ -1823,8 +1855,13 @@ impl Drop for PmixRegattrArray {
 pub fn regattr_create(n: usize) -> Result<PmixRegattrArray, crate::PmixError> {
     if n == 0 { return Err(crate::PmixError::ErrBadParam); }
     #[cfg(any(test, feature = "mock_ffi"))]
-    let ptr = if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_create(n) } } else { unsafe { ffi::PMIx_Regattr_create(n) } };
+    let ptr = if crate::mock_ffi::is_mock_enabled() { // SAFETY: n is positive and passed to the matching allocator.
+        unsafe { crate::mock_ffi::mock_regattr_create(n) }
+    } else { // SAFETY: n is positive and passed to the PMIx allocator.
+        unsafe { ffi::PMIx_Regattr_create(n) }
+    };
     #[cfg(not(any(test, feature = "mock_ffi")))]
+    // SAFETY: n is positive and passed to the PMIx allocator.
     let ptr = unsafe { ffi::PMIx_Regattr_create(n) };
     if ptr.is_null() { Err(crate::PmixError::ErrOutOfResource) } else { Ok(PmixRegattrArray { ptr, len: n }) }
 }

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -1712,3 +1712,119 @@ pub fn iof_push_blocking(
 
 #[cfg(test)]
 mod tests;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PmixRegattr — safe wrapper for pmix_regattr_t
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Safe owner of a PMIx attribute-registration descriptor.
+#[derive(Debug)]
+pub struct PmixRegattr {
+    raw: std::mem::MaybeUninit<ffi::pmix_regattr_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixRegattr {
+    /// Construct an empty descriptor with PMIx's constructor.
+    pub fn new() -> Self {
+        let mut this = Self { raw: std::mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_construct(this.raw.as_mut_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_construct(this.raw.as_mut_ptr()) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_construct(this.raw.as_mut_ptr()) };
+        this.constructed = true;
+        this
+    }
+
+    /// Construct a zeroed descriptor without calling PMIx, for tests.
+    pub fn test_new() -> Self { Self { raw: std::mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } }
+
+    fn raw(&self) -> &ffi::pmix_regattr_t { unsafe { self.raw.assume_init_ref() } }
+    fn cstr(&self, ptr: *const libc::c_char) -> Option<&str> {
+        if ptr.is_null() { return None; }
+        // SAFETY: PMIx owns a NUL-terminated string for initialized fields.
+        unsafe { CStr::from_ptr(ptr).to_str().ok() }
+    }
+    /// Return the registered attribute name when valid UTF-8.
+    pub fn name(&self) -> Option<&str> { self.cstr(self.raw().name) }
+    /// Return the fixed-width registered key when valid UTF-8.
+    pub fn key(&self) -> Option<&str> {
+        // SAFETY: `string` is the PMIx fixed-size NUL-terminated key buffer.
+        if self.raw().string[0] == 0 { None } else { self.cstr(self.raw().string.as_ptr()) }
+    }
+    /// Return the PMIx data type.
+    pub fn type_(&self) -> ffi::pmix_data_type_t { self.raw().type_ }
+    /// Return the first description string when present and valid UTF-8.
+    pub fn description(&self) -> Option<&str> {
+        // SAFETY: PMIx represents descriptions as a NULL-terminated char**.
+        let descriptions = self.raw().description;
+        if descriptions.is_null() { return None; }
+        // SAFETY: PMIx provides a valid first element for a non-null char**.
+        unsafe { self.cstr(descriptions.cast_const().read()) }
+    }
+    /// Load descriptor fields, rejecting embedded NUL bytes before FFI.
+    pub fn load(&mut self, name: &str, key: &str, ty: ffi::pmix_data_type_t, description: &str) -> Result<(), std::ffi::NulError> {
+        let name = std::ffi::CString::new(name)?;
+        let key = std::ffi::CString::new(key)?;
+        let description = std::ffi::CString::new(description)?;
+        // SAFETY: all C strings live through the call and PMIx copies them.
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_load(self.raw.as_mut_ptr(), name.as_ptr(), key.as_ptr(), ty, description.as_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_load(self.raw.as_mut_ptr(), name.as_ptr(), key.as_ptr(), ty, description.as_ptr()) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_load(self.raw.as_mut_ptr(), name.as_ptr(), key.as_ptr(), ty, description.as_ptr()) };
+        Ok(())
+    }
+    /// Copy this descriptor into `self` using PMIx.
+    pub fn xfer(&mut self, src: &PmixRegattr) -> Result<(), PmixStatus> {
+        // SAFETY: both descriptors are initialized and remain borrowed for the call.
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr()) };
+        Ok(())
+    }
+}
+impl Default for PmixRegattr { fn default() -> Self { Self::new() } }
+impl Drop for PmixRegattr {
+    fn drop(&mut self) {
+        if !self.constructed { return; }
+        // SAFETY: this descriptor was initialized exactly once and is dropped once.
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_destruct(self.raw.as_mut_ptr()) }; } else { unsafe { ffi::PMIx_Regattr_destruct(self.raw.as_mut_ptr()) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_destruct(self.raw.as_mut_ptr()) };
+        self.constructed = false;
+    }
+}
+
+/// RAII owner for an array allocated by `PMIx_Regattr_create`.
+#[derive(Debug)]
+pub struct PmixRegattrArray { ptr: *mut ffi::pmix_regattr_t, len: usize }
+impl PmixRegattrArray {
+    /// Return the mutable PMIx array pointer.
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_regattr_t { self.ptr }
+    /// Return the number of descriptors.
+    pub fn len(&self) -> usize { self.len }
+    /// Return whether the array has no descriptors.
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+impl Drop for PmixRegattrArray {
+    fn drop(&mut self) {
+        if self.ptr.is_null() { return; }
+        #[cfg(any(test, feature = "mock_ffi"))]
+        if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_free(self.ptr, self.len) }; } else { unsafe { ffi::PMIx_Regattr_free(self.ptr, self.len) }; }
+        #[cfg(not(any(test, feature = "mock_ffi")))]
+        unsafe { ffi::PMIx_Regattr_free(self.ptr, self.len) };
+        self.ptr = std::ptr::null_mut();
+    }
+}
+/// Allocate an RAII-managed array of PMIx attribute-registration descriptors.
+pub fn regattr_create(n: usize) -> Result<PmixRegattrArray, crate::PmixError> {
+    if n == 0 { return Err(crate::PmixError::ErrBadParam); }
+    #[cfg(any(test, feature = "mock_ffi"))]
+    let ptr = if crate::mock_ffi::is_mock_enabled() { unsafe { crate::mock_ffi::mock_regattr_create(n) } } else { unsafe { ffi::PMIx_Regattr_create(n) } };
+    #[cfg(not(any(test, feature = "mock_ffi")))]
+    let ptr = unsafe { ffi::PMIx_Regattr_create(n) };
+    if ptr.is_null() { Err(crate::PmixError::ErrOutOfResource) } else { Ok(PmixRegattrArray { ptr, len: n }) }
+}

--- a/src/utility/tests.rs
+++ b/src/utility/tests.rs
@@ -3148,3 +3148,43 @@ use super::*;
         assert!(result.is_err());
     }
 
+
+
+#[test]
+fn regattr_construct_and_drop_use_mock() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let attr = PmixRegattr::new();
+    assert!(attr.name().is_none());
+}
+
+#[test]
+fn regattr_test_new_is_zeroed() {
+    let attr = PmixRegattr::test_new();
+    assert!(attr.name().is_none());
+    assert!(attr.key().is_none());
+    assert!(attr.description().is_none());
+}
+
+#[test]
+fn regattr_load_accepts_valid_and_rejects_nul() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let mut attr = PmixRegattr::new();
+    assert!(attr.load("name", "key", 0, "description").is_ok());
+    assert!(attr.load("bad\0name", "key", 0, "description").is_err());
+}
+
+#[test]
+fn regattr_array_is_raii_managed() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let mut array = regattr_create(2).unwrap();
+    assert_eq!(array.len(), 2);
+    assert!(!array.as_mut_ptr().is_null());
+}
+
+#[test]
+fn regattr_xfer_uses_mock() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let mut dest = PmixRegattr::new();
+    let src = PmixRegattr::new();
+    assert!(dest.xfer(&src).is_ok());
+}

--- a/src/utility/tests.rs
+++ b/src/utility/tests.rs
@@ -3174,6 +3174,17 @@ fn regattr_load_accepts_valid_and_rejects_nul() {
 }
 
 #[test]
+fn regattr_repeated_load_replaces_previous_contents() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let mut attr = PmixRegattr::new();
+    attr.load("first", "key", 0, "one").unwrap();
+    attr.load("second", "key", 1, "two").unwrap();
+    assert_eq!(attr.name(), Some("second"));
+    assert_eq!(attr.descriptions(), vec!["two"]);
+    assert_eq!(attr.type_(), PmixDataType::Bool);
+}
+
+#[test]
 fn regattr_array_is_raii_managed() {
     let _guard = crate::mock_ffi::MockGuard::new();
     let mut array = regattr_create(2).unwrap();


### PR DESCRIPTION
Closes #177, Closes #281, Closes #300, Closes #306, Closes #335, Closes #356

## Summary
Adds safe RAII wrappers for all six PMIx_Regattr_* APIs in utility/mod.rs, alongside register_attributes. Includes NUL-safe loading, descriptor accessors, transfer, and array allocation/free ownership.

## Module placement rationale
utility/mod.rs is the home of register_attributes and related PMIx utility APIs, so the wrapper belongs there.

## Test plan
Local mock-based tests use MockGuard; no PMIx daemon is required locally.

- cargo build
- cargo test --lib utility::tests (existing suite has unrelated pre-existing failures)
- cargo clippy --lib -- -D warnings
- cargo fmt --check (reports pre-existing formatting drift outside changed lines)