### PR TITLE
feat(query): add safe wrappers for PMIx_Query_construct/destruct/release/qualifiers_create

### DIFF
--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3553,3 +3553,24 @@ pub unsafe fn mock_regattr_load(p: *mut crate::ffi::pmix_regattr_t, name: *const
     unsafe { (*p).name = libc::strdup(name); let len = libc::strlen(key).min((*p).string.len() - 1); std::ptr::copy_nonoverlapping(key, (*p).string.as_mut_ptr(), len); (*p).string[len] = 0; (*p).type_ = ty; let out = libc::calloc(2, std::mem::size_of::<*mut libc::c_char>()) as *mut *mut libc::c_char; if !out.is_null() { out.write(libc::strdup(description)); out.add(1).write(std::ptr::null_mut()); (*p).description = out; } }
 }
 pub unsafe fn mock_regattr_xfer(_dest: *mut crate::ffi::pmix_regattr_t, _src: *const crate::ffi::pmix_regattr_t) {}
+
+
+/// Mock implementation of `PMIx_Query_construct`.
+pub fn mock_query_construct(p: *mut crate::ffi::pmix_query_t) {
+    if is_mock_enabled() && !p.is_null() {
+        unsafe {
+            (*p).keys = std::ptr::null_mut();
+            (*p).qualifiers = std::ptr::null_mut();
+            (*p).nqual = 0;
+        }
+    }
+}
+
+/// Mock implementation of `PMIx_Query_destruct`.
+pub fn mock_query_destruct(_p: *mut crate::ffi::pmix_query_t) {}
+
+/// Mock implementation of `PMIx_Query_release`.
+pub fn mock_query_release(_p: *mut crate::ffi::pmix_query_t) {}
+
+/// Mock implementation of `PMIx_Query_qualifiers_create`.
+pub fn mock_query_qualifiers_create(_p: *mut crate::ffi::pmix_query_t, _n: usize) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3567,10 +3567,29 @@ pub fn mock_query_construct(p: *mut crate::ffi::pmix_query_t) {
 }
 
 /// Mock implementation of `PMIx_Query_destruct`.
-pub fn mock_query_destruct(_p: *mut crate::ffi::pmix_query_t) {}
+pub fn mock_query_destruct(p: *mut crate::ffi::pmix_query_t) {
+    if !p.is_null() {
+        unsafe {
+            if !(*p).qualifiers.is_null() {
+                libc::free((*p).qualifiers.cast());
+                (*p).qualifiers = std::ptr::null_mut();
+            }
+            (*p).nqual = 0;
+        }
+    }
+}
 
 /// Mock implementation of `PMIx_Query_release`.
 pub fn mock_query_release(_p: *mut crate::ffi::pmix_query_t) {}
 
 /// Mock implementation of `PMIx_Query_qualifiers_create`.
-pub fn mock_query_qualifiers_create(_p: *mut crate::ffi::pmix_query_t, _n: usize) {}
+pub fn mock_query_qualifiers_create(p: *mut crate::ffi::pmix_query_t, n: usize) {
+    if p.is_null() {
+        return;
+    }
+    unsafe {
+        (*p).qualifiers = libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_info_t>())
+            as *mut crate::ffi::pmix_info_t;
+        (*p).nqual = n;
+    }
+}

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -1843,33 +1843,20 @@ pub struct PmixQueryConstructed {
 impl PmixQueryConstructed {
     /// Construct a zero-initialized query with `PMIx_Query_construct`.
     pub fn construct() -> Self {
+        // SAFETY: allocation is converted to the matching `pmix_query_t` pointer
+        // and is freed by `destruct`/`release` while owned by this wrapper.
         let handle = unsafe {
-            #[cfg(any(test, feature = "mock_ffi"))]
-            if mock_ffi::is_mock_enabled() {
-                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
-                    as *mut ffi::pmix_query_t;
-                if !p.is_null() {
-                    mock_ffi::mock_query_construct(p);
-                }
-                p
-            } else {
-                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
-                    as *mut ffi::pmix_query_t;
-                if !p.is_null() {
-                    ffi::PMIx_Query_construct(p);
-                }
-                p
-            }
-            #[cfg(not(any(test, feature = "mock_ffi")))]
-            {
-                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
-                    as *mut ffi::pmix_query_t;
-                if !p.is_null() {
-                    ffi::PMIx_Query_construct(p);
-                }
-                p
-            }
+            libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
+                as *mut ffi::pmix_query_t
         };
+        if !handle.is_null() {
+            // SAFETY: `handle` is freshly calloc'd storage with the exact
+            // `pmix_query_t` layout, and remains owned by the returned wrapper.
+            crate::pmix_ffi_or_mock!(
+                mock = mock_ffi::mock_query_construct(handle),
+                real = unsafe { ffi::PMIx_Query_construct(handle) },
+            );
+        }
         Self {
             handle,
             destructed: false,
@@ -1887,19 +1874,27 @@ impl PmixQueryConstructed {
         if self.handle.is_null() || self.destructed {
             return Err(PmixError::ErrBadParam);
         }
-        unsafe {
-            #[cfg(any(test, feature = "mock_ffi"))]
-            if mock_ffi::is_mock_enabled() {
-                mock_ffi::mock_query_qualifiers_create(self.handle, n);
-            } else {
-                ffi::PMIx_Query_qualifiers_create(self.handle, n);
-            }
-            #[cfg(not(any(test, feature = "mock_ffi")))]
-            {
-                ffi::PMIx_Query_qualifiers_create(self.handle, n);
-            }
-        }
-        // The C helper owns the allocation and updates `qualifiers`/`nqual`.
+        // `PMIx_Query_qualifiers_create` returns void, so allocation failure
+        // cannot be reported by this wrapper. Destructing and reconstructing
+        // first releases any qualifiers array left by an earlier call.
+        // SAFETY: `self.handle` is a live query allocated and initialized by
+        // `construct`; destruct resets its owned qualifiers before recreation.
+        crate::pmix_ffi_or_mock!(
+            mock = mock_ffi::mock_query_destruct(self.handle),
+            real = unsafe { ffi::PMIx_Query_destruct(self.handle) },
+        );
+        // SAFETY: `self.handle` remains the wrapper-owned, valid query pointer;
+        // construct initializes its qualifiers array ownership for this call.
+        crate::pmix_ffi_or_mock!(
+            mock = mock_ffi::mock_query_construct(self.handle),
+            real = unsafe { ffi::PMIx_Query_construct(self.handle) },
+        );
+        // SAFETY: the pointer is valid and initialized above; the C helper owns
+        // its qualifiers allocation and updates `qualifiers`/`nqual`.
+        crate::pmix_ffi_or_mock!(
+            mock = mock_ffi::mock_query_qualifiers_create(self.handle, n),
+            real = unsafe { ffi::PMIx_Query_qualifiers_create(self.handle, n) },
+        );
         Ok(())
     }
 
@@ -1908,17 +1903,14 @@ impl PmixQueryConstructed {
         if self.handle.is_null() || self.destructed {
             return;
         }
+        // SAFETY: `self.handle` came from calloc and is initialized as a PMIx
+        // query; `destructed` prevents this owned allocation from being freed twice.
+        crate::pmix_ffi_or_mock!(
+            mock = mock_ffi::mock_query_destruct(self.handle),
+            real = unsafe { ffi::PMIx_Query_destruct(self.handle) },
+        );
+        // SAFETY: the query storage was allocated by libc::calloc in construct.
         unsafe {
-            #[cfg(any(test, feature = "mock_ffi"))]
-            if mock_ffi::is_mock_enabled() {
-                mock_ffi::mock_query_destruct(self.handle);
-            } else {
-                ffi::PMIx_Query_destruct(self.handle);
-            }
-            #[cfg(not(any(test, feature = "mock_ffi")))]
-            {
-                ffi::PMIx_Query_destruct(self.handle);
-            }
             libc::free(self.handle.cast());
         }
         self.handle = ptr::null_mut();
@@ -1930,20 +1922,16 @@ impl PmixQueryConstructed {
         if self.handle.is_null() || self.destructed {
             return;
         }
-        unsafe {
-            #[cfg(any(test, feature = "mock_ffi"))]
-            if mock_ffi::is_mock_enabled() {
+        // SAFETY: `self.handle` is the live query allocated by construct;
+        // release consumes it, and `destructed` prevents a second release.
+        crate::pmix_ffi_or_mock!(
+            mock = {
                 mock_ffi::mock_query_release(self.handle);
-                libc::free(self.handle.cast());
-            } else {
-                ffi::PMIx_Query_release(self.handle);
-            }
-            #[cfg(not(any(test, feature = "mock_ffi")))]
-            {
-                // PMIx_Query_release frees the struct itself.
-                ffi::PMIx_Query_release(self.handle);
-            }
-        }
+                // The mock release does not own the calloc'd wrapper storage.
+                unsafe { libc::free(self.handle.cast()) };
+            },
+            real = unsafe { ffi::PMIx_Query_release(self.handle) },
+        );
         self.handle = ptr::null_mut();
         self.destructed = true;
     }
@@ -1995,6 +1983,8 @@ mod query_extras_tests {
         let _guard = mock_ffi::MockGuard::new();
         let mut query = query_construct();
         assert!(query.qualifiers_create(2).is_ok());
-        unsafe { assert_eq!((*query.as_mut_ptr()).nqual, 0); }
+        assert_eq!(unsafe { (*query.as_mut_ptr()).nqual }, 2);
+        assert!(query.qualifiers_create(3).is_ok());
+        assert_eq!(unsafe { (*query.as_mut_ptr()).nqual }, 3);
     }
 }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -1822,3 +1822,179 @@ mod tests {
         assert!(result.is_ok());
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PmixQueryConstructed — safe wrapper for stack-style query helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A query initialized with `PMIx_Query_construct`.
+///
+/// This is separate from [`PmixQuery`], whose heap allocation is created with
+/// `PMIx_Query_create` and is released by its existing `Drop` implementation.
+/// Call [`PmixQueryConstructed::destruct`] (or let `Drop` do so) for this stack
+/// pairing; [`PmixQueryConstructed::release`] is provided for the explicit
+/// heap-style release API and must not be mixed with `destruct`.
+pub struct PmixQueryConstructed {
+    handle: *mut ffi::pmix_query_t,
+    destructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixQueryConstructed {
+    /// Construct a zero-initialized query with `PMIx_Query_construct`.
+    pub fn construct() -> Self {
+        let handle = unsafe {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
+                    as *mut ffi::pmix_query_t;
+                if !p.is_null() {
+                    mock_ffi::mock_query_construct(p);
+                }
+                p
+            } else {
+                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
+                    as *mut ffi::pmix_query_t;
+                if !p.is_null() {
+                    ffi::PMIx_Query_construct(p);
+                }
+                p
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                let p = libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
+                    as *mut ffi::pmix_query_t;
+                if !p.is_null() {
+                    ffi::PMIx_Query_construct(p);
+                }
+                p
+            }
+        };
+        Self {
+            handle,
+            destructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
+
+    /// Return the underlying query pointer for advanced PMIx integrations.
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::pmix_query_t {
+        self.handle
+    }
+
+    /// Allocate `n` qualifier entries using `PMIx_Query_qualifiers_create`.
+    pub fn qualifiers_create(&mut self, n: usize) -> Result<(), PmixError> {
+        if self.handle.is_null() || self.destructed {
+            return Err(PmixError::ErrBadParam);
+        }
+        unsafe {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                mock_ffi::mock_query_qualifiers_create(self.handle, n);
+            } else {
+                ffi::PMIx_Query_qualifiers_create(self.handle, n);
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                ffi::PMIx_Query_qualifiers_create(self.handle, n);
+            }
+        }
+        // The C helper owns the allocation and updates `qualifiers`/`nqual`.
+        Ok(())
+    }
+
+    /// Pair this object with `PMIx_Query_destruct`.
+    pub fn destruct(&mut self) {
+        if self.handle.is_null() || self.destructed {
+            return;
+        }
+        unsafe {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                mock_ffi::mock_query_destruct(self.handle);
+            } else {
+                ffi::PMIx_Query_destruct(self.handle);
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                ffi::PMIx_Query_destruct(self.handle);
+            }
+            libc::free(self.handle.cast());
+        }
+        self.handle = ptr::null_mut();
+        self.destructed = true;
+    }
+
+    /// Explicitly invoke `PMIx_Query_release` on this constructed query.
+    pub fn release(&mut self) {
+        if self.handle.is_null() || self.destructed {
+            return;
+        }
+        unsafe {
+            #[cfg(any(test, feature = "mock_ffi"))]
+            if mock_ffi::is_mock_enabled() {
+                mock_ffi::mock_query_release(self.handle);
+                libc::free(self.handle.cast());
+            } else {
+                ffi::PMIx_Query_release(self.handle);
+            }
+            #[cfg(not(any(test, feature = "mock_ffi")))]
+            {
+                // PMIx_Query_release frees the struct itself.
+                ffi::PMIx_Query_release(self.handle);
+            }
+        }
+        self.handle = ptr::null_mut();
+        self.destructed = true;
+    }
+}
+
+impl Drop for PmixQueryConstructed {
+    fn drop(&mut self) {
+        self.destruct();
+    }
+}
+
+/// Construct a stack-style query with `PMIx_Query_construct`.
+pub fn query_construct() -> PmixQueryConstructed {
+    PmixQueryConstructed::construct()
+}
+
+/// Explicitly release a query initialized by [`query_construct`].
+pub fn query_release(query: &mut PmixQueryConstructed) {
+    query.release();
+}
+
+/// Explicitly destruct a query initialized by [`query_construct`].
+pub fn query_destruct(query: &mut PmixQueryConstructed) {
+    query.destruct();
+}
+
+#[cfg(test)]
+mod query_extras_tests {
+    use super::*;
+
+    #[test]
+    fn construct_destruct_pairing_is_idempotent() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut query = query_construct();
+        assert!(!query.as_mut_ptr().is_null());
+        query_destruct(&mut query);
+        query_destruct(&mut query);
+    }
+
+    #[test]
+    fn release_is_no_panic() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut query = query_construct();
+        query_release(&mut query);
+    }
+
+    #[test]
+    fn qualifiers_create_mock_path_is_successful() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut query = query_construct();
+        assert!(query.qualifiers_create(2).is_ok());
+        unsafe { assert_eq!((*query.as_mut_ptr()).nqual, 0); }
+    }
+}


### PR DESCRIPTION
Closes #150, Closes #176, Closes #237, Closes #258

## Summary
- Add safe stack-style `PmixQueryConstructed` wrappers for `PMIx_Query_construct`, `PMIx_Query_destruct`, `PMIx_Query_release`, and `PMIx_Query_qualifiers_create`.
- Keep the existing heap-backed `PmixQuery::new` and its ownership behavior unchanged.
- Add mock-only FFI implementations and mock-based lifecycle/qualifier tests.

## Module placement rationale
The wrappers live in `src/query_log.rs`, the existing home for `PmixQuery` and query APIs, so the related ownership and FFI behavior remains together.

## Test plan
- Local mock-based tests; no PMIx daemon or DVM required.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` passed.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib query_log::tests` passed (67 passed, 5 ignored daemon/async tests).
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib query_log::query_extras_tests` passed (3 passed).
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo clippy --lib -- -D warnings` passed.
- `cargo fmt --check` reports pre-existing formatting differences outside the added blocks; no whole-file formatting was applied.
