### PR TITLE
fix(data): reclaim pmix_value_t struct allocation in get_value/get_nb

### DIFF
--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -7,7 +7,7 @@
 // PMIx_Publish — publish data for later lookup
 // ─────────────────────────────────────────────────────────────────────────────
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 use std::ptr;
 use std::sync::{LazyLock, Mutex};
@@ -219,6 +219,8 @@ pub trait GetValueCallback: Send {
 type GetRegistry = std::collections::HashMap<usize, Box<dyn GetValueCallback>>;
 static GET_REGISTRY: LazyLock<Mutex<GetRegistry>> =
     LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static QUALIFIED_GETS: LazyLock<Mutex<std::collections::HashSet<usize>>> =
+    LazyLock::new(|| Mutex::new(std::collections::HashSet::new()));
 
 /// Monotonically increasing request ID counter.
 static GET_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
@@ -252,20 +254,37 @@ extern "C" fn get_value_callback_bridge(
         None => return, // Callback already consumed or never registered.
     };
 
+    let qualified = QUALIFIED_GETS
+        .lock()
+        .expect("mutex poisoned (data_ops.rs)")
+        .remove(&req_id);
+
     // Convert the status.
     let pmix_status = PmixStatus::from_raw(status);
 
-    // Extract the value on success.
+    // Extract the value on success. Qualified values borrow PMIx info memory.
     let value = if pmix_status.is_success() && !kv.is_null() {
-        // SAFETY: On success, PMIx returns a valid pmix_value_t that we
-        // take ownership of. We read it and then null the pointer so
-        // PMIx doesn't try to free it.
-        let val = unsafe { ptr::read(kv) };
-        // Clear the pointer so PMIx doesn't double-free.
-        unsafe { ptr::write(kv, std::mem::zeroed()) };
-        Some(PmixOwnedValue { inner: val, 
-            _not_thread_safe: std::marker::PhantomData,
-        })
+        if qualified {
+            // SAFETY: `kv` is valid during the callback; Value_xfer does not modify it.
+            let mut copied = unsafe { std::mem::zeroed() };
+            let copy_status = crate::pmix_ffi_or_mock!(
+                mock = unsafe { mock_ffi::mock_value_xfer(&mut copied, kv) },
+                real = unsafe { ffi::PMIx_Value_xfer(&mut copied, kv) },
+            );
+            (copy_status == ffi::PMIX_SUCCESS as i32).then_some(PmixOwnedValue {
+                inner: copied,
+                _not_thread_safe: std::marker::PhantomData,
+            })
+        } else {
+            // SAFETY: The ordinary callback path returns an allocated struct.
+            let val = unsafe { ptr::read(kv) };
+            // SAFETY: `kv` is the allocation returned by PMIx_Get_nb.
+            drop(unsafe { Box::from_raw(kv) });
+            Some(PmixOwnedValue {
+                inner: val,
+                _not_thread_safe: std::marker::PhantomData,
+            })
+        }
     } else {
         None
     };
@@ -342,6 +361,21 @@ pub fn get_nb(
         }
         None => (ptr::null(), 0),
     };
+
+    if let Some(info) = info {
+        if !info.handle.is_null() && info.len > 0 {
+            // SAFETY: `handle` points to the borrowed Info array.
+            let qualified = unsafe {
+                CStr::from_ptr((*info.handle).key.as_ptr()).to_bytes() == b"pmix.qual.val"
+            };
+            if qualified {
+                QUALIFIED_GETS
+                    .lock()
+                    .expect("mutex poisoned (data_ops.rs)")
+                    .insert(req_id);
+            }
+        }
+    }
 
     // Call the FFI function.
     let status = crate::pmix_ffi_or_mock!(

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -236,6 +236,8 @@ extern "C" fn get_value_callback_bridge(
     cbdata: *mut c_void,
 ) {
     if cbdata.is_null() {
+        // Unreachable in practice: encode_req_id always supplies non-null cbdata,
+        // and PMIx invokes the callback with that same opaque pointer.
         return;
     }
 

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -416,6 +416,12 @@ pub fn get_nb(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
+        // The completion callback never runs on this path, so drop both the
+        // callback registration and any qualified-value marker.
+        QUALIFIED_GETS
+            .lock()
+            .expect("mutex poisoned (data_ops.rs)")
+            .remove(&req_id);
         let mut registry = GET_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
         registry.remove(&req_id);
         Err(pmix_status)

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -265,6 +265,10 @@ extern "C" fn get_value_callback_bridge(
     // Extract the value on success. Qualified values borrow PMIx info memory.
     let value = if pmix_status.is_success() && !kv.is_null() {
         if qualified {
+            // The server round-trip route provides a fresh heap struct that
+            // OpenPMIx does not reclaim, so this xfer leaves that struct and
+            // its nested payloads leaked. We cannot reclaim it here: the
+            // local-GDS route provides a pointer into C-owned info memory.
             // SAFETY: `kv` is valid during the callback; Value_xfer does not modify it.
             let mut copied = unsafe { std::mem::zeroed() };
             let copy_status = crate::pmix_ffi_or_mock!(
@@ -364,10 +368,13 @@ pub fn get_nb(
 
     if let Some(info) = info {
         if !info.handle.is_null() && info.len > 0 {
-            // SAFETY: `handle` points to the borrowed Info array.
-            let qualified = unsafe {
-                CStr::from_ptr((*info.handle).key.as_ptr()).to_bytes() == b"pmix.qual.val"
-            };
+            // SAFETY: `handle` points to `len` entries in the borrowed Info
+            // array, which remains valid for the duration of this call.
+            let entries = unsafe { std::slice::from_raw_parts(info.handle, info.len) };
+            let qualified = entries.iter().any(|entry| {
+                // SAFETY: each entry's key is a NUL-terminated pmix_key_t.
+                unsafe { CStr::from_ptr(entry.key.as_ptr()).to_bytes() == b"pmix.qual.val" }
+            });
             if qualified {
                 QUALIFIED_GETS
                     .lock()

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2060,15 +2060,19 @@ use super::*;
             registry.insert(req_id, Box::new(TestGetCb));
         }
 
-        // Create a mock pmix_value_t for the callback
-        let mut mock_value: ffi::pmix_value_t = unsafe { std::mem::zeroed() };
+        // Create a heap-allocated mock pmix_value_t for the callback.
+        // SAFETY: pmix_value_t is a C representation and zero is a valid
+        // initialization state before setting the type field.
+        let mut mock_value = Box::new(unsafe { std::mem::zeroed::<ffi::pmix_value_t>() });
         mock_value.type_ = PMIX_STRING_U16;
 
         let cbdata = crate::cbdata::encode_req_id(req_id);
         unsafe {
+            // SAFETY: The bridge takes ownership of the heap-allocated value,
+            // mirroring the real PMIx_Get_nb callback contract.
             get_value_callback_bridge(
                 PMIX_SUCCESS,
-                &mut mock_value as *mut ffi::pmix_value_t,
+                Box::into_raw(mock_value),
                 cbdata,
             );
         }
@@ -2795,15 +2799,19 @@ use super::*;
             registry.insert(req_id, Box::new(StringValueCb));
         }
 
-        // Create a mock pmix_value_t with PMIX_STRING type
-        let mut mock_value: ffi::pmix_value_t = unsafe { std::mem::zeroed() };
+        // Create a heap-allocated mock pmix_value_t with PMIX_STRING type.
+        // SAFETY: pmix_value_t is a C representation and zero is a valid
+        // initialization state before setting the type field.
+        let mut mock_value = Box::new(unsafe { std::mem::zeroed::<ffi::pmix_value_t>() });
         mock_value.type_ = PMIX_STRING_U16;
 
         let cbdata = crate::cbdata::encode_req_id(req_id);
         unsafe {
+            // SAFETY: The bridge takes ownership of the heap-allocated value,
+            // mirroring the real PMIx_Get_nb callback contract.
             get_value_callback_bridge(
                 PMIX_SUCCESS,
-                &mut mock_value as *mut ffi::pmix_value_t,
+                Box::into_raw(mock_value),
                 cbdata,
             );
         }

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2119,6 +2119,68 @@ use super::*;
         get_value_callback_bridge(PMIX_SUCCESS, std::ptr::null_mut(), std::ptr::null_mut());
     }
 
+    /// An immediate PMIx_Get_nb failure must reclaim the qualified marker.
+    #[test]
+    fn test_get_nb_failure_removes_qualified_marker() {
+        struct DummyGet;
+        impl GetValueCallback for DummyGet {
+            fn on_result(self: Box<Self>, _status: PmixStatus, _value: Option<PmixOwnedValue>) {}
+        }
+
+        let config = MockConfig::new().with_function_status("PMIx_Get_nb", PMIX_ERR_INIT);
+        let _guard = MockGuard::with_config(config);
+        let proc = Proc::new("mock.ns", 0).unwrap();
+        let mut builder = InfoBuilder::new();
+        builder.add_string_key("pmix.qual.val", "true", PMIX_STRING as _);
+        let info = builder.build();
+
+        let result = get_nb(&proc, "qualified.key", Some(&info), Box::new(DummyGet));
+
+        assert_eq!(result, Err(PmixStatus::Known(PmixError::ErrInit)));
+        assert!(QUALIFIED_GETS.lock().unwrap().is_empty());
+        assert!(GET_REGISTRY.lock().unwrap().is_empty());
+    }
+
+    /// A successful qualified callback uses mock value transfer and clears its marker.
+    #[test]
+    fn test_get_nb_qualified_success_uses_value_xfer() {
+        use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+        static CB_STATUS: AtomicI32 = AtomicI32::new(-999);
+        static CB_HAS_VALUE: AtomicBool = AtomicBool::new(false);
+
+        struct QualifiedGet;
+        impl GetValueCallback for QualifiedGet {
+            fn on_result(self: Box<Self>, status: PmixStatus, value: Option<PmixOwnedValue>) {
+                CB_STATUS.store(status.to_raw(), Ordering::SeqCst);
+                CB_HAS_VALUE.store(value.is_some(), Ordering::SeqCst);
+            }
+        }
+
+        let _guard = MockGuard::new();
+        let req_id = {
+            let mut seq = GET_SEQ.lock().unwrap();
+            *seq += 1;
+            *seq
+        };
+        GET_REGISTRY
+            .lock()
+            .unwrap()
+            .insert(req_id, Box::new(QualifiedGet));
+        QUALIFIED_GETS.lock().unwrap().insert(req_id);
+
+        let mut mock_value = Box::new(unsafe { std::mem::zeroed::<ffi::pmix_value_t>() });
+        mock_value.type_ = PMIX_STRING_U16;
+        get_value_callback_bridge(
+            PMIX_SUCCESS,
+            Box::into_raw(mock_value),
+            crate::cbdata::encode_req_id(req_id),
+        );
+
+        assert_eq!(CB_STATUS.load(Ordering::SeqCst), PMIX_SUCCESS);
+        assert!(CB_HAS_VALUE.load(Ordering::SeqCst));
+        assert!(!QUALIFIED_GETS.lock().unwrap().contains(&req_id));
+    }
+
     // ─── Mock-aware lookup_nb callback tests ────────────────────────────────
 
     /// Test lookup_nb callback bridge with success status.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2894,9 +2894,9 @@ fn write_payload(dst: &mut pmix_value, payload: PmixPayload) {
 /// After this call `v` is zeroed and safe to drop or reuse.
 ///
 /// # Safety
-/// `v` must have been produced by this crate's builder (or have equivalent
-/// allocation discipline).  Calling this on a `pmix_value_t` produced by the C
-/// library (and therefore managed by `PMIX_VALUE_RELEASE`) is a double-free.
+/// `v` must have been produced by this crate's builder, or be a Rust-owned copy
+/// whose nested payloads follow the same allocation discipline. It must not be
+/// a value still owned by PMIx or a borrowed copy of a C-owned info array.
 pub fn free_value(v: &mut pmix_value_t) {
     // SAFETY: type_ was set by write_payload; we access only the matching arm.
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3864,10 +3864,16 @@ pub fn get_value(proc: &Proc, key: &[u8], info: Option<Info>) -> Result<PmixOwne
         },
     ));
 
-    if status.is_success() {
+    if status.is_success() && !value.is_null() {
+        // SAFETY: PMIx returned a valid heap-allocated value on success. The
+        // copy owns nested payloads; reclaiming the Box reclaims only the
+        // C-allocated struct.
+        let owned = unsafe { *value };
+        // SAFETY: `value` is the allocation returned by PMIx_Get and is
+        // reclaimed exactly once after copying its contents.
+        drop(unsafe { Box::from_raw(value) });
         Ok(PmixOwnedValue {
-            inner: unsafe { *value },
-        
+            inner: owned,
             _not_thread_safe: std::marker::PhantomData,
         })
     } else {

--- a/src/value.rs
+++ b/src/value.rs
@@ -570,9 +570,9 @@ fn write_payload(dst: &mut pmix_value, payload: PmixPayload) {
 /// After this call `v` is zeroed and safe to drop or reuse.
 ///
 /// # Safety
-/// `v` must have been produced by this crate's builder (or have equivalent
-/// allocation discipline).  Calling this on a `pmix_value_t` produced by the C
-/// library (and therefore managed by `PMIX_VALUE_RELEASE`) is a double-free.
+/// `v` must have been produced by this crate's builder, or be a Rust-owned copy
+/// whose nested payloads follow the same allocation discipline. It must not be
+/// a value still owned by PMIx or a borrowed copy of a C-owned info array.
 pub fn free_value(v: &mut pmix_value_t) {
     // SAFETY: type_ was set by write_payload; we access only the matching arm.
     unsafe {


### PR DESCRIPTION
Closes #389

## Summary
- Reclaims the heap-allocated pmix_value_t struct returned by blocking PMIx_Get after copying its payload pointers into the Rust RAII value.
- Reclaims the plain PMIx_Get_nb struct allocation without writing zeroed data into C-owned memory.
- Detects PMIX_QUALIFIED_VALUE directives and deep-copies through PMIx_Value_xfer, leaving the C-owned info array untouched.

The installed OpenPMIx 6.1.0 headers confirm PMIX_QUALIFIED_VALUE is the `pmix.qual.val` directive. The installed headers expose the pmix_cb_t type and callback API, but the distribution does not include OpenPMIx client source/cbdes implementation; the destructor claim was therefore not independently verified from installed source.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build`
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib data_ops::tests::test_get_value_callback_bridge_invokes_callback`
- Full daemon-free mock tests are constrained by pre-existing test compilation issues in the repository.
- `cargo clippy --all-targets -- -D warnings` remains blocked by pre-existing warnings/errors in mock/test sources.
- `cargo fmt --check` reports pre-existing formatting differences.
