### PR TITLE
feat: add safe wrappers for misc PMIx utilities

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -1594,3 +1594,28 @@ pub fn resource_block_directive_string(d: ffi::pmix_resource_block_directive_t)-
 pub fn resource_block(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info])->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())},real=unsafe{ffi::PMIx_Resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn resource_block_nb(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info],cb:ffi::pmix_op_cbfunc_t,cbdata:*mut c_void)->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)},real=unsafe{ffi::PMIx_Resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
+
+
+#[cfg(test)]
+mod misc_wrapper_tests {
+    use super::*;
+    use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+
+    extern "C" fn callback(status: ffi::pmix_status_t, data: *mut std::os::raw::c_void) {
+        // SAFETY: test passes a pointer to the live AtomicUsize below.
+        unsafe { (*data.cast::<AtomicUsize>()).store(status as usize + 1, Ordering::SeqCst); }
+    }
+
+    #[test]
+    fn resource_block_sync_and_nb_callback() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let mut block = [0_u8; 8];
+        let units = [crate::fabric::PmixResourceUnit::new()];
+        assert!(resource_block(0, &mut block, &units, &[]).is_ok());
+        let called = AtomicUsize::new(0);
+        // SAFETY: callback has the PMIx ABI and called remains live through the
+        // synchronous mock invocation; a real caller must extend that lifetime.
+        assert!(unsafe { resource_block_nb(0, &mut block, &units, &[], Some(callback), (&called as *const AtomicUsize).cast_mut().cast()) }.is_ok());
+        assert_eq!(called.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -1592,8 +1592,21 @@ mod tests {
 
 pub fn resource_block_directive_string(d: ffi::pmix_resource_block_directive_t)->&'static str {let p=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_directive_string(d)},real=unsafe{ffi::PMIx_Resource_block_directive_string(d)});if p.is_null(){""}else{unsafe{std::ffi::CStr::from_ptr(p).to_str().unwrap_or("")}}}
 pub fn resource_block(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info])->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())},real=unsafe{ffi::PMIx_Resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn resource_block_nb(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info],cb:ffi::pmix_op_cbfunc_t,cbdata:*mut c_void)->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)},real=unsafe{ffi::PMIx_Resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
+/// Starts an asynchronous resource-block operation.
+///
+/// # Safety
+///
+/// The caller must ensure that `cb` has exactly the `pmix_op_cbfunc_t` ABI
+/// expected by PMIx and remains a valid callable function for the entire
+/// period in which PMIx may invoke it. `cbdata` must be a valid pointer for
+/// the callback's use (or null if the callback permits null), and the pointed-to
+/// data, together with any resources it references, must remain valid until
+/// PMIx has invoked the callback. The callback must not use the pointer after
+/// that lifetime, free data it does not own, or otherwise invalidate data that
+/// PMIx or another owner may still use. The `block`, `res`, and `info` storage
+/// must likewise remain valid and unmodified in ways incompatible with PMIx
+/// until the asynchronous operation has completed, as required by the PMIx API.
+pub unsafe fn resource_block_nb(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info],cb:ffi::pmix_op_cbfunc_t,cbdata:*mut c_void)->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)},real=unsafe{ffi::PMIx_Resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
 
 
 #[cfg(test)]

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -1588,3 +1588,9 @@ mod tests {
         }
     }
 }
+
+
+pub fn resource_block_directive_string(d: ffi::pmix_resource_block_directive_t)->&'static str {let p=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_directive_string(d)},real=unsafe{ffi::PMIx_Resource_block_directive_string(d)});if p.is_null(){""}else{unsafe{std::ffi::CStr::from_ptr(p).to_str().unwrap_or("")}}}
+pub fn resource_block(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info])->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())},real=unsafe{ffi::PMIx_Resource_block(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn resource_block_nb(d:ffi::pmix_resource_block_directive_t,block:&mut [u8],res:&[crate::fabric::PmixResourceUnit],info:&[Info],cb:ffi::pmix_op_cbfunc_t,cbdata:*mut c_void)->Result<(),PmixStatus>{let rp=res.first().map_or(ptr::null(),|x|x.as_ptr());let ip=info.first().map_or(ptr::null(),|x| Info::as_ptr(x).cast_const());let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)},real=unsafe{ffi::PMIx_Resource_block_nb(d,block.as_mut_ptr().cast(),rp,res.len(),ip,info.len(),cb,cbdata)});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -1417,3 +1417,15 @@ pub fn fence_nb(
 
 #[cfg(test)]
 mod tests;
+
+
+
+
+/// Owned RAII wrapper for a standalone PMIx pdata object.
+pub struct PmixPdataHandle { raw: std::mem::MaybeUninit<ffi::pmix_pdata_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixPdataHandle { pub fn new()->Self{let mut s=Self{raw:std::mem::MaybeUninit::uninit(),constructed:false,_not_thread_safe:std::marker::PhantomData};crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_construct(s.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Pdata_construct(s.raw.as_mut_ptr())});s.constructed=true;s} #[cfg(test)] pub fn test_new()->Self{Self{raw:std::mem::MaybeUninit::zeroed(),constructed:true,_not_thread_safe:std::marker::PhantomData}} pub fn load(&mut self,p:&Proc,key:&str,data:&[u8],ty:ffi::pmix_data_type_t)->Result<(),std::ffi::NulError>{let key=CString::new(key)?;crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_load(self.raw.as_mut_ptr(),&p.handle,key.as_ptr(),data.as_ptr().cast(),ty)},real=unsafe{ffi::PMIx_Pdata_load(self.raw.as_mut_ptr(),&p.handle,key.as_ptr(),data.as_ptr().cast(),ty)});Ok(())} pub fn xfer(&mut self,src:&PmixPdataHandle)->Result<(),PmixStatus>{crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_xfer(self.raw.as_mut_ptr(),src.raw.as_ptr().cast_mut())},real=unsafe{ffi::PMIx_Pdata_xfer(self.raw.as_mut_ptr(),src.raw.as_ptr().cast_mut())});Ok(())}}
+impl Default for PmixPdataHandle{fn default()->Self{Self::new()}}
+impl Drop for PmixPdataHandle{fn drop(&mut self){if self.constructed{crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_destruct(self.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Pdata_destruct(self.raw.as_mut_ptr())});self.constructed=false;}}}
+pub struct PmixPdataArray{ptr:*mut ffi::pmix_pdata_t,len:usize,_not_thread_safe:std::marker::PhantomData<*mut u8>}
+pub fn pdata_create(n:usize)->Result<PmixPdataArray,PmixError>{if n==0{return Ok(PmixPdataArray{ptr:ptr::null_mut(),len:0,_not_thread_safe:std::marker::PhantomData})}let p=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_create(n)},real=unsafe{ffi::PMIx_Pdata_create(n)});if p.is_null(){Err(PmixError::ErrNomem)}else{Ok(PmixPdataArray{ptr:p,len:n,_not_thread_safe:std::marker::PhantomData})}}
+impl Drop for PmixPdataArray{fn drop(&mut self){if !self.ptr.is_null(){crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_free(self.ptr,self.len)},real=unsafe{ffi::PMIx_Pdata_free(self.ptr,self.len)});self.ptr=ptr::null_mut();}}}

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -1422,10 +1422,117 @@ mod tests;
 
 
 /// Owned RAII wrapper for a standalone PMIx pdata object.
-pub struct PmixPdataHandle { raw: std::mem::MaybeUninit<ffi::pmix_pdata_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
-impl PmixPdataHandle { pub fn new()->Self{let mut s=Self{raw:std::mem::MaybeUninit::uninit(),constructed:false,_not_thread_safe:std::marker::PhantomData};crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_construct(s.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Pdata_construct(s.raw.as_mut_ptr())});s.constructed=true;s} #[cfg(test)] pub fn test_new()->Self{Self{raw:std::mem::MaybeUninit::zeroed(),constructed:true,_not_thread_safe:std::marker::PhantomData}} pub fn load(&mut self,p:&Proc,key:&str,data:&[u8],ty:ffi::pmix_data_type_t)->Result<(),std::ffi::NulError>{let key=CString::new(key)?;crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_load(self.raw.as_mut_ptr(),&p.handle,key.as_ptr(),data.as_ptr().cast(),ty)},real=unsafe{ffi::PMIx_Pdata_load(self.raw.as_mut_ptr(),&p.handle,key.as_ptr(),data.as_ptr().cast(),ty)});Ok(())} pub fn xfer(&mut self,src:&PmixPdataHandle)->Result<(),PmixStatus>{crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_xfer(self.raw.as_mut_ptr(),src.raw.as_ptr().cast_mut())},real=unsafe{ffi::PMIx_Pdata_xfer(self.raw.as_mut_ptr(),src.raw.as_ptr().cast_mut())});Ok(())}}
-impl Default for PmixPdataHandle{fn default()->Self{Self::new()}}
-impl Drop for PmixPdataHandle{fn drop(&mut self){if self.constructed{crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_destruct(self.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Pdata_destruct(self.raw.as_mut_ptr())});self.constructed=false;}}}
-pub struct PmixPdataArray{ptr:*mut ffi::pmix_pdata_t,len:usize,_not_thread_safe:std::marker::PhantomData<*mut u8>}
-pub fn pdata_create(n:usize)->Result<PmixPdataArray,PmixError>{if n==0{return Ok(PmixPdataArray{ptr:ptr::null_mut(),len:0,_not_thread_safe:std::marker::PhantomData})}let p=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_create(n)},real=unsafe{ffi::PMIx_Pdata_create(n)});if p.is_null(){Err(PmixError::ErrNomem)}else{Ok(PmixPdataArray{ptr:p,len:n,_not_thread_safe:std::marker::PhantomData})}}
-impl Drop for PmixPdataArray{fn drop(&mut self){if !self.ptr.is_null(){crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_pdata_free(self.ptr,self.len)},real=unsafe{ffi::PMIx_Pdata_free(self.ptr,self.len)});self.ptr=ptr::null_mut();}}}
+pub struct PmixPdataHandle {
+    raw: std::mem::MaybeUninit<ffi::pmix_pdata_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+impl PmixPdataHandle {
+    pub fn new() -> Self {
+        let mut this = Self {
+            raw: std::mem::MaybeUninit::uninit(),
+            constructed: false,
+            _not_thread_safe: std::marker::PhantomData,
+        };
+        // SAFETY: PMIx constructs the valid output object at this owned pointer;
+        // Drop destructs it exactly once after this successful construction.
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_pdata_construct(this.raw.as_mut_ptr()) },
+            real = unsafe { ffi::PMIx_Pdata_construct(this.raw.as_mut_ptr()) },
+        );
+        this.constructed = true;
+        this
+    }
+
+    #[cfg(test)]
+    pub fn test_new() -> Self {
+        Self {
+            raw: std::mem::MaybeUninit::zeroed(),
+            constructed: true,
+            _not_thread_safe: std::marker::PhantomData,
+        }
+    }
+
+    pub fn load(
+        &mut self,
+        proc: &Proc,
+        key: &str,
+        data: &[u8],
+        ty: ffi::pmix_data_type_t,
+    ) -> Result<(), std::ffi::NulError> {
+        let key = CString::new(key)?;
+        // SAFETY: self and proc are live owned/borrowed PMIx objects; key and
+        // data remain valid for the synchronous call, including empty data.
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_pdata_load(self.raw.as_mut_ptr(), &proc.handle, key.as_ptr(), data.as_ptr().cast(), ty) },
+            real = unsafe { ffi::PMIx_Pdata_load(self.raw.as_mut_ptr(), &proc.handle, key.as_ptr(), data.as_ptr().cast(), ty) },
+        );
+        Ok(())
+    }
+
+    pub fn xfer(&mut self, src: &PmixPdataHandle) -> Result<(), PmixStatus> {
+        // SAFETY: both handles are constructed and remain alive for this call;
+        // PMIx copies between the two initialized pdata objects.
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_pdata_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr().cast_mut()) },
+            real = unsafe { ffi::PMIx_Pdata_xfer(self.raw.as_mut_ptr(), src.raw.as_ptr().cast_mut()) },
+        );
+        Ok(())
+    }
+}
+
+impl Default for PmixPdataHandle {
+    fn default() -> Self { Self::new() }
+}
+
+impl Drop for PmixPdataHandle {
+    fn drop(&mut self) {
+        if self.constructed {
+            // SAFETY: constructed is set only after PMIx construction and is
+            // cleared after this one matching destruct call.
+            crate::pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_pdata_destruct(self.raw.as_mut_ptr()) },
+                real = unsafe { ffi::PMIx_Pdata_destruct(self.raw.as_mut_ptr()) },
+            );
+            self.constructed = false;
+        }
+    }
+}
+
+pub struct PmixPdataArray {
+    ptr: *mut ffi::pmix_pdata_t,
+    len: usize,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
+}
+
+pub fn pdata_create(n: usize) -> Result<PmixPdataArray, PmixError> {
+    if n == 0 {
+        return Ok(PmixPdataArray { ptr: ptr::null_mut(), len: 0, _not_thread_safe: std::marker::PhantomData });
+    }
+    // SAFETY: PMIx allocates an array of n pdata objects; the returned pointer
+    // is owned by this RAII value and freed with the matching PMIx function.
+    let p = crate::pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_pdata_create(n) },
+        real = unsafe { ffi::PMIx_Pdata_create(n) },
+    );
+    if p.is_null() {
+        Err(PmixError::ErrNomem)
+    } else {
+        Ok(PmixPdataArray { ptr: p, len: n, _not_thread_safe: std::marker::PhantomData })
+    }
+}
+
+impl Drop for PmixPdataArray {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: ptr/len are the exact successful allocation returned by
+            // PMIx_Pdata_create and have not previously been freed.
+            crate::pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_pdata_free(self.ptr, self.len) },
+                real = unsafe { ffi::PMIx_Pdata_free(self.ptr, self.len) },
+            );
+            self.ptr = ptr::null_mut();
+        }
+    }
+}

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -4143,3 +4143,20 @@ use super::*;
         assert_eq!(PUB_CB_PARTIAL.load(Ordering::SeqCst), -52);
     }
 
+
+
+#[cfg(any(test, feature = "mock_ffi"))]
+#[test]
+fn test_misc_pdata_wrappers_construct_load_xfer_and_arrays() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let proc = crate::Proc::new("test", 0).unwrap();
+    let mut dst = super::PmixPdataHandle::new();
+    let src = super::PmixPdataHandle::new();
+    assert!(dst.load(&proc, "key", &[], crate::ffi::PMIX_BYTE as u16).is_ok());
+    assert!(dst.load(&proc, "bad\0key", &[], crate::ffi::PMIX_BYTE as u16).is_err());
+    assert!(dst.xfer(&src).is_ok());
+    let array = super::pdata_create(2).unwrap();
+    drop(array);
+    let empty = super::pdata_create(0).unwrap();
+    assert!(empty.ptr.is_null());
+}

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -3325,3 +3325,22 @@ mod added_type_tests {
         assert_eq!(device.device_type(), 9);
     }
 }
+
+
+/// An owned PMIx resource unit.
+pub struct PmixResourceUnit { raw: MaybeUninit<ffi::pmix_resource_unit_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixResourceUnit {
+    pub fn new() -> Self { let mut s=Self{raw:MaybeUninit::uninit(),constructed:false,_not_thread_safe:std::marker::PhantomData}; crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_construct(s.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Resource_unit_construct(s.raw.as_mut_ptr())}); s.constructed=true;s }
+    #[cfg(test)] pub fn test_new() -> Self { Self{raw:MaybeUninit::zeroed(),constructed:true,_not_thread_safe:std::marker::PhantomData} }
+    pub fn unit_type(&self)->ffi::pmix_device_type_t { unsafe{self.raw.assume_init_ref().type_} }
+    pub fn count(&self)->usize { unsafe{self.raw.assume_init_ref().count} }
+    pub(crate) fn as_ptr(&self)->*const ffi::pmix_resource_unit_t { self.raw.as_ptr() }
+}
+impl Default for PmixResourceUnit { fn default()->Self{Self::new()} }
+impl Drop for PmixResourceUnit { fn drop(&mut self){if self.constructed {crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_destruct(self.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Resource_unit_destruct(self.raw.as_mut_ptr())});self.constructed=false;}} }
+
+pub struct PmixResourceUnitArray { ptr:*mut ffi::pmix_resource_unit_t, len:usize, _not_thread_safe:std::marker::PhantomData<*mut u8> }
+impl PmixResourceUnitArray { pub fn as_ptr(&self)->*const ffi::pmix_resource_unit_t{self.ptr} pub fn len(&self)->usize{self.len} pub fn is_empty(&self)->bool{self.len==0} }
+impl Drop for PmixResourceUnitArray { fn drop(&mut self){if !self.ptr.is_null(){crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_free(self.ptr,self.len)},real=unsafe{ffi::PMIx_Resource_unit_free(self.ptr,self.len)});self.ptr=ptr::null_mut();}} }
+pub fn resource_unit_create(n:usize)->Result<PmixResourceUnitArray,PmixError>{if n==0{return Ok(PmixResourceUnitArray{ptr:ptr::null_mut(),len:0,_not_thread_safe:std::marker::PhantomData})}let ptr=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_create(n)},real=unsafe{ffi::PMIx_Resource_unit_create(n)});if ptr.is_null(){Err(PmixError::ErrNomem)}else{Ok(PmixResourceUnitArray{ptr,len:n,_not_thread_safe:std::marker::PhantomData})}}
+impl PmixResourceUnit { pub fn to_string(&self)->Result<String,PmixError>{let p=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_string(self.as_ptr())},real=unsafe{ffi::PMIx_Resource_unit_string(self.as_ptr())});if p.is_null(){return Err(PmixError::ErrNomem)}let s=unsafe{CStr::from_ptr(p).to_string_lossy().into_owned()};unsafe{libc::free(p.cast())};Ok(s)} }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -3328,19 +3328,120 @@ mod added_type_tests {
 
 
 /// An owned PMIx resource unit.
-pub struct PmixResourceUnit { raw: MaybeUninit<ffi::pmix_resource_unit_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
-impl PmixResourceUnit {
-    pub fn new() -> Self { let mut s=Self{raw:MaybeUninit::uninit(),constructed:false,_not_thread_safe:std::marker::PhantomData}; crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_construct(s.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Resource_unit_construct(s.raw.as_mut_ptr())}); s.constructed=true;s }
-    #[cfg(test)] pub fn test_new() -> Self { Self{raw:MaybeUninit::zeroed(),constructed:true,_not_thread_safe:std::marker::PhantomData} }
-    pub fn unit_type(&self)->ffi::pmix_device_type_t { unsafe{self.raw.assume_init_ref().type_} }
-    pub fn count(&self)->usize { unsafe{self.raw.assume_init_ref().count} }
-    pub(crate) fn as_ptr(&self)->*const ffi::pmix_resource_unit_t { self.raw.as_ptr() }
+pub struct PmixResourceUnit {
+    raw: MaybeUninit<ffi::pmix_resource_unit_t>,
+    constructed: bool,
+    _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
-impl Default for PmixResourceUnit { fn default()->Self{Self::new()} }
-impl Drop for PmixResourceUnit { fn drop(&mut self){if self.constructed {crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_destruct(self.raw.as_mut_ptr())},real=unsafe{ffi::PMIx_Resource_unit_destruct(self.raw.as_mut_ptr())});self.constructed=false;}} }
 
-pub struct PmixResourceUnitArray { ptr:*mut ffi::pmix_resource_unit_t, len:usize, _not_thread_safe:std::marker::PhantomData<*mut u8> }
-impl PmixResourceUnitArray { pub fn as_ptr(&self)->*const ffi::pmix_resource_unit_t{self.ptr} pub fn len(&self)->usize{self.len} pub fn is_empty(&self)->bool{self.len==0} }
-impl Drop for PmixResourceUnitArray { fn drop(&mut self){if !self.ptr.is_null(){crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_free(self.ptr,self.len)},real=unsafe{ffi::PMIx_Resource_unit_free(self.ptr,self.len)});self.ptr=ptr::null_mut();}} }
-pub fn resource_unit_create(n:usize)->Result<PmixResourceUnitArray,PmixError>{if n==0{return Ok(PmixResourceUnitArray{ptr:ptr::null_mut(),len:0,_not_thread_safe:std::marker::PhantomData})}let ptr=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_create(n)},real=unsafe{ffi::PMIx_Resource_unit_create(n)});if ptr.is_null(){Err(PmixError::ErrNomem)}else{Ok(PmixResourceUnitArray{ptr,len:n,_not_thread_safe:std::marker::PhantomData})}}
-impl PmixResourceUnit { pub fn to_string(&self)->Result<String,PmixError>{let p=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_resource_unit_string(self.as_ptr())},real=unsafe{ffi::PMIx_Resource_unit_string(self.as_ptr())});if p.is_null(){return Err(PmixError::ErrNomem)}let s=unsafe{CStr::from_ptr(p).to_string_lossy().into_owned()};unsafe{libc::free(p.cast())};Ok(s)} }
+impl PmixResourceUnit {
+    pub fn new() -> Self {
+        let mut this = Self { raw: MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData };
+        // SAFETY: PMIx initializes this owned, suitably aligned output object;
+        // Drop performs the matching destruct operation once.
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_resource_unit_construct(this.raw.as_mut_ptr()) },
+            real = unsafe { ffi::PMIx_Resource_unit_construct(this.raw.as_mut_ptr()) },
+        );
+        this.constructed = true;
+        this
+    }
+
+    #[cfg(test)]
+    pub fn test_new() -> Self {
+        Self { raw: MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData }
+    }
+
+    pub fn unit_type(&self) -> ffi::pmix_device_type_t {
+        // SAFETY: new/test_new initialize the complete C struct before access.
+        unsafe { self.raw.assume_init_ref().type_ }
+    }
+
+    pub fn count(&self) -> usize {
+        // SAFETY: new/test_new initialize the complete C struct before access.
+        unsafe { self.raw.assume_init_ref().count }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const ffi::pmix_resource_unit_t { self.raw.as_ptr() }
+}
+
+impl Default for PmixResourceUnit { fn default() -> Self { Self::new() } }
+
+impl Drop for PmixResourceUnit {
+    fn drop(&mut self) {
+        if self.constructed {
+            // SAFETY: constructed proves this is the one matching PMIx object.
+            crate::pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_resource_unit_destruct(self.raw.as_mut_ptr()) },
+                real = unsafe { ffi::PMIx_Resource_unit_destruct(self.raw.as_mut_ptr()) },
+            );
+            self.constructed = false;
+        }
+    }
+}
+
+pub struct PmixResourceUnitArray { ptr: *mut ffi::pmix_resource_unit_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+impl PmixResourceUnitArray {
+    pub fn as_ptr(&self) -> *const ffi::pmix_resource_unit_t { self.ptr }
+    pub fn len(&self) -> usize { self.len }
+    pub fn is_empty(&self) -> bool { self.len == 0 }
+}
+impl Drop for PmixResourceUnitArray {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: ptr/len are the exact PMIx allocation owned by this value.
+            crate::pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_resource_unit_free(self.ptr, self.len) },
+                real = unsafe { ffi::PMIx_Resource_unit_free(self.ptr, self.len) },
+            );
+            self.ptr = ptr::null_mut();
+        }
+    }
+}
+pub fn resource_unit_create(n: usize) -> Result<PmixResourceUnitArray, PmixError> {
+    if n == 0 { return Ok(PmixResourceUnitArray { ptr: ptr::null_mut(), len: 0, _not_thread_safe: std::marker::PhantomData }); }
+    // SAFETY: PMIx allocates n initialized resource units and transfers their
+    // ownership to the returned RAII array.
+    let ptr = crate::pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_resource_unit_create(n) },
+        real = unsafe { ffi::PMIx_Resource_unit_create(n) },
+    );
+    if ptr.is_null() { Err(PmixError::ErrNomem) } else { Ok(PmixResourceUnitArray { ptr, len: n, _not_thread_safe: std::marker::PhantomData }) }
+}
+impl PmixResourceUnit {
+    pub fn to_string(&self) -> Result<String, PmixError> {
+        // SAFETY: self points to a live constructed resource unit; PMIx returns
+        // a newly allocated NUL-terminated string owned by this function.
+        let p = crate::pmix_ffi_or_mock!(
+            mock = unsafe { mock_ffi::mock_resource_unit_string(self.as_ptr()) },
+            real = unsafe { ffi::PMIx_Resource_unit_string(self.as_ptr()) },
+        );
+        if p.is_null() { return Err(PmixError::ErrNomem); }
+        // SAFETY: PMIx returned a valid NUL-terminated string on success.
+        let s = unsafe { CStr::from_ptr(p).to_string_lossy().into_owned() };
+        // SAFETY: PMIx allocates this returned string with the C allocator.
+        unsafe { libc::free(p.cast()) };
+        Ok(s)
+    }
+}
+
+
+#[cfg(test)]
+mod misc_wrapper_tests {
+    use super::*;
+
+    #[test]
+    fn resource_unit_wrappers_construct_access_string_and_arrays() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let unit = PmixResourceUnit::new();
+        assert_eq!(unit.unit_type(), 0);
+        assert_eq!(unit.count(), 0);
+        assert_eq!(unit.to_string().unwrap(), "resource-unit");
+        let array = resource_unit_create(2).unwrap();
+        assert_eq!(array.len(), 2);
+        assert!(!array.is_empty());
+        let empty = resource_unit_create(0).unwrap();
+        assert!(empty.is_empty());
+        assert!(empty.as_ptr().is_null());
+    }
+}

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -2633,3 +2633,11 @@ pub fn group_operation_string(op: ffi::pmix_group_operation_t) -> &'static str {
     if p.is_null() { return ""; }
     unsafe { std::ffi::CStr::from_ptr(p).to_str().unwrap_or("") }
 }
+
+
+#[cfg(test)]
+#[test]
+fn test_misc_group_string_wrapper() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    assert_eq!(group_operation_string(crate::ffi::pmix_group_operation_t::PMIX_GROUP_CONSTRUCT), "unknown");
+}

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -2625,3 +2625,11 @@ mod tests {
     }
 }
 
+
+
+/// Return the static PMIx spelling for a group operation.
+pub fn group_operation_string(op: ffi::pmix_group_operation_t) -> &'static str {
+    let p = crate::pmix_ffi_or_mock!(mock = unsafe { crate::mock_ffi::mock_group_operation_string(op) }, real = unsafe { ffi::PMIx_Group_operation_string(op) });
+    if p.is_null() { return ""; }
+    unsafe { std::ffi::CStr::from_ptr(p).to_str().unwrap_or("") }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5995,3 +5995,12 @@ pub fn error_code(name: &str) -> Option<PmixError> {
     let raw = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_error_code(name.as_ptr()) }, real = unsafe { ffi::PMIx_Error_code(name.as_ptr()) });
     PmixError::from_raw(raw)
 }
+
+
+#[cfg(test)]
+#[test]
+fn test_misc_error_code_wrapper() {
+    let _guard = mock_ffi::MockGuard::new();
+    assert_eq!(error_code("PMIX_SUCCESS"), Some(PmixError::Success));
+    assert!(error_code("bad\0name").is_none());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5987,3 +5987,11 @@ pub fn multicluster_nspace_parse(target: &str) -> Result<(String, String), PmixE
     }
     Ok((cluster.to_string_lossy().into_owned(), nspace.to_string_lossy().into_owned()))
 }
+
+
+/// Look up a PMIx error by its symbolic name.
+pub fn error_code(name: &str) -> Option<PmixError> {
+    let name = CString::new(name).ok()?;
+    let raw = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_error_code(name.as_ptr()) }, real = unsafe { ffi::PMIx_Error_code(name.as_ptr()) });
+    PmixError::from_raw(raw)
+}

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3652,3 +3652,46 @@ pub unsafe fn mock_multicluster_nspace_parse(target: *mut libc::c_char, cluster:
         if let Some(pos) = text.iter().position(|&b| b == b':') { std::ptr::copy_nonoverlapping(text.as_ptr(), cluster.cast(), pos.min(255)); *cluster.add(pos.min(255)) = 0; let rest = &text[pos + 1..]; std::ptr::copy_nonoverlapping(rest.as_ptr(), nspace.cast(), rest.len().min(255)); *nspace.add(rest.len().min(255)) = 0; }
     }
 }
+
+
+// Miscellaneous PMIx utility mocks appended for the safe-wrapper tests.
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_error_code(_name: *const std::os::raw::c_char) -> i32 { 0 }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_group_operation_string(_op: crate::ffi::pmix_group_operation_t) -> *const std::os::raw::c_char { b"unknown\0".as_ptr().cast() }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_unit_construct(d: *mut crate::ffi::pmix_resource_unit_t) { if !d.is_null() { (*d).type_ = 0; (*d).count = 0; } }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_unit_destruct(_d: *mut crate::ffi::pmix_resource_unit_t) {}
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_unit_create(n: usize) -> *mut crate::ffi::pmix_resource_unit_t { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_resource_unit_t>()).cast() }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_unit_free(d: *mut crate::ffi::pmix_resource_unit_t, _n: usize) { libc::free(d.cast()); }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_unit_string(_d: *const crate::ffi::pmix_resource_unit_t) -> *mut std::os::raw::c_char { libc::strdup(b"resource-unit\0".as_ptr().cast()) }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_block_directive_string(_d: crate::ffi::pmix_resource_block_directive_t) -> *const std::os::raw::c_char { b"unknown\0".as_ptr().cast() }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_block(_d: crate::ffi::pmix_resource_block_directive_t, _b: *mut std::os::raw::c_char, _r: *const crate::ffi::pmix_resource_unit_t, _nr: usize, _i: *const crate::ffi::pmix_info_t, _ni: usize) -> i32 { 0 }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_resource_block_nb(_d: crate::ffi::pmix_resource_block_directive_t, _b: *mut std::os::raw::c_char, _r: *const crate::ffi::pmix_resource_unit_t, _nr: usize, _i: *const crate::ffi::pmix_info_t, _ni: usize, cb: crate::ffi::pmix_op_cbfunc_t, data: *mut std::os::raw::c_void) -> i32 { if let Some(cb) = cb { cb(0, data); } 0 }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_heartbeat() {}
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_construct(p: *mut crate::ffi::pmix_pdata_t) { if !p.is_null() { std::ptr::write_bytes(p, 0, 1); } }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_destruct(_p: *mut crate::ffi::pmix_pdata_t) {}
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_create(n: usize) -> *mut crate::ffi::pmix_pdata_t { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_pdata_t>()).cast() }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_free(p: *mut crate::ffi::pmix_pdata_t, _n: usize) { libc::free(p.cast()); }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_load(_d: *mut crate::ffi::pmix_pdata_t, _p: *const crate::ffi::pmix_proc_t, _k: *const std::os::raw::c_char, _v: *const std::os::raw::c_void, _t: crate::ffi::pmix_data_type_t) {}
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_pdata_xfer(_d: *mut crate::ffi::pmix_pdata_t, _s: *mut crate::ffi::pmix_pdata_t) {}
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_tool_set_server_module(_m: *mut crate::ffi::pmix_server_module_t) -> i32 { 0 }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_server_generate_cpuset(_s: *const std::os::raw::c_char, _c: *mut crate::ffi::pmix_cpuset_t) -> i32 { 0 }
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn mock_server_collect_job_info(_p: *mut crate::ffi::pmix_proc_t, _n: usize, _b: *mut crate::ffi::pmix_data_buffer_t) -> i32 { 0 }

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1004,3 +1004,11 @@ mod tests {
 
 
 pub fn heartbeat_raw() { crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_heartbeat()},real=unsafe{ffi::PMIx_Heartbeat()}); }
+
+
+#[cfg(test)]
+#[test]
+fn test_misc_heartbeat_wrapper() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    heartbeat_raw();
+}

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1001,3 +1001,6 @@ mod tests {
         }
     }
 }
+
+
+pub fn heartbeat_raw() { crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_heartbeat()},real=unsafe{ffi::PMIx_Heartbeat()}); }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2960,3 +2960,7 @@ pub fn server_generate_cpuset_string(
     Ok(cpuset_string)
 }
 
+
+
+pub fn server_generate_cpuset(cpuset_string:&str,cpuset:&mut crate::fabric::PmixCpuset)->Result<(),PmixStatus>{let s=CString::new(cpuset_string).map_err(|_|PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;let raw=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())},real=unsafe{ffi::PMIx_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())});if raw==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(raw))}}
+pub fn server_collect_job_info(procs:&[Proc],dbuf:&mut crate::data_serialization::PmixDataBuffer)->Result<(),PmixStatus>{let mut raw=procs.iter().map(|p|p.handle).collect::<Vec<_>>();let s=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())},real=unsafe{ffi::PMIx_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2964,3 +2964,17 @@ pub fn server_generate_cpuset_string(
 
 pub fn server_generate_cpuset(cpuset_string:&str,cpuset:&mut crate::fabric::PmixCpuset)->Result<(),PmixStatus>{let s=CString::new(cpuset_string).map_err(|_|PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;let raw=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())},real=unsafe{ffi::PMIx_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())});if raw==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(raw))}}
 pub fn server_collect_job_info(procs:&[Proc],dbuf:&mut crate::data_serialization::PmixDataBuffer)->Result<(),PmixStatus>{let mut raw=procs.iter().map(|p|p.handle).collect::<Vec<_>>();let s=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())},real=unsafe{ffi::PMIx_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
+
+#[cfg(test)]
+mod misc_wrapper_tests {
+    use super::*;
+    #[test]
+    fn server_cpuset_and_collect_job_info_wrappers() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let mut cpuset = crate::fabric::PmixCpuset::new();
+        assert!(server_generate_cpuset("mock:0", &mut cpuset).is_ok());
+        let proc = crate::Proc::new("test", 0).unwrap();
+        let mut buffer = crate::data_serialization::data_buffer_create().unwrap();
+        assert!(server_collect_job_info(&[proc], &mut buffer).is_ok());
+    }
+}

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1459,3 +1459,6 @@ mod tests {
         let _ = h.join().unwrap();
     }
 }
+
+
+pub fn tool_set_server_module(module:&crate::server::PmixServerModule)->Result<(),PmixStatus>{let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_tool_set_server_module(module.as_c_ptr().cast_mut())},real=unsafe{ffi::PMIx_tool_set_server_module(module.as_c_ptr().cast_mut())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1462,3 +1462,12 @@ mod tests {
 
 
 pub fn tool_set_server_module(module:&crate::server::PmixServerModule)->Result<(),PmixStatus>{let s=crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_tool_set_server_module(module.as_c_ptr().cast_mut())},real=unsafe{ffi::PMIx_tool_set_server_module(module.as_c_ptr().cast_mut())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
+
+
+#[cfg(test)]
+#[test]
+fn test_misc_tool_set_server_module_wrapper() {
+    let _guard = crate::mock_ffi::MockGuard::new();
+    let module = crate::server::PmixServerModule::default();
+    assert!(tool_set_server_module(&module).is_ok());
+}


### PR DESCRIPTION
Closes #199, Closes #201, Closes #207, Closes #213, Closes #216, Closes #219, Closes #220, Closes #229, Closes #233, Closes #247, Closes #250, Closes #260, Closes #268, Closes #273, Closes #295, Closes #313, Closes #318

## Summary
Add safe wrappers for the remaining gap functions across modules:
- Error/group string lookup helpers (lib.rs, groups.rs)
- Resource-unit construct/destruct/allocate/free/string (allocation.rs)
- Resource-block sync + non-blocking ops (monitoring.rs)
- Heartbeat raw API (fabric.rs)
- Pdata construct/load/xfer + arrays (data_ops/mod.rs)
- Tool set_server_module (tool.rs) and server cpuset/job-info (server/mod.rs)
All wrappers append-only; mock-based tests; daemon/DVM tests CI-only.