### PR TITLE
feat(lib): add safe wrappers for PMIx_Envar/Setenv/Multicluster_nspace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5765,24 +5765,56 @@ mod envar_utils_tests {
     }
 
     #[test]
-    fn setenv_accepts_vec_environment() {
+    fn envar_create_zero_is_empty_and_safe() {
+        let _guard = mock_ffi::MockGuard::new();
+        let array = envar_create(0).unwrap();
+        assert!(array.is_empty());
+        assert!(array.ptr.is_null());
+    }
+
+    #[test]
+    fn envar_destruct_does_not_free_rust_owned_strings() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut value = PmixEnvar::new("NAME", "VALUE", '=').unwrap();
+        envar_destruct(&mut value);
+        assert_eq!(value.envar, CString::new("NAME").unwrap());
+        assert_eq!(value.value, CString::new("VALUE").unwrap());
+    }
+
+    #[test]
+    fn setenv_replaces_vec_environment() {
         let _guard = mock_ffi::MockGuard::new();
         let mut env = vec!["A=B".to_owned()];
         setenv("C", "D", true, &mut env).unwrap();
-        assert_eq!(env, vec!["A=B"]);
+        assert_eq!(env, vec!["A=B", "C=D"]);
     }
 
     #[test]
-    fn multicluster_parse_reports_mock_failure() {
+    fn setenv_rejects_later_interior_nul_without_panicking() {
         let _guard = mock_ffi::MockGuard::new();
-        assert!(multicluster_nspace_parse("cluster:nspace").is_err());
+        let mut env = vec!["A=B".to_owned(), "BAD\0=VALUE".to_owned()];
+        assert!(setenv("C", "D", true, &mut env).is_err());
+        assert_eq!(env, vec!["A=B", "BAD\0=VALUE"]);
     }
 
     #[test]
-    fn multicluster_construct_is_safe_with_mock() {
+    fn multicluster_parse_returns_mock_buffers() {
         let _guard = mock_ffi::MockGuard::new();
-        let result = multicluster_nspace_construct("cluster", "nspace");
-        assert_eq!(result.unwrap(), "");
+        assert_eq!(multicluster_nspace_parse("cluster:nspace").unwrap(), ("cluster".into(), "nspace".into()));
+    }
+
+    #[test]
+    fn multicluster_construct_writes_target() {
+        let _guard = mock_ffi::MockGuard::new();
+        assert_eq!(multicluster_nspace_construct("cluster", "nspace").unwrap(), "cluster:nspace");
+    }
+
+    #[test]
+    fn multicluster_rejects_oversized_components() {
+        let _guard = mock_ffi::MockGuard::new();
+        let component = "x".repeat(PMIX_MAX_NSLEN + 1);
+        assert!(multicluster_nspace_construct(&component, "nspace").is_err());
+        assert!(multicluster_nspace_parse(&format!("{}:nspace", component)).is_err());
     }
 }
 
@@ -5818,14 +5850,14 @@ pub fn envar_load(envar: &str, value: &str, separator: char) -> Result<PmixEnvar
     Ok(result)
 }
 
-/// Invoke the PMIx destructor contract without exposing the raw struct.
-pub fn envar_destruct(_envar: &mut PmixEnvar) {
-    let mut raw = unsafe { mem::zeroed::<pmix_envar_t>() };
-    pmix_ffi_or_mock!(
-        mock = unsafe { mock_ffi::mock_envar_destruct(&mut raw) },
-        real = unsafe { ffi::PMIx_Envar_destruct(&mut raw) },
-    );
-}
+/// Release hook for a [`PmixEnvar`].
+///
+/// `PmixEnvar` owns both [`CString`] fields. Calling the PMIx destructor on a
+/// temporary raw value would not affect this value, while calling it on a raw
+/// view of these fields would make PMIx free Rust-owned allocations. Therefore
+/// this function intentionally performs no FFI call; normal Rust `Drop` owns
+/// destruction of the strings.
+pub fn envar_destruct(_envar: &mut PmixEnvar) {}
 
 /// Owned array allocated by PMIx_Envar_create.
 pub struct PmixEnvarArray {
@@ -5874,7 +5906,12 @@ fn c_string_vector(values: &[String]) -> Result<*mut *mut c_char, PmixStatus> {
         let c = match CString::new(value.as_str()) {
             Ok(c) => c,
             Err(_) => {
-                unsafe { libc::free(argv.cast()) };
+                unsafe {
+                    for initialized in 0..index {
+                        libc::free((*argv.add(initialized)).cast());
+                    }
+                    libc::free(argv.cast());
+                }
                 return Err(PmixStatus::from_raw(PmixError::ErrBadParam as i32));
             }
         };
@@ -5915,6 +5952,11 @@ pub fn setenv(name: &str, value: &str, overwrite: bool, env: &mut Vec<String>) -
 const PMIX_MAX_NSLEN: usize = 255;
 
 pub fn multicluster_nspace_construct(cluster: &str, nspace: &str) -> Result<String, PmixError> {
+    if cluster.len() > PMIX_MAX_NSLEN || nspace.len() > PMIX_MAX_NSLEN
+        || cluster.len().checked_add(nspace.len()).and_then(|len| len.checked_add(1)).is_none_or(|len| len > PMIX_MAX_NSLEN)
+    {
+        return Err(PmixError::ErrBadParam);
+    }
     let target = [0 as c_char; PMIX_MAX_NSLEN + 1];
     let cluster = CString::new(cluster).map_err(|_| PmixError::ErrBadParam)?;
     let nspace = CString::new(nspace).map_err(|_| PmixError::ErrBadParam)?;
@@ -5928,6 +5970,9 @@ pub fn multicluster_nspace_construct(cluster: &str, nspace: &str) -> Result<Stri
 }
 
 pub fn multicluster_nspace_parse(target: &str) -> Result<(String, String), PmixError> {
+    if target.len() > PMIX_MAX_NSLEN {
+        return Err(PmixError::ErrBadParam);
+    }
     let target = CString::new(target).map_err(|_| PmixError::ErrBadParam)?;
     let cluster = [0 as c_char; PMIX_MAX_NSLEN + 1];
     let nspace = [0 as c_char; PMIX_MAX_NSLEN + 1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5742,3 +5742,203 @@ mod value_utils_tests {
 
 /// Safe wrapper around an opaque PMIx info linked list.
 pub use info::PmixInfoList;
+
+#[cfg(test)]
+mod envar_utils_tests {
+    use super::*;
+
+    #[test]
+    fn envar_load_round_trip() {
+        let _guard = mock_ffi::MockGuard::new();
+        let value = envar_load("PATH", "/bin", ':').unwrap();
+        assert_eq!(value.envar.as_c_str().to_str().unwrap(), "PATH");
+        assert_eq!(value.value.as_c_str().to_str().unwrap(), "/bin");
+        assert_eq!(value.separator, b':');
+    }
+
+    #[test]
+    fn envar_create_allocates_and_drops() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut array = envar_create(2).unwrap();
+        assert_eq!(array.len(), 2);
+        assert!(!array.as_mut_ptr().is_null());
+    }
+
+    #[test]
+    fn setenv_accepts_vec_environment() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut env = vec!["A=B".to_owned()];
+        setenv("C", "D", true, &mut env).unwrap();
+        assert_eq!(env, vec!["A=B"]);
+    }
+
+    #[test]
+    fn multicluster_parse_reports_mock_failure() {
+        let _guard = mock_ffi::MockGuard::new();
+        assert!(multicluster_nspace_parse("cluster:nspace").is_err());
+    }
+
+    #[test]
+    fn multicluster_construct_is_safe_with_mock() {
+        let _guard = mock_ffi::MockGuard::new();
+        let result = multicluster_nspace_construct("cluster", "nspace");
+        assert_eq!(result.unwrap(), "");
+    }
+}
+
+// END TDD TESTS
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Safe wrappers for PMIx_Envar_*, PMIx_Setenv, and multicluster namespaces.
+
+/// Construct a Rust-owned environment variable using the PMIx construct contract.
+pub fn envar_construct() -> PmixEnvar {
+    let mut raw = unsafe { mem::zeroed::<pmix_envar_t>() };
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_envar_construct(&mut raw) },
+        real = unsafe { ffi::PMIx_Envar_construct(&mut raw) },
+    );
+    PmixEnvar::new("", "", '\0').expect("empty strings cannot contain NUL")
+}
+
+/// Apply the PMIx environment-variable load operation to a validated value.
+pub fn envar_load(envar: &str, value: &str, separator: char) -> Result<PmixEnvar, NulError> {
+    let result = PmixEnvar::new(envar, value, separator)?;
+    let mut raw = unsafe { mem::zeroed::<pmix_envar_t>() };
+    let var = CString::new(envar)?;
+    let val = CString::new(value)?;
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_envar_load(&mut raw, var.as_ptr().cast_mut(), val.as_ptr().cast_mut(), separator as c_char) },
+        real = unsafe { ffi::PMIx_Envar_load(&mut raw, var.as_ptr().cast_mut(), val.as_ptr().cast_mut(), separator as c_char) },
+    );
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_envar_destruct(&mut raw) },
+        real = unsafe { ffi::PMIx_Envar_destruct(&mut raw) },
+    );
+    Ok(result)
+}
+
+/// Invoke the PMIx destructor contract without exposing the raw struct.
+pub fn envar_destruct(_envar: &mut PmixEnvar) {
+    let mut raw = unsafe { mem::zeroed::<pmix_envar_t>() };
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_envar_destruct(&mut raw) },
+        real = unsafe { ffi::PMIx_Envar_destruct(&mut raw) },
+    );
+}
+
+/// Owned array allocated by PMIx_Envar_create.
+pub struct PmixEnvarArray {
+    ptr: *mut pmix_envar_t,
+    len: usize,
+}
+
+impl PmixEnvarArray {
+    pub fn as_mut_ptr(&mut self) -> *mut pmix_envar_t { self.ptr }
+    pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+
+impl Drop for PmixEnvarArray {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_envar_free(self.ptr, self.len) },
+                real = unsafe { ffi::PMIx_Envar_free(self.ptr, self.len) },
+            );
+            self.ptr = ptr::null_mut();
+        }
+    }
+}
+
+pub fn envar_create(len: usize) -> Result<PmixEnvarArray, PmixError> {
+    if len == 0 {
+        return Ok(PmixEnvarArray { ptr: ptr::null_mut(), len });
+    }
+    let ptr = pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_envar_create(len) },
+        real = unsafe { ffi::PMIx_Envar_create(len) },
+    );
+    if ptr.is_null() {
+        Err(PmixError::ErrNomem)
+    } else {
+        Ok(PmixEnvarArray { ptr, len })
+    }
+}
+
+fn c_string_vector(values: &[String]) -> Result<*mut *mut c_char, PmixStatus> {
+    let slots = values.len().checked_add(1).ok_or(PmixStatus::from_raw(PmixError::ErrBadParam as i32))?;
+    let argv = unsafe { libc::calloc(slots, mem::size_of::<*mut c_char>()) as *mut *mut c_char };
+    if argv.is_null() { return Err(PmixStatus::from_raw(PmixError::ErrNomem as i32)); }
+    for (index, value) in values.iter().enumerate() {
+        let c = match CString::new(value.as_str()) {
+            Ok(c) => c,
+            Err(_) => {
+                unsafe { libc::free(argv.cast()) };
+                return Err(PmixStatus::from_raw(PmixError::ErrBadParam as i32));
+            }
+        };
+        unsafe { *argv.add(index) = c.into_raw(); }
+    }
+    Ok(argv)
+}
+
+/// Set an environment entry while preserving the caller's Vec<String> API.
+pub fn setenv(name: &str, value: &str, overwrite: bool, env: &mut Vec<String>) -> Result<(), PmixStatus> {
+    let name = CString::new(name).map_err(|_| PmixStatus::from_raw(PmixError::ErrBadParam as i32))?;
+    let value = CString::new(value).map_err(|_| PmixStatus::from_raw(PmixError::ErrBadParam as i32))?;
+    let mut argv = c_string_vector(env)?;
+    let status = pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_setenv(name.as_ptr(), value.as_ptr(), overwrite, &mut argv) },
+        real = unsafe { ffi::PMIx_Setenv(name.as_ptr(), value.as_ptr(), overwrite, &mut argv) },
+    );
+    let result = PmixStatus::from_raw(status as i32);
+    if result.is_success() {
+        let mut copied = Vec::new();
+        unsafe {
+            let mut index = 0;
+            while !(*argv.add(index)).is_null() {
+                copied.push(CStr::from_ptr(*argv.add(index)).to_string_lossy().into_owned());
+                index += 1;
+            }
+        }
+        *env = copied;
+    }
+    // PMIx_Argv_free is the matching deallocator even when PMIx_Setenv replaced argv.
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_argv_free(argv) },
+        real = unsafe { ffi::PMIx_Argv_free(argv) },
+    );
+    if result.is_success() { Ok(()) } else { Err(result) }
+}
+
+const PMIX_MAX_NSLEN: usize = 255;
+
+pub fn multicluster_nspace_construct(cluster: &str, nspace: &str) -> Result<String, PmixError> {
+    let target = [0 as c_char; PMIX_MAX_NSLEN + 1];
+    let cluster = CString::new(cluster).map_err(|_| PmixError::ErrBadParam)?;
+    let nspace = CString::new(nspace).map_err(|_| PmixError::ErrBadParam)?;
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_multicluster_nspace_construct(target.as_ptr().cast_mut(), cluster.as_ptr().cast_mut(), nspace.as_ptr().cast_mut()) },
+        real = unsafe { ffi::PMIx_Multicluster_nspace_construct(target.as_ptr().cast_mut(), cluster.as_ptr().cast_mut(), nspace.as_ptr().cast_mut()) },
+    );
+    CStr::from_bytes_until_nul(unsafe { std::slice::from_raw_parts(target.as_ptr().cast::<u8>(), target.len()) })
+        .map_err(|_| PmixError::ErrBadParam)
+        .and_then(|s| s.to_str().map(str::to_owned).map_err(|_| PmixError::ErrBadParam))
+}
+
+pub fn multicluster_nspace_parse(target: &str) -> Result<(String, String), PmixError> {
+    let target = CString::new(target).map_err(|_| PmixError::ErrBadParam)?;
+    let cluster = [0 as c_char; PMIX_MAX_NSLEN + 1];
+    let nspace = [0 as c_char; PMIX_MAX_NSLEN + 1];
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_multicluster_nspace_parse(target.as_ptr().cast_mut(), cluster.as_ptr().cast_mut(), nspace.as_ptr().cast_mut()) },
+        real = unsafe { ffi::PMIx_Multicluster_nspace_parse(target.as_ptr().cast_mut(), cluster.as_ptr().cast_mut(), nspace.as_ptr().cast_mut()) },
+    );
+    let cluster = CStr::from_bytes_until_nul(unsafe { std::slice::from_raw_parts(cluster.as_ptr().cast::<u8>(), cluster.len()) }).map_err(|_| PmixError::ErrNotFound)?;
+    let nspace = CStr::from_bytes_until_nul(unsafe { std::slice::from_raw_parts(nspace.as_ptr().cast::<u8>(), nspace.len()) }).map_err(|_| PmixError::ErrNotFound)?;
+    if cluster.to_bytes().is_empty() && nspace.to_bytes().is_empty() {
+        return Err(PmixError::ErrNotFound);
+    }
+    Ok((cluster.to_string_lossy().into_owned(), nspace.to_string_lossy().into_owned()))
+}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3635,7 +3635,7 @@ pub unsafe fn mock_setenv(name: *const libc::c_char, value: *const libc::c_char,
         for i in 0..index { *replacement.add(i) = libc::strdup(*(*env).add(i)); }
         *replacement.add(index) = libc::strdup(std::ffi::CString::new(entry).unwrap().as_ptr());
         let old = *env;
-        for i in 0..index { libc::free(*old.add(i)); }
+        for i in 0..index { libc::free((*old.add(i)).cast()); }
         libc::free(old.cast());
         *env = replacement;
     }

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3609,3 +3609,13 @@ pub unsafe fn mock_app_string(_p: *const crate::ffi::pmix_app_t) -> *mut libc::c
     // SAFETY: strdup allocates with malloc, matching the wrapper's libc::free.
     unsafe { libc::strdup(c"mock_app".as_ptr()) }
 }
+
+// PMIx_Envar_*, PMIx_Setenv, and multicluster namespace mocks.
+pub unsafe fn mock_envar_construct(e: *mut crate::ffi::pmix_envar_t) { if !e.is_null() { unsafe { std::ptr::write_bytes(e, 0, 1) } } }
+pub unsafe fn mock_envar_destruct(_e: *mut crate::ffi::pmix_envar_t) {}
+pub unsafe fn mock_envar_create(n: usize) -> *mut crate::ffi::pmix_envar_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_envar_t>()) as *mut _ } }
+pub unsafe fn mock_envar_free(_e: *mut crate::ffi::pmix_envar_t, _n: usize) {}
+pub unsafe fn mock_envar_load(_e: *mut crate::ffi::pmix_envar_t, _var: *mut libc::c_char, _value: *mut libc::c_char, _separator: libc::c_char) {}
+pub unsafe fn mock_setenv(_name: *const libc::c_char, _value: *const libc::c_char, _overwrite: bool, _env: *mut *mut *mut libc::c_char) -> crate::ffi::pmix_status_t { 0 }
+pub unsafe fn mock_multicluster_nspace_construct(_target: *mut libc::c_char, _cluster: *mut libc::c_char, _nspace: *mut libc::c_char) {}
+pub unsafe fn mock_multicluster_nspace_parse(_target: *mut libc::c_char, _cluster: *mut libc::c_char, _nspace: *mut libc::c_char) {}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3616,6 +3616,39 @@ pub unsafe fn mock_envar_destruct(_e: *mut crate::ffi::pmix_envar_t) {}
 pub unsafe fn mock_envar_create(n: usize) -> *mut crate::ffi::pmix_envar_t { unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_envar_t>()) as *mut _ } }
 pub unsafe fn mock_envar_free(_e: *mut crate::ffi::pmix_envar_t, _n: usize) {}
 pub unsafe fn mock_envar_load(_e: *mut crate::ffi::pmix_envar_t, _var: *mut libc::c_char, _value: *mut libc::c_char, _separator: libc::c_char) {}
-pub unsafe fn mock_setenv(_name: *const libc::c_char, _value: *const libc::c_char, _overwrite: bool, _env: *mut *mut *mut libc::c_char) -> crate::ffi::pmix_status_t { 0 }
-pub unsafe fn mock_multicluster_nspace_construct(_target: *mut libc::c_char, _cluster: *mut libc::c_char, _nspace: *mut libc::c_char) {}
-pub unsafe fn mock_multicluster_nspace_parse(_target: *mut libc::c_char, _cluster: *mut libc::c_char, _nspace: *mut libc::c_char) {}
+pub unsafe fn mock_setenv(name: *const libc::c_char, value: *const libc::c_char, overwrite: bool, env: *mut *mut *mut libc::c_char) -> crate::ffi::pmix_status_t {
+    if name.is_null() || value.is_null() || env.is_null() { return crate::ffi::PMIX_ERR_BAD_PARAM as _; }
+    unsafe {
+        let name = std::ffi::CStr::from_ptr(name).to_string_lossy();
+        let entry = format!("{}={}", name, std::ffi::CStr::from_ptr(value).to_string_lossy());
+        let mut index = 0;
+        while !(*(*env).add(index)).is_null() {
+            let current = std::ffi::CStr::from_ptr(*(*env).add(index)).to_string_lossy();
+            if current.split_once('=').map_or(false, |(key, _)| key == name) {
+                if overwrite { libc::free(*(*env).add(index).cast()); *(*env).add(index) = libc::strdup(std::ffi::CString::new(entry).unwrap().as_ptr()); }
+                return 0;
+            }
+            index += 1;
+        }
+        let replacement = libc::calloc(index + 2, std::mem::size_of::<*mut libc::c_char>()) as *mut *mut libc::c_char;
+        if replacement.is_null() { return crate::ffi::PMIX_ERR_NOMEM as _; }
+        for i in 0..index { *replacement.add(i) = libc::strdup(*(*env).add(i)); }
+        *replacement.add(index) = libc::strdup(std::ffi::CString::new(entry).unwrap().as_ptr());
+        let old = *env;
+        for i in 0..index { libc::free(*old.add(i)); }
+        libc::free(old.cast());
+        *env = replacement;
+    }
+    0
+}
+pub unsafe fn mock_multicluster_nspace_construct(target: *mut libc::c_char, cluster: *mut libc::c_char, nspace: *mut libc::c_char) {
+    if target.is_null() || cluster.is_null() || nspace.is_null() { return; }
+    unsafe { libc::snprintf(target, 256, b"%s:%s\0".as_ptr().cast(), cluster, nspace); }
+}
+pub unsafe fn mock_multicluster_nspace_parse(target: *mut libc::c_char, cluster: *mut libc::c_char, nspace: *mut libc::c_char) {
+    if target.is_null() || cluster.is_null() || nspace.is_null() { return; }
+    unsafe {
+        let text = std::ffi::CStr::from_ptr(target).to_bytes();
+        if let Some(pos) = text.iter().position(|&b| b == b':') { std::ptr::copy_nonoverlapping(text.as_ptr(), cluster.cast(), pos.min(255)); *cluster.add(pos.min(255)) = 0; let rest = &text[pos + 1..]; std::ptr::copy_nonoverlapping(rest.as_ptr(), nspace.cast(), rest.len().min(255)); *nspace.add(rest.len().min(255)) = 0; }
+    }
+}


### PR DESCRIPTION
Closes #75, Closes #95, Closes #142, Closes #151, Closes #154, Closes #158, Closes #160, Closes #195, Closes #311

## Summary
- Add envar construct/destruct/load wrappers and PmixEnvarArray (create/free) in src/lib.rs (home of the real PmixEnvar; orphan files untouched).
- Add setenv() Vec<String>-based wrapper.
- Add multicluster_nspace_construct/parse wrappers.
- Append mock FFI for daemon-free tests.
## Test plan
- Local mock-based tests; daemon/DVM tests remain CI-only.