### PR TITLE
perf(threading): back spawn_from_callback with a bounded worker pool

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -74,7 +74,9 @@ Rules (same deadlock class as client `_nb` / events — issue #51 helpers):
    uses a process-wide bounded worker pool (available parallelism workers and
    four queue slots per worker); a full queue falls back to a detached,
    dedicated `pmix-callback-hop` thread so callback work is never dropped or
-   blocked. Pool workers are detached and require no finalize-time shutdown.
+   blocked. If pool initialization cannot create its workers, the call uses
+   the direct-thread path and a later call retries pool initialization. Pool
+   workers are detached and require no finalize-time shutdown.
 3. Invoke the provided `cbfunc` **later** when RM / network work finishes.
 4. Copy C buffers before hopping; do not join hop work in-handler.
 

--- a/THREADING.md
+++ b/THREADING.md
@@ -70,7 +70,11 @@ progress engine (table above), not which core runs a given upcall body.
 Rules (same deadlock class as client `_nb` / events — issue #51 helpers):
 
 1. Return quickly; never call blocking PMIx from the upcall.
-2. Hop with `threading::spawn_from_callback` or `CallbackChannel`.
+2. Hop with `threading::spawn_from_callback` or `CallbackChannel`. The former
+   uses a process-wide bounded worker pool (available parallelism workers and
+   four queue slots per worker); a full queue falls back to a detached,
+   dedicated `pmix-callback-hop` thread so callback work is never dropped or
+   blocked. Pool workers are detached and require no finalize-time shutdown.
 3. Invoke the provided `cbfunc` **later** when RM / network work finishes.
 4. Copy C buffers before hopping; do not join hop work in-handler.
 
@@ -165,7 +169,8 @@ channel.
 2. Build `Info` and other C-owned handles on the calling thread.  
 3. Callbacks **and server module upcalls** = progress context — hop before
    blocking PMIx. Use `threading::spawn_from_callback` (fire-and-forget
-   thread) or `threading::CallbackChannel` (app-thread receiver) — see
+   worker pool, with a dedicated-thread fallback) or
+   `threading::CallbackChannel` (app-thread receiver) — see
    `examples/callback_hop.rs` (client `_nb` / events) and
    `examples/server_upcall_hop.rs` (fence_nb / direct_modex + delayed
    `cbfunc`). Never join/wait in-handler; convert C-owned (`!Send`) values

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -41,8 +41,8 @@
 //! The two primitives cover the two ways a handler can get work off the
 //! progress thread:
 //!
-//! * [`spawn_from_callback`] — fire-and-forget: start a fresh application
-//!   thread for blocking work and return immediately.
+//! * [`spawn_from_callback`] — fire-and-forget: queue blocking work on the
+//!   shared callback worker pool and return immediately.
 //! * [`CallbackChannel`] — request/response: the application thread owns the
 //!   channel (receiver side) and processes messages the handler sends.
 //!
@@ -57,7 +57,7 @@
 //! // Inside a PMIx callback (progress thread):
 //! let _ctx = ProgressContext;                 // documents: we are on progress
 //! let _ = tx.send((0, b"payload".to_vec()));  // cheap, non-blocking
-//! let _ = spawn_from_callback(move || {       // or: fresh thread for blocking work
+//! let _ = spawn_from_callback(move || {       // or: pooled thread for blocking work
 //!     // blocking PMIx calls are legal here
 //! });
 //!
@@ -75,7 +75,9 @@
 //! `examples/server_upcall_hop.rs` (server module fence/modex upcalls +
 //! delayed `cbfunc`), plus [THREADING.md](../THREADING.md).
 
+use std::any::Any;
 use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, Sender, TryRecvError};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Zero-sized marker for code that runs on the PMIx **progress thread**.
 ///
@@ -122,8 +124,10 @@ pub struct ProgressContext;
 ///
 /// The callback runs on the PMIx progress thread; any work that could block
 /// (including blocking PMIx calls) must be moved to an application thread.
-/// This helper spawns a fresh, named thread to run `f` and returns a
-/// [`JoinHandle`](std::thread::JoinHandle) the caller may store or detach.
+/// This helper queues `f` on a process-wide, bounded pool of named worker
+/// threads and returns a [`CallbackJoinHandle`] the caller may store or
+/// detach. If the queue is full, it falls back to a fresh named thread rather
+/// than blocking the PMIx progress thread or dropping work.
 ///
 /// # Rules
 ///
@@ -140,8 +144,7 @@ pub struct ProgressContext;
 ///   (the default panic hook does not call `exit()` for non-main threads).
 ///   Under `panic = "abort"` the process aborts regardless of this helper.
 ///   This helper logs a branded diagnostic on stderr for fire-and-forget
-///   callers, then resumes unwinding so a joined handle still reports
-///   [`JoinHandle::join`](std::thread::JoinHandle::join) `Err`. Prefer not
+///   callers; a joined [`CallbackJoinHandle`] still reports `Err`. Prefer not
 ///   panicking in hop work in long-running HPC jobs — treat panics as bugs.
 ///
 /// # Example
@@ -154,26 +157,134 @@ pub struct ProgressContext;
 ///     std::thread::sleep(std::time::Duration::from_millis(10));
 /// });
 /// ```
-pub fn spawn_from_callback<F>(f: F) -> std::io::Result<std::thread::JoinHandle<()>>
+pub fn spawn_from_callback<F>(f: F) -> std::io::Result<CallbackJoinHandle>
 where
     F: FnOnce() + Send + 'static,
 {
-    std::thread::Builder::new()
-        .name("pmix-callback-hop".to_string())
-        .spawn(move || {
-            // Log a clear diagnostic for operators (fire-and-forget callers
-            // never join), then resume so `JoinHandle::join` still surfaces
-            // the payload instead of a silent `Ok(())`. This is not true
-            // isolation under `panic = "abort"`, and resume_unwind still
-            // panics the hop thread (by design, for joiners).
-            if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-                eprintln!(
-                    "pmix: thread 'pmix-callback-hop' panicked while running \
-                     work hopped off the PMIx progress thread"
-                );
-                std::panic::resume_unwind(payload);
-            }
+    let pool = match CALLBACK_POOL.get_or_init(CallbackPool::new) {
+        Ok(pool) => pool,
+        Err(error) => return Err(std::io::Error::new(error.kind(), error.to_string())),
+    };
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let task = CallbackTask {
+        work: Box::new(f),
+        completion: completion_tx.clone(),
+    };
+
+    match pool.queue.try_send(task) {
+        Ok(()) => Ok(CallbackJoinHandle {
+            completion: completion_rx,
+            direct: None,
+        }),
+        Err(mpsc::TrySendError::Full(task)) | Err(mpsc::TrySendError::Disconnected(task)) => {
+            let direct = std::thread::Builder::new()
+                .name("pmix-callback-hop".to_string())
+                .spawn(move || {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task.work));
+                    if let Err(payload) = result {
+                        eprintln!(
+                            "pmix: thread 'pmix-callback-hop' panicked while running \
+                             work hopped off the PMIx progress thread"
+                        );
+                        std::panic::resume_unwind(payload);
+                    }
+                    let _ = task.completion.send(Ok(()));
+                })?;
+            Ok(CallbackJoinHandle {
+                completion: completion_rx,
+                direct: Some(direct),
+            })
+        }
+    }
+}
+
+const CALLBACK_QUEUE_CAPACITY_MULTIPLIER: usize = 4;
+
+type CallbackResult = Result<(), Box<dyn Any + Send + 'static>>;
+type CallbackWork = Box<dyn FnOnce() + Send + 'static>;
+
+struct CallbackTask {
+    work: CallbackWork,
+    completion: Sender<CallbackResult>,
+}
+
+struct CallbackPool {
+    queue: mpsc::SyncSender<CallbackTask>,
+}
+
+static CALLBACK_POOL: OnceLock<Result<CallbackPool, std::io::Error>> = OnceLock::new();
+
+impl CallbackPool {
+    fn new() -> std::io::Result<Self> {
+        let workers = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(4)
+            .max(1);
+        let capacity = workers
+            .saturating_mul(CALLBACK_QUEUE_CAPACITY_MULTIPLIER)
+            .max(1);
+        let (queue, receiver) = mpsc::sync_channel(capacity);
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        for _ in 0..workers {
+            let receiver = Arc::clone(&receiver);
+            std::thread::Builder::new()
+                .name("pmix-callback-hop".to_string())
+                .spawn(move || {
+                    loop {
+                        let task = {
+                            let receiver = receiver
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            receiver.recv()
+                        };
+                        match task {
+                            Ok(task) => run_callback_task(task),
+                            Err(_) => break,
+                        }
+                    }
+                })?;
+        }
+        Ok(Self { queue })
+    }
+}
+
+fn run_callback_task(task: CallbackTask) {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task.work));
+    if let Err(payload) = result {
+        eprintln!(
+            "pmix: thread 'pmix-callback-hop' panicked while running \
+             work hopped off the PMIx progress thread"
+        );
+        let _ = task.completion.send(Err(payload));
+    } else {
+        let _ = task.completion.send(Ok(()));
+    }
+}
+
+/// A completion handle for work submitted by [`spawn_from_callback`].
+///
+/// `join` waits for either a pooled task's completion or its direct-thread
+/// fallback. A panic is returned as `Err`, just like
+/// [`std::thread::JoinHandle::join`]. Dropping this handle detaches the work.
+pub struct CallbackJoinHandle {
+    completion: Receiver<CallbackResult>,
+    direct: Option<std::thread::JoinHandle<()>>,
+}
+
+impl CallbackJoinHandle {
+    /// Wait for the hopped work and return its panic payload, if any.
+    pub fn join(self) -> CallbackResult {
+        if let Some(direct) = self.direct {
+            direct.join()?;
+        }
+        self.completion.recv().unwrap_or_else(|_| {
+            Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "callback worker stopped before reporting completion",
+            )))
         })
+    }
 }
 
 /// Invoke a user callback from an `extern "C"` bridge **without** letting a
@@ -318,10 +429,7 @@ mod tests {
         let spawned = rx
             .recv_timeout(Duration::from_secs(5))
             .expect("callback ran");
-        assert_ne!(
-            caller, spawned,
-            "closure must run on a fresh application thread"
-        );
+        assert_ne!(caller, spawned, "closure must run off the caller thread");
         handle.join().expect("join");
     }
 
@@ -329,7 +437,7 @@ mod tests {
     fn spawn_from_callback_failure_returns_error() {
         // Spawning with an exhausted OS limit is not reliably triggerable in
         // tests; verify only that the signature reports io::Result.
-        let _: std::io::Result<std::thread::JoinHandle<()>> = spawn_from_callback(|| {});
+        let _: std::io::Result<CallbackJoinHandle> = spawn_from_callback(|| {});
     }
 
     #[test]
@@ -450,5 +558,31 @@ mod tests {
             std::thread::yield_now();
         }
         assert_eq!(blocking_done.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn spawn_from_callback_full_queue_falls_back_without_dropping_work() {
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..100 {
+            let release_rx = Arc::clone(&release_rx);
+            let completed = Arc::clone(&completed);
+            handles.push(
+                spawn_from_callback(move || {
+                    let _ = release_rx.lock().unwrap().recv();
+                    completed.fetch_add(1, Ordering::SeqCst);
+                })
+                .expect("submit backpressure task"),
+            );
+        }
+        for _ in 0..100 {
+            release_tx.send(()).expect("release task");
+        }
+        for handle in handles {
+            handle.join().expect("backpressure task");
+        }
+        assert_eq!(completed.load(Ordering::SeqCst), 100);
     }
 }

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -126,8 +126,10 @@ pub struct ProgressContext;
 /// (including blocking PMIx calls) must be moved to an application thread.
 /// This helper queues `f` on a process-wide, bounded pool of named worker
 /// threads and returns a [`CallbackJoinHandle`] the caller may store or
-/// detach. If the queue is full, it falls back to a fresh named thread rather
-/// than blocking the PMIx progress thread or dropping work.
+/// detach. If the queue is full, it falls back to a fresh named thread
+/// rather than blocking the PMIx progress thread or dropping work. If pool
+/// initialization cannot create its workers, this call falls back to the
+/// direct-thread path; a later call retries pool initialization.
 ///
 /// # Rules
 ///
@@ -161,46 +163,40 @@ pub fn spawn_from_callback<F>(f: F) -> std::io::Result<CallbackJoinHandle>
 where
     F: FnOnce() + Send + 'static,
 {
-    let pool = match CALLBACK_POOL.get_or_init(CallbackPool::new) {
-        Ok(pool) => pool,
-        Err(error) => return Err(std::io::Error::new(error.kind(), error.to_string())),
-    };
     let (completion_tx, completion_rx) = mpsc::channel();
     let task = CallbackTask {
         work: Box::new(f),
-        completion: completion_tx.clone(),
+        completion: completion_tx,
     };
-
-    match pool.queue.try_send(task) {
-        Ok(()) => Ok(CallbackJoinHandle {
-            completion: completion_rx,
-            direct: None,
-        }),
-        Err(mpsc::TrySendError::Full(task)) | Err(mpsc::TrySendError::Disconnected(task)) => {
-            let direct = std::thread::Builder::new()
-                .name("pmix-callback-hop".to_string())
-                .spawn(move || {
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task.work));
-                    if let Err(payload) = result {
-                        eprintln!(
-                            "pmix: thread 'pmix-callback-hop' panicked while running \
-                             work hopped off the PMIx progress thread"
-                        );
-                        std::panic::resume_unwind(payload);
-                    }
-                    let _ = task.completion.send(Ok(()));
-                })?;
-            Ok(CallbackJoinHandle {
-                completion: completion_rx,
-                direct: Some(direct),
-            })
+    let mut pool_guard = CALLBACK_POOL
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if pool_guard.is_none() {
+        if let Ok(new_pool) = CallbackPool::new() {
+            *pool_guard = Some(Arc::new(new_pool));
         }
+    }
+    let pool = pool_guard.as_ref().map(Arc::clone);
+    drop(pool_guard);
+
+    match pool {
+        Some(pool) => match pool.queue.try_send(task) {
+            Ok(()) => Ok(CallbackJoinHandle {
+                completion: completion_rx,
+                direct: None,
+            }),
+            Err(mpsc::TrySendError::Full(task)) | Err(mpsc::TrySendError::Disconnected(task)) => {
+                spawn_direct(task, completion_rx)
+            }
+        },
+        None => spawn_direct(task, completion_rx),
     }
 }
 
 const CALLBACK_QUEUE_CAPACITY_MULTIPLIER: usize = 4;
 
-type CallbackResult = Result<(), Box<dyn Any + Send + 'static>>;
+pub type CallbackResult = Result<(), Box<dyn Any + Send + 'static>>;
 type CallbackWork = Box<dyn FnOnce() + Send + 'static>;
 
 struct CallbackTask {
@@ -212,7 +208,31 @@ struct CallbackPool {
     queue: mpsc::SyncSender<CallbackTask>,
 }
 
-static CALLBACK_POOL: OnceLock<Result<CallbackPool, std::io::Error>> = OnceLock::new();
+static CALLBACK_POOL: OnceLock<Mutex<Option<Arc<CallbackPool>>>> = OnceLock::new();
+
+fn spawn_direct(
+    task: CallbackTask,
+    completion: Receiver<CallbackResult>,
+) -> std::io::Result<CallbackJoinHandle> {
+    let direct = std::thread::Builder::new()
+        .name("pmix-callback-hop".to_string())
+        .spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task.work));
+            if let Err(payload) = result {
+                eprintln!(
+                    "pmix: thread 'pmix-callback-hop' panicked while running \
+                     work hopped off the PMIx progress thread"
+                );
+                let _ = task.completion.send(Err(payload));
+                return;
+            }
+            let _ = task.completion.send(Ok(()));
+        })?;
+    Ok(CallbackJoinHandle {
+        completion,
+        direct: Some(direct),
+    })
+}
 
 impl CallbackPool {
     fn new() -> std::io::Result<Self> {
@@ -230,18 +250,16 @@ impl CallbackPool {
             let receiver = Arc::clone(&receiver);
             std::thread::Builder::new()
                 .name("pmix-callback-hop".to_string())
-                .spawn(move || {
-                    loop {
-                        let task = {
-                            let receiver = receiver
-                                .lock()
-                                .unwrap_or_else(|poisoned| poisoned.into_inner());
-                            receiver.recv()
-                        };
-                        match task {
-                            Ok(task) => run_callback_task(task),
-                            Err(_) => break,
-                        }
+                .spawn(move || loop {
+                    let task = {
+                        let receiver = receiver
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        receiver.recv()
+                    };
+                    match task {
+                        Ok(task) => run_callback_task(task),
+                        Err(_) => break,
                     }
                 })?;
         }
@@ -580,9 +598,13 @@ mod tests {
         for _ in 0..100 {
             release_tx.send(()).expect("release task");
         }
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while completed.load(Ordering::SeqCst) < 100 && std::time::Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(completed.load(Ordering::SeqCst), 100);
         for handle in handles {
             handle.join().expect("backpressure task");
         }
-        assert_eq!(completed.load(Ordering::SeqCst), 100);
     }
 }


### PR DESCRIPTION
Closes #388

## Summary
- Replaces per-callback thread creation with a process-global detached worker pool.
- Uses one worker per available parallelism (falling back to four) and a bounded queue with four slots per worker.
- Uses non-blocking enqueue; a full or disconnected queue falls back to a dedicated `pmix-callback-hop` thread so work is never dropped and the PMIx progress thread never waits.
- Pool workers are detached and need no finalize-time shutdown.

## API changes
- `spawn_from_callback` now returns `CallbackJoinHandle` instead of `std::thread::JoinHandle<()>`.
- `CallbackJoinHandle::join` preserves completion waiting and panic reporting for pooled and fallback work.
- All in-repository callers already use the returned value as fire-and-forget; no caller changes were required.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` (pass)
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test` (pass; daemon tests remain ignored without PRTE/DVM)
- Targeted burst, fallback, and panic-containment tests (pass)
- `cargo fmt --check` (pass before final targeted test; later full-suite build formatting exposed pre-existing unrelated formatting drift)
- `cargo clippy --all-targets -- -D warnings` (fails on pre-existing repository warnings/errors outside this change; changed code had only a fixable `question_mark` lint, fixed before publication)
