### PR TITLE
perf: fold _nb SEQ/REGISTRY pairs into atomic-backed Registry structs

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -55,7 +55,7 @@ use std::sync::LazyLock;
 
 use crate::ffi;
 use crate::threading::invoke_user_callback;
-use crate::cbdata::{decode_req_id, encode_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::{Info, PmixStatus, Proc};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -290,15 +290,11 @@ pub trait AllocationCallback: Send + 'static {
     fn on_complete(&self, status: PmixStatus, results: AllocationResults);
 }
 
-/// Monotonically increasing allocation request ID counter.
-static ALLOCATION_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// Global registry of pending allocation callbacks.
 ///
 /// Maps request ID -> callback. Entries are removed when the callback fires.
-static ALLOCATION_REGISTRY: LazyLock<
-    Mutex<std::collections::HashMap<usize, Box<dyn AllocationCallback>>>,
-> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static ALLOCATION_REGISTRY: LazyLock<Registry<Box<dyn AllocationCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_info_cbfunc_t` (allocation completion).
 ///
@@ -322,7 +318,7 @@ extern "C" fn allocation_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = ALLOCATION_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+        let mut registry = ALLOCATION_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -383,20 +379,13 @@ pub fn allocation_request_nb(
     callback: Box<dyn AllocationCallback>,
 ) -> Result<(), PmixStatus> {
     // Assign a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = ALLOCATION_SEQ.lock().expect("mutex poisoned (allocation.rs)");
-        *seq += 1;
-        *seq
-    };
+    let req_id = ALLOCATION_REGISTRY.next_req_id();
 
     // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
     // is never null (req_id starts at 1).
     let cbdata = encode_req_id(req_id);
 
-    {
-        let mut registry = ALLOCATION_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
-        registry.insert(req_id, callback);
-    }
+    ALLOCATION_REGISTRY.lock().insert(req_id, callback);
 
     // Convert the Info slice to C pointers.
     let info_ptr = if info.is_empty() {
@@ -432,7 +421,7 @@ pub fn allocation_request_nb(
         Ok(())
     } else {
         // Request was rejected — remove the callback so it doesn't leak.
-        let mut registry = ALLOCATION_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+        let mut registry = ALLOCATION_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -666,15 +655,11 @@ pub trait JobControlCallback: Send + 'static {
     fn on_complete(&self, status: PmixStatus, results: JobControlResults);
 }
 
-/// Monotonically increasing job control request ID counter.
-static JOB_CTRL_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// Global registry of pending job control callbacks.
 ///
 /// Maps request ID -> callback. Entries are removed when the callback fires.
-static JOB_CTRL_REGISTRY: LazyLock<
-    Mutex<std::collections::HashMap<usize, Box<dyn JobControlCallback>>>,
-> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static JOB_CTRL_REGISTRY: LazyLock<Registry<Box<dyn JobControlCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_info_cbfunc_t` (job control completion).
 ///
@@ -698,7 +683,7 @@ extern "C" fn job_control_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = JOB_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+        let mut registry = JOB_CTRL_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -759,20 +744,13 @@ pub fn job_control_nb(
     callback: Box<dyn JobControlCallback>,
 ) -> Result<(), PmixStatus> {
     // Assign a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = JOB_CTRL_SEQ.lock().expect("mutex poisoned (allocation.rs)");
-        *seq += 1;
-        *seq
-    };
+    let req_id = JOB_CTRL_REGISTRY.next_req_id();
 
     // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
     // is never null (req_id starts at 1).
     let cbdata = encode_req_id(req_id);
 
-    {
-        let mut registry = JOB_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
-        registry.insert(req_id, callback);
-    }
+    JOB_CTRL_REGISTRY.lock().insert(req_id, callback);
 
     // Convert targets slice to C pointer.
     let targets_ptr = if targets.is_empty() {
@@ -821,7 +799,7 @@ pub fn job_control_nb(
         Ok(())
     } else {
         // Request was rejected — remove the callback so it doesn't leak.
-        let mut registry = JOB_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+        let mut registry = JOB_CTRL_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -872,11 +850,7 @@ pub trait SessionControlCallback: Send + 'static {
     fn on_complete(&self, status: PmixStatus, results: SessionControlResults);
 }
 
-static SESSION_CTRL_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-
-static SESSION_CTRL_REGISTRY: LazyLock<
-    Mutex<std::collections::HashMap<usize, Box<dyn SessionControlCallback>>>,
-> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static SESSION_CTRL_REGISTRY: LazyLock<Registry<Box<dyn SessionControlCallback>>> = LazyLock::new(Registry::new);
 
 extern "C" fn session_control_callback_bridge(
     status: ffi::pmix_status_t,
@@ -893,7 +867,7 @@ extern "C" fn session_control_callback_bridge(
     let req_id = decode_req_id(cbdata);
 
     let cb = {
-        let mut registry = SESSION_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+        let mut registry = SESSION_CTRL_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -959,17 +933,10 @@ pub fn session_control(
     match callback {
         Some(cb) => {
             // Non-blocking mode
-            let req_id = {
-                let mut seq = SESSION_CTRL_SEQ.lock().expect("mutex poisoned (allocation.rs)");
-                *seq += 1;
-                *seq
-            };
+            let req_id = SESSION_CTRL_REGISTRY.next_req_id();
             let cbdata = encode_req_id(req_id);
 
-            {
-                let mut registry = SESSION_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
-                registry.insert(req_id, cb);
-            }
+            SESSION_CTRL_REGISTRY.lock().insert(req_id, cb);
 
             let status = unsafe {
                 ffi::PMIx_Session_control(
@@ -985,7 +952,7 @@ pub fn session_control(
             if pmix_status.is_success() {
                 Ok(None)
             } else {
-                let mut registry = SESSION_CTRL_REGISTRY.lock().expect("mutex poisoned (allocation.rs)");
+                let mut registry = SESSION_CTRL_REGISTRY.lock();
                 registry.remove(&req_id);
                 Err(pmix_status)
             }

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -381,8 +381,8 @@ pub fn allocation_request_nb(
     // Assign a unique request ID and register the callback.
     let req_id = ALLOCATION_REGISTRY.next_req_id();
 
-    // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
-    // is never null (req_id starts at 1).
+    // SAFETY: encode_req_id casts the request ID directly; Registry never
+    // returns 0, so cbdata is never null.
     let cbdata = encode_req_id(req_id);
 
     ALLOCATION_REGISTRY.lock().insert(req_id, callback);
@@ -746,8 +746,8 @@ pub fn job_control_nb(
     // Assign a unique request ID and register the callback.
     let req_id = JOB_CTRL_REGISTRY.next_req_id();
 
-    // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
-    // is never null (req_id starts at 1).
+    // SAFETY: encode_req_id casts the request ID directly; Registry never
+    // returns 0, so cbdata is never null.
     let cbdata = encode_req_id(req_id);
 
     JOB_CTRL_REGISTRY.lock().insert(req_id, callback);

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::os::raw::c_void;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 /// Encode a non-zero request ID as opaque cbdata for a PMIx C callback.
@@ -37,7 +37,7 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
 
 /// Process-global callback registry with a lock-free request-ID sequence.
 ///
-/// The sequence counter is an `AtomicU64`, so allocating a request ID never
+/// The sequence counter is an `AtomicUsize`, so allocating a request ID never
 /// takes the callback-map lock; concurrent ops therefore never serialize on
 /// the counter. An op pays ONE map lock acquisition instead of the previous
 /// SEQ lock + map lock pair.
@@ -45,7 +45,7 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
 /// Request IDs start at 1 and saturate rather than wrap, so they can never
 /// become 0 (which would encode as a null cbdata pointer).
 pub struct Registry<T> {
-    seq: AtomicU64,
+    seq: AtomicUsize,
     map: Mutex<HashMap<usize, T>>,
 }
 
@@ -59,7 +59,7 @@ impl<T> Registry<T> {
     /// Create an empty registry with the sequence starting at zero.
     pub fn new() -> Self {
         Self {
-            seq: AtomicU64::new(0),
+            seq: AtomicUsize::new(0),
             map: Mutex::new(HashMap::new()),
         }
     }
@@ -75,7 +75,7 @@ impl<T> Registry<T> {
                 .compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
-                return next as usize;
+                return next;
             }
         }
     }

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -10,8 +10,10 @@
 //! 2. Use [`std::ptr::with_exposed_provenance_mut`] / [`pointer::addr`] so the
 //!    conversion is explicit and portable.
 
+use std::collections::HashMap;
 use std::os::raw::c_void;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
 
 /// Encode a non-zero request ID as opaque cbdata for a PMIx C callback.
 ///
@@ -59,6 +61,72 @@ pub fn next_req_id(seq: &Mutex<usize>) -> usize {
     *g
 }
 
+/// Process-global callback registry with a lock-free request-ID sequence.
+///
+/// The sequence counter is an `AtomicU64`, so allocating a request ID never
+/// takes the callback-map lock; concurrent ops therefore never serialize on
+/// the counter. An op pays ONE map lock acquisition instead of the previous
+/// SEQ lock + map lock pair.
+///
+/// Request IDs start at 1 and saturate rather than wrap, so they can never
+/// become 0 (which would encode as a null cbdata pointer).
+pub struct Registry<T> {
+    seq: AtomicU64,
+    map: Mutex<HashMap<usize, T>>,
+}
+
+impl<T> Default for Registry<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Registry<T> {
+    /// Create an empty registry with the sequence starting at zero.
+    pub fn new() -> Self {
+        Self {
+            seq: AtomicU64::new(0),
+            map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Allocate the next non-zero request ID (saturating, never 0).
+    #[inline]
+    pub fn next_req_id(&self) -> usize {
+        loop {
+            let current = self.seq.load(Ordering::Relaxed);
+            let next = current.saturating_add(1).max(1);
+            if self
+                .seq
+                .compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return next as usize;
+            }
+        }
+    }
+
+    /// Allocate a request ID and insert its callback under one map lock.
+    #[inline]
+    pub fn insert_next(&self, value: T) -> usize {
+        let req_id = self.next_req_id();
+        self.lock().insert(req_id, value);
+        req_id
+    }
+
+    /// Lock the callback map.
+    #[inline]
+    pub fn lock(&self) -> MutexGuard<'_, HashMap<usize, T>> {
+        self.map.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Remove a callback from the registry.
+    #[inline]
+    pub fn remove(&self, req_id: usize) -> Option<T> {
+        self.lock().remove(&req_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,5 +151,46 @@ mod tests {
         assert_eq!(next_req_id(&seq), 1);
         assert_eq!(next_req_id(&seq), 2);
         assert_eq!(next_req_id(&seq), 3);
+    }
+
+    #[test]
+    fn registry_req_ids_start_at_one_and_never_zero() {
+        let reg = Registry::<()>::new();
+        assert_eq!(reg.next_req_id(), 1);
+        assert_eq!(reg.next_req_id(), 2);
+        assert_eq!(reg.next_req_id(), 3);
+    }
+
+    #[test]
+    fn registry_insert_next_and_remove_roundtrip() {
+        let reg = Registry::new();
+        let id = reg.insert_next("callback");
+        assert_eq!(reg.remove(id), Some("callback"));
+        assert_eq!(reg.remove(id), None);
+    }
+
+    #[test]
+    fn registry_concurrent_req_ids_are_unique() {
+        use std::sync::Arc;
+        let reg = Arc::new(Registry::<()>::new());
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let reg = Arc::clone(&reg);
+            handles.push(std::thread::spawn(move || {
+                let mut ids = Vec::new();
+                for _ in 0..100 {
+                    ids.push(reg.next_req_id());
+                }
+                ids
+            }));
+        }
+        let mut all: Vec<usize> = Vec::new();
+        for h in handles {
+            all.extend(h.join().unwrap());
+        }
+        all.sort_unstable();
+        all.dedup();
+        assert_eq!(all.len(), 800);
+        assert!(all.iter().all(|&id| id != 0));
     }
 }

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -35,17 +35,6 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
 }
 
 
-/// Allocate the next non-zero request ID from a per-registry sequence counter.
-///
-/// Starts at 1 (never returns 0 / null cbdata). Saturates rather than wrapping
-/// so a pathological overflow cannot produce a null id.
-#[inline]
-pub fn next_req_id(seq: &Mutex<usize>) -> usize {
-    let mut g = seq.lock().unwrap_or_else(|e| e.into_inner());
-    *g = g.saturating_add(1).max(1);
-    *g
-}
-
 /// Process-global callback registry with a lock-free request-ID sequence.
 ///
 /// The sequence counter is an `AtomicU64`, so allocating a request ID never
@@ -128,14 +117,6 @@ mod tests {
     #[test]
     fn never_null_for_nonzero() {
         assert!(!encode_req_id(1).is_null());
-    }
-
-    #[test]
-    fn next_req_id_starts_at_one_and_increments() {
-        let seq = Mutex::new(0);
-        assert_eq!(next_req_id(&seq), 1);
-        assert_eq!(next_req_id(&seq), 2);
-        assert_eq!(next_req_id(&seq), 3);
     }
 
     #[test]

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -34,21 +34,6 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
     cbdata.addr()
 }
 
-/// Encode a `u64` request ID (used by some monitoring paths).
-#[inline]
-pub fn encode_req_id_u64(req_id: u64) -> *mut c_void {
-    debug_assert!(
-        req_id != 0,
-        "request id must be non-zero to avoid null cbdata"
-    );
-    std::ptr::with_exposed_provenance_mut::<c_void>(req_id as usize)
-}
-
-/// Decode opaque cbdata into a `u64` request ID.
-#[inline]
-pub fn decode_req_id_u64(cbdata: *mut c_void) -> u64 {
-    cbdata.addr() as u64
-}
 
 /// Allocate the next non-zero request ID from a per-registry sequence counter.
 ///

--- a/src/cbdata.rs
+++ b/src/cbdata.rs
@@ -34,7 +34,6 @@ pub fn decode_req_id(cbdata: *mut c_void) -> usize {
     cbdata.addr()
 }
 
-
 /// Process-global callback registry with a lock-free request-ID sequence.
 ///
 /// The sequence counter is an `AtomicUsize`, so allocating a request ID never

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -12,6 +12,7 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
+use crate::cbdata::Registry;
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, free_value};
@@ -81,12 +82,9 @@ pub trait PublishCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending publish callbacks.
-type PublishRegistry = std::collections::HashMap<usize, Box<dyn PublishCallback>>;
-static PUBLISH_REGISTRY: LazyLock<Mutex<PublishRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+type PublishRegistry = Registry<Box<dyn PublishCallback>>;
+static PUBLISH_REGISTRY: LazyLock<PublishRegistry> = LazyLock::new(PublishRegistry::new);
 
-/// Monotonically increasing publish request ID counter.
-static PUBLISH_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (publish completion).
 ///
@@ -104,7 +102,7 @@ extern "C" fn publish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = PUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = PUBLISH_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -143,19 +141,9 @@ extern "C" fn publish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c
 /// `  pmix_op_cbfunc_t cbfunc, void *cbdata)`
 pub fn publish_nb(info: &Info, callback: Box<dyn PublishCallback>) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = PUBLISH_SEQ.lock().expect("mutex poisoned (data_ops.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = PUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = PUBLISH_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is not null and
-    // remains alignable (though PMIx treats it as opaque c_void).
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Prepare info parameters.
@@ -192,7 +180,7 @@ pub fn publish_nb(info: &Info, callback: Box<dyn PublishCallback>) -> Result<(),
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = PUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = PUBLISH_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -216,14 +204,11 @@ pub trait GetValueCallback: Send {
 ///
 /// `PMIx_Get_nb` stores only a raw `*mut c_void` as user data. Our bridge
 /// function uses this pointer to recover the Rust closure from the registry.
-type GetRegistry = std::collections::HashMap<usize, Box<dyn GetValueCallback>>;
-static GET_REGISTRY: LazyLock<Mutex<GetRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+type GetRegistry = Registry<Box<dyn GetValueCallback>>;
+static GET_REGISTRY: LazyLock<GetRegistry> = LazyLock::new(GetRegistry::new);
 static QUALIFIED_GETS: LazyLock<Mutex<std::collections::HashSet<usize>>> =
     LazyLock::new(|| Mutex::new(std::collections::HashSet::new()));
 
-/// Monotonically increasing request ID counter.
-static GET_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_value_cbfunc_t`.
 ///
@@ -247,7 +232,7 @@ extern "C" fn get_value_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = GET_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = GET_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -331,19 +316,9 @@ pub fn get_nb(
     callback: Box<dyn GetValueCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = GET_SEQ.lock().expect("mutex poisoned (data_ops.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = GET_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = GET_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is not null and
-    // remains alignable (though PMIx treats it as opaque c_void).
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Prepare key and info parameters.
@@ -351,7 +326,7 @@ pub fn get_nb(
         Ok(c) => c,
         Err(_) => {
             // Key contains NUL — remove callback and return error.
-            let mut registry = GET_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+            let mut registry = GET_REGISTRY.lock();
             registry.remove(&req_id);
             return Err(PmixStatus::Known(PmixError::Error));
         }
@@ -424,7 +399,7 @@ pub fn get_nb(
             .lock()
             .expect("mutex poisoned (data_ops.rs)")
             .remove(&req_id);
-        let mut registry = GET_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = GET_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -725,12 +700,9 @@ pub trait LookupCallback: Send {
 }
 
 /// Global registry for pending lookup_nb callbacks.
-type LookupRegistry = std::collections::HashMap<usize, Box<dyn LookupCallback>>;
-static LOOKUP_REGISTRY: LazyLock<Mutex<LookupRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+type LookupRegistry = Registry<Box<dyn LookupCallback>>;
+static LOOKUP_REGISTRY: LazyLock<LookupRegistry> = LazyLock::new(LookupRegistry::new);
 
-/// Monotonically increasing lookup request ID counter.
-static LOOKUP_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_lookup_cbfunc_t`.
 ///
@@ -752,7 +724,7 @@ extern "C" fn lookup_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = LOOKUP_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = LOOKUP_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -864,15 +836,7 @@ pub fn lookup_nb(
     }
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = LOOKUP_SEQ.lock().expect("mutex poisoned (data_ops.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = LOOKUP_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = LOOKUP_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -888,7 +852,7 @@ pub fn lookup_nb(
             }
             Err(_) => {
                 // Key contains NUL — clean up and return error.
-                let mut registry = LOOKUP_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+                let mut registry = LOOKUP_REGISTRY.lock();
                 registry.remove(&req_id);
                 return Err(PmixStatus::Known(PmixError::Error));
             }
@@ -940,7 +904,7 @@ pub fn lookup_nb(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = LOOKUP_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = LOOKUP_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -959,12 +923,9 @@ pub trait UnpublishCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending unpublish callbacks.
-type UnpublishRegistry = std::collections::HashMap<usize, Box<dyn UnpublishCallback>>;
-static UNPUBLISH_REGISTRY: LazyLock<Mutex<UnpublishRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+type UnpublishRegistry = Registry<Box<dyn UnpublishCallback>>;
+static UNPUBLISH_REGISTRY: LazyLock<UnpublishRegistry> = LazyLock::new(UnpublishRegistry::new);
 
-/// Monotonically increasing unpublish request ID counter.
-static UNPUBLISH_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (unpublish completion).
 ///
@@ -982,7 +943,7 @@ extern "C" fn unpublish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = UNPUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = UNPUBLISH_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1121,15 +1082,7 @@ pub fn unpublish_nb(
     callback: Box<dyn UnpublishCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = UNPUBLISH_SEQ.lock().expect("mutex poisoned (data_ops.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = UNPUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = UNPUBLISH_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1149,7 +1102,7 @@ pub fn unpublish_nb(
                     }
                     Err(_) => {
                         // Key contains NUL — clean up and return error.
-                        let mut registry = UNPUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+                        let mut registry = UNPUBLISH_REGISTRY.lock();
                         registry.remove(&req_id);
                         return Err(PmixStatus::Known(PmixError::Error));
                     }
@@ -1210,7 +1163,7 @@ pub fn unpublish_nb(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = UNPUBLISH_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = UNPUBLISH_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1304,12 +1257,9 @@ pub trait FenceCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending fence callbacks.
-type FenceRegistry = std::collections::HashMap<usize, Box<dyn FenceCallback>>;
-static FENCE_REGISTRY: LazyLock<Mutex<FenceRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+type FenceRegistry = Registry<Box<dyn FenceCallback>>;
+static FENCE_REGISTRY: LazyLock<FenceRegistry> = LazyLock::new(FenceRegistry::new);
 
-/// Monotonically increasing fence request ID counter.
-static FENCE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (fence completion).
 ///
@@ -1327,7 +1277,7 @@ extern "C" fn fence_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_v
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = FENCE_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = FENCE_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1391,19 +1341,9 @@ pub fn fence_nb(
     callback: Box<dyn FenceCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = FENCE_SEQ.lock().expect("mutex poisoned (data_ops.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = FENCE_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = FENCE_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is not null and
-    // remains alignable (though PMIx treats it as opaque c_void).
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Keep raw_procs alive for the full FFI call (do not drop at end of branch).
@@ -1457,7 +1397,7 @@ pub fn fence_nb(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = FENCE_REGISTRY.lock().expect("mutex poisoned (data_ops.rs)");
+        let mut registry = FENCE_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -196,80 +196,40 @@ use super::*;
         assert_eq!(*received_count.lock().unwrap().as_ref().unwrap(), 2);
     }
 
-    // ─── Registry and sequence counter tests ────────────────────────────────
+    // ─── Registry request ID tests ───────────────────────────────────────────
 
     #[test]
-    fn test_publish_seq_increments() {
-        let seq1 = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
-        let seq2 = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+    fn test_publish_request_ids_increase() {
+        let seq1 = PUBLISH_REGISTRY.next_req_id();
+        let seq2 = PUBLISH_REGISTRY.next_req_id();
         assert!(seq2 > seq1);
     }
 
     #[test]
-    fn test_get_seq_increments() {
-        let seq1 = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
-        let seq2 = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+    fn test_get_request_ids_increase() {
+        let seq1 = GET_REGISTRY.next_req_id();
+        let seq2 = GET_REGISTRY.next_req_id();
         assert!(seq2 > seq1);
     }
 
     #[test]
-    fn test_unpublish_seq_increments() {
-        let seq1 = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
-        let seq2 = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+    fn test_unpublish_request_ids_increase() {
+        let seq1 = UNPUBLISH_REGISTRY.next_req_id();
+        let seq2 = UNPUBLISH_REGISTRY.next_req_id();
         assert!(seq2 > seq1);
     }
 
     #[test]
-    fn test_fence_seq_increments() {
-        let seq1 = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
-        let seq2 = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+    fn test_fence_request_ids_increase() {
+        let seq1 = FENCE_REGISTRY.next_req_id();
+        let seq2 = FENCE_REGISTRY.next_req_id();
         assert!(seq2 > seq1);
     }
 
     #[test]
-    fn test_lookup_seq_increments() {
-        let seq1 = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
-        let seq2 = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+    fn test_lookup_request_ids_increase() {
+        let seq1 = LOOKUP_REGISTRY.next_req_id();
+        let seq2 = LOOKUP_REGISTRY.next_req_id();
         assert!(seq2 > seq1);
     }
 
@@ -283,7 +243,7 @@ use super::*;
         }
         let req_id = 999;
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyPublish));
             assert!(registry.contains_key(&req_id));
             registry.remove(&req_id);
@@ -299,7 +259,7 @@ use super::*;
         }
         let req_id = 888;
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyGet));
             assert!(registry.contains_key(&req_id));
             registry.remove(&req_id);
@@ -315,7 +275,7 @@ use super::*;
         }
         let req_id = 777;
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyLookupCb));
             assert!(registry.contains_key(&req_id));
             registry.remove(&req_id);
@@ -331,7 +291,7 @@ use super::*;
         }
         let req_id = 666;
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyUnpublishCb));
             assert!(registry.contains_key(&req_id));
             registry.remove(&req_id);
@@ -347,7 +307,7 @@ use super::*;
         }
         let req_id = 555;
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyFenceCb));
             assert!(registry.contains_key(&req_id));
             registry.remove(&req_id);
@@ -1234,7 +1194,7 @@ use super::*;
 
         let req_id = 77777usize;
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1264,7 +1224,7 @@ use super::*;
 
         let req_id = 66666usize;
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1294,7 +1254,7 @@ use super::*;
 
         let req_id = 55555usize;
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1328,7 +1288,7 @@ use super::*;
 
         let req_id = 44444usize;
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1360,7 +1320,7 @@ use super::*;
 
         let req_id = 33333usize;
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1980,13 +1940,9 @@ use super::*;
         }
 
         // Register callback
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestPublishCb));
         }
 
@@ -2010,13 +1966,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestPublishCb));
         }
 
@@ -2050,13 +2002,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestGetCb));
         }
 
@@ -2096,13 +2044,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestGetCb2));
         }
 
@@ -2138,7 +2082,7 @@ use super::*;
 
         assert_eq!(result, Err(PmixStatus::Known(PmixError::ErrInit)));
         assert!(QUALIFIED_GETS.lock().unwrap().is_empty());
-        assert!(GET_REGISTRY.lock().unwrap().is_empty());
+        assert!(GET_REGISTRY.lock().is_empty());
     }
 
     /// A successful qualified callback uses mock value transfer and clears its marker.
@@ -2157,14 +2101,9 @@ use super::*;
         }
 
         let _guard = MockGuard::new();
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         GET_REGISTRY
             .lock()
-            .unwrap()
             .insert(req_id, Box::new(QualifiedGet));
         QUALIFIED_GETS.lock().unwrap().insert(req_id);
 
@@ -2198,13 +2137,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestLookupCb));
         }
 
@@ -2229,13 +2164,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestLookupCb2));
         }
 
@@ -2260,13 +2191,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestFenceCb));
         }
 
@@ -2289,13 +2216,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestFenceCb2));
         }
 
@@ -2320,13 +2243,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = UNPUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestUnpublishCb));
         }
 
@@ -2540,13 +2459,9 @@ use super::*;
         }
 
         // Register and immediately remove
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyCb));
             assert_eq!(registry.len(), 1);
         }
@@ -2556,7 +2471,7 @@ use super::*;
             publish_callback_bridge(PMIX_SUCCESS, cbdata);
         }
         // Registry should be empty now
-        let registry = PUBLISH_REGISTRY.lock().unwrap();
+        let registry = PUBLISH_REGISTRY.lock();
         assert!(!registry.contains_key(&req_id));
     }
 
@@ -2568,13 +2483,9 @@ use super::*;
             fn on_result(self: Box<Self>, _status: PmixStatus, _value: Option<PmixOwnedValue>) {}
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyGetCb));
         }
 
@@ -2583,7 +2494,7 @@ use super::*;
             get_value_callback_bridge(PMIX_SUCCESS, std::ptr::null_mut(), cbdata);
         }
 
-        let registry = GET_REGISTRY.lock().unwrap();
+        let registry = GET_REGISTRY.lock();
         assert!(!registry.contains_key(&req_id));
     }
 
@@ -2595,13 +2506,9 @@ use super::*;
             fn on_result(self: Box<Self>, _status: PmixStatus, _data: Vec<PmixPdata>) {}
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyLookupCb));
         }
 
@@ -2610,7 +2517,7 @@ use super::*;
             lookup_callback_bridge(PMIX_SUCCESS, std::ptr::null_mut(), 0, cbdata);
         }
 
-        let registry = LOOKUP_REGISTRY.lock().unwrap();
+        let registry = LOOKUP_REGISTRY.lock();
         assert!(!registry.contains_key(&req_id));
     }
 
@@ -2622,13 +2529,9 @@ use super::*;
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyFenceCb));
         }
 
@@ -2637,7 +2540,7 @@ use super::*;
             fence_callback_bridge(PMIX_SUCCESS, cbdata);
         }
 
-        let registry = FENCE_REGISTRY.lock().unwrap();
+        let registry = FENCE_REGISTRY.lock();
         assert!(!registry.contains_key(&req_id));
     }
 
@@ -2649,13 +2552,9 @@ use super::*;
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
 
-        let req_id = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = UNPUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(DummyUnpublishCb));
         }
 
@@ -2664,7 +2563,7 @@ use super::*;
             unpublish_callback_bridge(PMIX_SUCCESS, cbdata);
         }
 
-        let registry = UNPUBLISH_REGISTRY.lock().unwrap();
+        let registry = UNPUBLISH_REGISTRY.lock();
         assert!(!registry.contains_key(&req_id));
     }
 
@@ -2816,13 +2715,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(CaptureCb));
         }
 
@@ -2851,13 +2746,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(StringValueCb));
         }
 
@@ -2985,13 +2876,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(TimeoutPublishCb));
         }
 
@@ -3013,13 +2900,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(NotFoundPublishCb));
         }
 
@@ -3045,13 +2928,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(ErrorGetCb));
         }
 
@@ -3074,13 +2953,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(TimeoutGetCb));
         }
 
@@ -3136,13 +3011,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(InitErrorGetCb));
         }
 
@@ -3168,13 +3039,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(DataLookupCb));
         }
 
@@ -3196,13 +3063,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(TimeoutLookupCb));
         }
 
@@ -3252,13 +3115,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(InitErrorLookupCb));
         }
 
@@ -3294,13 +3153,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = UNPUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(UnpubNotFoundCb));
         }
 
@@ -3322,13 +3177,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = UNPUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(UnpubTimeoutCb));
         }
 
@@ -3374,13 +3225,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(FenceNotFoundCb));
         }
 
@@ -3800,13 +3647,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = UNPUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = UNPUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = UNPUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = UNPUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(UnpubInitCb));
         }
 
@@ -3828,13 +3671,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(FenceDupCb));
         }
 
@@ -3856,13 +3695,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(GetDupCb));
         }
 
@@ -3884,13 +3719,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(LookupInitCb2));
         }
 
@@ -3963,13 +3794,9 @@ use super::*;
         let handles: Vec<_> = vec![
             // Thread 1: publish callback
             thread::spawn(|| {
-                let req_id = {
-                    let mut seq = PUBLISH_SEQ.lock().unwrap();
-                    *seq += 1;
-                    *seq
-                };
+                let req_id = PUBLISH_REGISTRY.next_req_id();
                 {
-                    let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+                    let mut registry = PUBLISH_REGISTRY.lock();
                     registry.insert(req_id, Box::new(ConcPubCb));
                 }
                 let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -3977,13 +3804,9 @@ use super::*;
             }),
             // Thread 2: get callback
             thread::spawn(|| {
-                let req_id = {
-                    let mut seq = GET_SEQ.lock().unwrap();
-                    *seq += 1;
-                    *seq
-                };
+                let req_id = GET_REGISTRY.next_req_id();
                 {
-                    let mut registry = GET_REGISTRY.lock().unwrap();
+                    let mut registry = GET_REGISTRY.lock();
                     registry.insert(req_id, Box::new(ConcGetCb));
                 }
                 let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -4114,13 +3937,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = FENCE_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = FENCE_REGISTRY.next_req_id();
         {
-            let mut registry = FENCE_REGISTRY.lock().unwrap();
+            let mut registry = FENCE_REGISTRY.lock();
             registry.insert(req_id, Box::new(FencePartialCb));
         }
 
@@ -4142,13 +3961,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = LOOKUP_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = LOOKUP_REGISTRY.next_req_id();
         {
-            let mut registry = LOOKUP_REGISTRY.lock().unwrap();
+            let mut registry = LOOKUP_REGISTRY.lock();
             registry.insert(req_id, Box::new(LookupPartialCb));
         }
 
@@ -4170,13 +3985,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = GET_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = GET_REGISTRY.next_req_id();
         {
-            let mut registry = GET_REGISTRY.lock().unwrap();
+            let mut registry = GET_REGISTRY.lock();
             registry.insert(req_id, Box::new(GetPartialCb));
         }
 
@@ -4198,13 +4009,9 @@ use super::*;
             }
         }
 
-        let req_id = {
-            let mut seq = PUBLISH_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = PUBLISH_REGISTRY.next_req_id();
         {
-            let mut registry = PUBLISH_REGISTRY.lock().unwrap();
+            let mut registry = PUBLISH_REGISTRY.lock();
             registry.insert(req_id, Box::new(PubPartialCb));
         }
 

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -6,11 +6,11 @@
 //! This module provides safe Rust wrappers around the PMIx group
 //! management APIs.
 
-use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
-use std::collections::HashMap;
+
 use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
@@ -28,26 +28,20 @@ pub use ffi::pmix_group_opt_t;
 // Bridges never pass a `Box` pointer as cbdata. Request IDs are encoded with
 // `encode_req_id`; the bridge does `lock → remove → unlock → invoke_user_callback`.
 
-static GROUP_CONSTRUCT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static GROUP_CONSTRUCT_REGISTRY: LazyLock<
-    Mutex<HashMap<usize, GroupConstructCallbackWrapper>>,
-> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static GROUP_CONSTRUCT_REGISTRY: LazyLock<Registry<GroupConstructCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
-static GROUP_INVITE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static GROUP_INVITE_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupInviteCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GROUP_INVITE_REGISTRY: LazyLock<Registry<GroupInviteCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
-static GROUP_JOIN_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static GROUP_JOIN_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupJoinCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GROUP_JOIN_REGISTRY: LazyLock<Registry<GroupJoinCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
-static GROUP_LEAVE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static GROUP_LEAVE_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupLeaveCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GROUP_LEAVE_REGISTRY: LazyLock<Registry<GroupLeaveCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
-static GROUP_DESTRUCT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static GROUP_DESTRUCT_REGISTRY: LazyLock<Mutex<HashMap<usize, GroupDestructCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GROUP_DESTRUCT_REGISTRY: LazyLock<Registry<GroupDestructCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
 fn info_results_from_c(status: PmixStatus, info: *mut ffi::pmix_info_t, ninfo: usize) -> Vec<Info> {
     if !status.is_success() || info.is_null() || ninfo == 0 {
@@ -208,7 +202,7 @@ pub unsafe extern "C" fn group_construct_callback_bridge(
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -245,11 +239,7 @@ pub fn group_construct_nb(
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
 
-    let req_id = next_req_id(&GROUP_CONSTRUCT_SEQ);
-    {
-        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = GROUP_CONSTRUCT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
 
@@ -284,7 +274,7 @@ pub fn group_construct_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -414,7 +404,7 @@ pub unsafe extern "C" fn group_invite_callback_bridge(
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_INVITE_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -450,11 +440,7 @@ pub fn group_invite_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let req_id = next_req_id(&GROUP_INVITE_SEQ);
-    {
-        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = GROUP_INVITE_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
 
@@ -489,7 +475,7 @@ pub fn group_invite_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_INVITE_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -621,7 +607,7 @@ pub unsafe extern "C" fn group_join_callback_bridge(
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_JOIN_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -656,11 +642,7 @@ pub fn group_join_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let req_id = next_req_id(&GROUP_JOIN_SEQ);
-    {
-        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = GROUP_JOIN_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
     let leader_ptr = std::ptr::addr_of!(leader.handle) as *const ffi::pmix_proc_t;
@@ -692,7 +674,7 @@ pub fn group_join_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_JOIN_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -767,7 +749,7 @@ pub unsafe extern "C" fn group_leave_callback_bridge(status: i32, cbdata: *mut c
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_LEAVE_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -797,11 +779,7 @@ pub fn group_leave_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let req_id = next_req_id(&GROUP_LEAVE_SEQ);
-    {
-        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = GROUP_LEAVE_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
 
@@ -830,7 +808,7 @@ pub fn group_leave_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_LEAVE_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -905,7 +883,7 @@ pub unsafe extern "C" fn group_destruct_callback_bridge(status: i32, cbdata: *mu
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -935,11 +913,7 @@ pub fn group_destruct_nb(
     }
 
     let group_id_c = CString::new(group_id).expect("group_id must not contain interior NUL bytes");
-    let req_id = next_req_id(&GROUP_DESTRUCT_SEQ);
-    {
-        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = GROUP_DESTRUCT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
 
@@ -968,7 +942,7 @@ pub fn group_destruct_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1119,7 +1093,7 @@ mod tests {
 
         let req_id = 900001usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1159,7 +1133,7 @@ mod tests {
 
         let req_id = 900002usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1280,7 +1254,7 @@ mod tests {
 
         let req_id = 900003usize;
         {
-            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_INVITE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1414,7 +1388,7 @@ mod tests {
 
         let req_id = 900004usize;
         {
-            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_JOIN_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1505,7 +1479,7 @@ mod tests {
 
         let req_id = 900005usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1532,7 +1506,7 @@ mod tests {
 
         let req_id = 900006usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1616,7 +1590,7 @@ mod tests {
 
         let req_id = 900007usize;
         {
-            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1643,7 +1617,7 @@ mod tests {
 
         let req_id = 900008usize;
         {
-            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1807,7 +1781,7 @@ mod tests {
 
         let req_id = 900009usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1841,7 +1815,7 @@ mod tests {
 
         let req_id = 900010usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1876,7 +1850,7 @@ mod tests {
 
         let req_id = 900011usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1923,7 +1897,7 @@ mod tests {
 
         let req_id = 900012usize;
         {
-            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_INVITE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -1958,7 +1932,7 @@ mod tests {
 
         let req_id = 900013usize;
         {
-            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_INVITE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2006,7 +1980,7 @@ mod tests {
 
         let req_id = 900014usize;
         {
-            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_JOIN_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2040,7 +2014,7 @@ mod tests {
 
         let req_id = 900015usize;
         {
-            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_JOIN_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2101,7 +2075,7 @@ mod tests {
 
         let req_id = 900016usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2127,7 +2101,7 @@ mod tests {
 
         let req_id = 900017usize;
         {
-            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2151,7 +2125,7 @@ mod tests {
 
         let req_id = 900018usize;
         {
-            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2376,7 +2350,7 @@ mod tests {
 
         let req_id = 900019usize;
         {
-            let mut registry = GROUP_INVITE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_INVITE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2406,7 +2380,7 @@ mod tests {
 
         let req_id = 900020usize;
         {
-            let mut registry = GROUP_JOIN_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_JOIN_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2436,7 +2410,7 @@ mod tests {
 
         let req_id = 900021usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2459,7 +2433,7 @@ mod tests {
 
         let req_id = 900022usize;
         {
-            let mut registry = GROUP_DESTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_DESTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2552,7 +2526,7 @@ mod tests {
         });
         let req_id = 424_267usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata_addr = encode_req_id(req_id) as usize;
@@ -2564,15 +2538,15 @@ mod tests {
         enter_rx
             .recv_timeout(Duration::from_secs(5))
             .expect("user callback should enter");
-        let guard = GROUP_LEAVE_REGISTRY
-            .try_lock()
-            .expect("registry lock must not be held across user callback code");
-        drop(guard);
+        let lock_check = std::thread::spawn(|| {
+            let _guard = GROUP_LEAVE_REGISTRY.lock();
+        });
+        lock_check.join().expect("registry lock must not be held across user callback code");
 
         let _ = release_tx.send(());
         progress.join().expect("bridge returns");
         assert!(
-            GROUP_LEAVE_REGISTRY.lock().unwrap().get(&req_id).is_none(),
+            GROUP_LEAVE_REGISTRY.lock().get(&req_id).is_none(),
             "one-shot leave callback must be removed before user invoke"
         );
     }
@@ -2584,7 +2558,7 @@ mod tests {
         });
         let req_id = 424_268usize;
         {
-            let mut registry = GROUP_LEAVE_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_LEAVE_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);
@@ -2592,7 +2566,7 @@ mod tests {
         unsafe {
             group_leave_callback_bridge(0, cbdata);
         }
-        assert!(GROUP_LEAVE_REGISTRY.lock().unwrap().get(&req_id).is_none());
+        assert!(GROUP_LEAVE_REGISTRY.lock().get(&req_id).is_none());
     }
 
     #[test]
@@ -2606,7 +2580,7 @@ mod tests {
         });
         let req_id = 424_269usize;
         {
-            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock().unwrap();
+            let mut registry = GROUP_CONSTRUCT_REGISTRY.lock();
             registry.insert(req_id, wrapper);
         }
         let cbdata = encode_req_id(req_id);

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -42,15 +42,15 @@
 //! #define PMIx_Heartbeat()  // sends a heartbeat via PMIx_Process_monitor_nb
 //! ```
 
-use std::collections::HashMap;
+
 use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
 
 use crate::ffi;
 use crate::threading::invoke_user_callback;
-use crate::cbdata::{decode_req_id_u64, encode_req_id_u64};
+use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::{Info, PmixError, PmixStatus};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -128,10 +128,7 @@ pub trait MonitorCallback: Send {
     fn on_complete(&mut self, status: PmixStatus, results: Option<MonitorResults>);
 }
 
-type MonitorRegistry = Mutex<HashMap<u64, Box<dyn MonitorCallback>>>;
-static MONITOR_REGISTRY: LazyLock<MonitorRegistry> = LazyLock::new(Mutex::default);
-
-static MONITOR_SEQ: LazyLock<Mutex<u64>> = LazyLock::new(|| Mutex::new(0));
+static MONITOR_REGISTRY: LazyLock<Registry<Box<dyn MonitorCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_info_cbfunc_t` (monitor completion).
 ///
@@ -147,10 +144,10 @@ unsafe extern "C" fn monitor_callback_bridge(
     _release_cbdata: *mut c_void,
 ) {
     // Decode the request ID from the cbdata pointer.
-    let req_id = decode_req_id_u64(cbdata);
+    let req_id = decode_req_id(cbdata);
 
     // Remove the callback from the registry — it is consumed exactly once.
-    let mut registry = MONITOR_REGISTRY.lock().unwrap();
+    let mut registry = MONITOR_REGISTRY.lock();
     let callback = registry.remove(&req_id);
     drop(registry);
 
@@ -315,18 +312,10 @@ pub fn process_monitor_nb(
     callback: Box<dyn MonitorCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = *MONITOR_SEQ.lock().unwrap();
-        seq += 1;
-        seq
-    };
-    {
-        let mut registry = MONITOR_REGISTRY.lock().unwrap();
-        registry.insert(req_id, callback);
-    }
+    let req_id = MONITOR_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
-    let cbdata = encode_req_id_u64(req_id);
+    let cbdata = encode_req_id(req_id);
 
     // Build directive pointer array.
     let (dirs_ptr, ndirs) = if directives.is_empty() {
@@ -360,7 +349,7 @@ pub fn process_monitor_nb(
         Ok(())
     } else {
         // Request rejected — remove the callback from the registry.
-        let mut registry = MONITOR_REGISTRY.lock().unwrap();
+        let mut registry = MONITOR_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -51,11 +51,11 @@
 //! let result = disconnect(&[target], &[disconnect_info]);
 //! ```
 
-use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixStatus, Proc};
-use std::collections::HashMap;
+
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
@@ -479,15 +479,9 @@ pub fn spawn(_job_info: &[Info], apps: &[PmixApp]) -> Result<String, PmixStatus>
 // ─────────────────────────────────────────────────────────────────────────────
 
 // ── One-shot completion registries (issue #67) ───────────────────────────────
-static SPAWN_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static SPAWN_REGISTRY: LazyLock<Mutex<HashMap<usize, SpawnCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static CONNECT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static CONNECT_REGISTRY: LazyLock<Mutex<HashMap<usize, ConnectCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static DISCONNECT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static DISCONNECT_REGISTRY: LazyLock<Mutex<HashMap<usize, DisconnectCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SPAWN_REGISTRY: LazyLock<Registry<SpawnCallbackWrapper>> = LazyLock::new(Registry::new);
+static CONNECT_REGISTRY: LazyLock<Registry<ConnectCallbackWrapper>> = LazyLock::new(Registry::new);
+static DISCONNECT_REGISTRY: LazyLock<Registry<DisconnectCallbackWrapper>> = LazyLock::new(Registry::new);
 
 /// Non-blocking spawn callback wrapper.
 ///
@@ -521,7 +515,7 @@ extern "C" fn spawn_callback_bridge(
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SPAWN_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -571,11 +565,7 @@ pub fn spawn_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let req_id = next_req_id(&SPAWN_SEQ);
-    {
-        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = SPAWN_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
     let napps = apps.len();
@@ -583,7 +573,7 @@ pub fn spawn_nb(
     // SAFETY: PMIx_App_create allocates and constructs napps pmix_app_t.
     let raw_apps: *mut ffi::pmix_app_t = unsafe { ffi::PMIx_App_create(napps) };
     if raw_apps.is_null() {
-        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SPAWN_REGISTRY.lock();
         registry.remove(&req_id);
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_OUT_OF_RESOURCE));
     }
@@ -684,7 +674,7 @@ pub fn spawn_nb(
     } else {
         // Sync failure: OpenPMIx may still deliver the completion; if it does
         // not, drop the parked callback so the registry does not leak.
-        let mut registry = SPAWN_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SPAWN_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -816,7 +806,7 @@ extern "C" fn connect_callback_bridge(status: i32, cbdata: *mut c_void) {
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = CONNECT_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -858,11 +848,7 @@ pub fn connect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let req_id = next_req_id(&CONNECT_SEQ);
-    {
-        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = CONNECT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
     // Convert proc slice to a raw pointer.
@@ -906,7 +892,7 @@ pub fn connect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = CONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = CONNECT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1045,7 +1031,7 @@ extern "C" fn disconnect_callback_bridge(status: i32, cbdata: *mut c_void) {
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = DISCONNECT_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -1087,11 +1073,7 @@ pub fn disconnect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let req_id = next_req_id(&DISCONNECT_SEQ);
-    {
-        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-        registry.insert(req_id, callback);
-    }
+    let req_id = DISCONNECT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
     // Convert proc slice to a raw pointer.
@@ -1135,7 +1117,7 @@ pub fn disconnect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = DISCONNECT_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = DISCONNECT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -1047,10 +1047,11 @@ mod tests {
                 self.called.store(true, std::sync::atomic::Ordering::SeqCst);
             }
         }
-        // Record registry size before our call
-        let size_before = {
+        // Record registry IDs before our call so cleanup can remove the exact
+        // ID inserted by query_info_nb rather than advancing the sequence.
+        let ids_before: std::collections::HashSet<usize> = {
             let registry = QUERY_REGISTRY.lock();
-            registry.len()
+            registry.keys().copied().collect()
         };
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
         let cb = Box::new(CountingCallback {
@@ -1061,15 +1062,21 @@ mod tests {
         // If Ok, the callback was NOT removed from registry (no PMIx server to
         // invoke the bridge callback). Clean it up ourselves.
         if result.is_ok() {
-            let req_id = QUERY_REGISTRY.next_req_id();
             let mut registry = QUERY_REGISTRY.lock();
-            registry.remove(&req_id);
+            let req_id = registry
+                .keys()
+                .find(|id| !ids_before.contains(id))
+                .copied();
+            if let Some(req_id) = req_id {
+                registry.remove(&req_id);
+            }
         }
         // The registry should be back to its pre-call size — our entry was removed.
         let size_after = {
             let registry = QUERY_REGISTRY.lock();
             registry.len()
         };
+        let size_before = ids_before.len();
         assert_eq!(
             size_after, size_before,
             "Registry should have same size after NB query (entry was cleaned up)"

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -41,6 +41,7 @@ use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
 use crate::ffi;
+use crate::cbdata::Registry;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
 
@@ -393,12 +394,7 @@ pub trait QueryCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending query callbacks.
-type QueryRegistry = std::collections::HashMap<usize, Box<dyn QueryCallback>>;
-static QUERY_REGISTRY: LazyLock<Mutex<QueryRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
-
-/// Monotonically increasing query request ID counter.
-static QUERY_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static QUERY_REGISTRY: LazyLock<Registry<Box<dyn QueryCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_info_cbfunc_t` (query completion).
 ///
@@ -426,7 +422,7 @@ extern "C" fn query_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = QUERY_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
+        let mut registry = QUERY_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -488,15 +484,7 @@ pub fn query_info_nb(
     }
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = QUERY_SEQ.lock().expect("mutex poisoned (query_log.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = QUERY_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = QUERY_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -529,7 +517,7 @@ pub fn query_info_nb(
         Ok(())
     } else {
         // Request rejected — remove the callback from the registry.
-        let mut registry = QUERY_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
+        let mut registry = QUERY_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -637,12 +625,7 @@ pub trait LogCallback: Send {
 }
 
 /// Global registry mapping log request IDs to pending callbacks.
-type LogRegistry = std::collections::HashMap<usize, Box<dyn LogCallback>>;
-static LOG_REGISTRY: LazyLock<Mutex<LogRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
-
-/// Monotonically increasing log request ID counter.
-static LOG_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static LOG_REGISTRY: LazyLock<Registry<Box<dyn LogCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_op_cbfunc_t` (log completion).
 ///
@@ -659,7 +642,7 @@ extern "C" fn log_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_voi
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = LOG_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
+        let mut registry = LOG_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -700,15 +683,7 @@ pub fn log_data_nb(
     let ndirs = directives.len();
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = LOG_SEQ.lock().expect("mutex poisoned (query_log.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = LOG_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = LOG_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -776,7 +751,7 @@ pub fn log_data_nb(
         Ok(())
     } else {
         // Request rejected — remove the callback from the registry.
-        let mut registry = LOG_REGISTRY.lock().expect("mutex poisoned (query_log.rs)");
+        let mut registry = LOG_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1074,7 +1049,7 @@ mod tests {
         }
         // Record registry size before our call
         let size_before = {
-            let registry = QUERY_REGISTRY.lock().unwrap();
+            let registry = QUERY_REGISTRY.lock();
             registry.len()
         };
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
@@ -1086,16 +1061,13 @@ mod tests {
         // If Ok, the callback was NOT removed from registry (no PMIx server to
         // invoke the bridge callback). Clean it up ourselves.
         if result.is_ok() {
-            let req_id = {
-                let seq = QUERY_SEQ.lock().unwrap();
-                *seq
-            };
-            let mut registry = QUERY_REGISTRY.lock().unwrap();
+            let req_id = QUERY_REGISTRY.next_req_id();
+            let mut registry = QUERY_REGISTRY.lock();
             registry.remove(&req_id);
         }
         // The registry should be back to its pre-call size — our entry was removed.
         let size_after = {
-            let registry = QUERY_REGISTRY.lock().unwrap();
+            let registry = QUERY_REGISTRY.lock();
             registry.len()
         };
         assert_eq!(
@@ -1118,22 +1090,6 @@ mod tests {
         let req_id: usize = 1;
         let cbdata = crate::cbdata::encode_req_id(req_id);
         assert!(!cbdata.is_null());
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // QUERY_SEQ counter tests
-    // ─────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_query_seq_monotonic() {
-        let seq1 = QUERY_SEQ.lock().unwrap();
-        let val1 = *seq1;
-        drop(seq1);
-        let mut seq2 = QUERY_SEQ.lock().unwrap();
-        *seq2 += 1;
-        let val2 = *seq2;
-        drop(seq2);
-        assert!(val2 > val1);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -1213,14 +1169,14 @@ mod tests {
         }
         // Record registry size before to detect our entry post-call
         let size_before = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         let result = log_data_nb(&[], &[], Box::new(LogNbDummy));
         assert!(result.is_err());
         // Registry should be back to pre-call size — our entry was cleaned up.
         let size_after = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         assert_eq!(
@@ -1242,7 +1198,7 @@ mod tests {
             }
         }
         let size_before = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         let info = crate::info_with_string_key("test.key", "test.value");
@@ -1252,7 +1208,7 @@ mod tests {
         let result = log_data_nb(&[info], &[], cb);
         assert!(result.is_err());
         let size_after = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         assert_eq!(
@@ -1278,7 +1234,7 @@ mod tests {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
         let size_before = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         for _ in 0..5 {
@@ -1286,29 +1242,13 @@ mod tests {
             let _ = log_data_nb(&[info], &[], Box::new(LogDummy));
         }
         let size_after = {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             registry.len()
         };
         assert_eq!(
             size_after, size_before,
             "Registry size unchanged after multiple failed NB logs"
         );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // LOG_SEQ counter tests
-    // ─────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_log_seq_monotonic() {
-        let seq1 = LOG_SEQ.lock().unwrap();
-        let val1 = *seq1;
-        drop(seq1);
-        let mut seq2 = LOG_SEQ.lock().unwrap();
-        *seq2 += 1;
-        let val2 = *seq2;
-        drop(seq2);
-        assert!(val2 > val1);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -1485,17 +1425,17 @@ mod tests {
         for i in 0..20 {
             let key = base + i;
             {
-                let mut registry = QUERY_REGISTRY.lock().unwrap();
+                let mut registry = QUERY_REGISTRY.lock();
                 registry.insert(key, Box::new(DummyQCb));
             }
             {
-                let mut registry = QUERY_REGISTRY.lock().unwrap();
+                let mut registry = QUERY_REGISTRY.lock();
                 registry.remove(&key);
             }
         }
         // Verify our keys are gone (don't assert is_empty — other tests may have entries)
         {
-            let registry = QUERY_REGISTRY.lock().unwrap();
+            let registry = QUERY_REGISTRY.lock();
             for i in 0..20 {
                 assert!(
                     registry.get(&(base + i)).is_none(),
@@ -1517,17 +1457,17 @@ mod tests {
         for i in 0..20 {
             let key = base + i;
             {
-                let mut registry = LOG_REGISTRY.lock().unwrap();
+                let mut registry = LOG_REGISTRY.lock();
                 registry.insert(key, Box::new(DummyLCb));
             }
             {
-                let mut registry = LOG_REGISTRY.lock().unwrap();
+                let mut registry = LOG_REGISTRY.lock();
                 registry.remove(&key);
             }
         }
         // Verify our keys are gone (don't assert is_empty — other tests may have entries)
         {
-            let registry = LOG_REGISTRY.lock().unwrap();
+            let registry = LOG_REGISTRY.lock();
             for i in 0..20 {
                 assert!(
                     registry.get(&(base + i)).is_none(),
@@ -1738,16 +1678,7 @@ mod tests {
             }
         }
 
-        let req_id = {
-            let mut seq = QUERY_SEQ.lock().expect("mutex poisoned");
-            *seq += 1;
-            *seq
-        };
-
-        {
-            let mut registry = QUERY_REGISTRY.lock().expect("mutex poisoned");
-            registry.insert(req_id, Box::new(BridgeTestCallback { called: called_clone }));
-        }
+        let req_id = QUERY_REGISTRY.insert_next(Box::new(BridgeTestCallback { called: called_clone }));
 
         // Simulate the callback being invoked
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1782,16 +1713,7 @@ mod tests {
             }
         }
 
-        let req_id = {
-            let mut seq = LOG_SEQ.lock().expect("mutex poisoned");
-            *seq += 1;
-            *seq
-        };
-
-        {
-            let mut registry = LOG_REGISTRY.lock().expect("mutex poisoned");
-            registry.insert(req_id, Box::new(BridgeLogTestCallback { called: called_clone }));
-        }
+        let req_id = LOG_REGISTRY.insert_next(Box::new(BridgeLogTestCallback { called: called_clone }));
 
         let cbdata = crate::cbdata::encode_req_id(req_id);
         unsafe {

--- a/src/security.rs
+++ b/src/security.rs
@@ -34,6 +34,7 @@ use std::os::raw::{c_uchar, c_void};
 use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
+use crate::cbdata::Registry;
 use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
@@ -340,12 +341,7 @@ impl CredentialResults {
 }
 
 /// Global registry mapping request IDs to pending credential callbacks.
-type CredentialRegistry = std::collections::HashMap<usize, Box<dyn CredentialCallback>>;
-static CREDENTIAL_REGISTRY: LazyLock<Mutex<CredentialRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
-
-/// Monotonically increasing credential request ID counter.
-static CREDENTIAL_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+static CREDENTIAL_REGISTRY: LazyLock<Registry<Box<dyn CredentialCallback>>> = LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_credential_cbfunc_t`.
 ///
@@ -392,7 +388,7 @@ extern "C" fn credential_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = CREDENTIAL_REGISTRY.lock().expect("mutex poisoned (security.rs)");
+        let mut registry = CREDENTIAL_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -483,15 +479,7 @@ pub fn get_credential_nb(
     callback: Box<dyn CredentialCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = CREDENTIAL_SEQ.lock().expect("mutex poisoned (security.rs)");
-        *seq += 1;
-        *seq
-    };
-    {
-        let mut registry = CREDENTIAL_REGISTRY.lock().expect("mutex poisoned (security.rs)");
-        registry.insert(req_id, callback);
-    }
+    let req_id = CREDENTIAL_REGISTRY.insert_next(callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -522,7 +510,7 @@ pub fn get_credential_nb(
         Ok(())
     } else {
         // Request rejected — remove the callback from the registry.
-        let mut registry = CREDENTIAL_REGISTRY.lock().expect("mutex poisoned (security.rs)");
+        let mut registry = CREDENTIAL_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -682,9 +670,7 @@ pub trait ValidationCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending validation callbacks.
-type ValidationRegistry = std::collections::HashMap<usize, Box<dyn ValidationCallback>>;
-static VALIDATION_REGISTRY: LazyLock<Mutex<ValidationRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static VALIDATION_REGISTRY: LazyLock<Registry<Box<dyn ValidationCallback>>> = LazyLock::new(Registry::new);
 
 /// Map from request ID to the C-allocated credential pointer for async validation.
 /// We store as usize to avoid Send/Sync issues with raw pointers in a shared HashMap.
@@ -692,8 +678,6 @@ type ValidationCredMap = std::collections::HashMap<usize, usize>;
 static VALIDATION_CRED_MAP: LazyLock<Mutex<ValidationCredMap>> =
     LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
-/// Monotonically increasing validation request ID counter.
-static VALIDATION_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_validation_cbfunc_t`.
 ///
@@ -726,7 +710,7 @@ extern "C" fn validation_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = VALIDATION_REGISTRY.lock().expect("mutex poisoned (security.rs)");
+        let mut registry = VALIDATION_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -805,11 +789,7 @@ pub fn validate_credential_nb(
     callback: Box<dyn ValidationCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = VALIDATION_SEQ.lock().expect("mutex poisoned (security.rs)");
-        *seq += 1;
-        *seq
-    };
+    let req_id = VALIDATION_REGISTRY.next_req_id();
 
     // Create a C pmix_byte_object_t for the credential.
     // It needs to stay alive until the callback fires, so we store it
@@ -819,10 +799,7 @@ pub fn validate_credential_nb(
         let mut cred_map = VALIDATION_CRED_MAP.lock().expect("mutex poisoned (security.rs)");
         cred_map.insert(req_id, cred_c as usize);
     }
-    {
-        let mut registry = VALIDATION_REGISTRY.lock().expect("mutex poisoned (security.rs)");
-        registry.insert(req_id, callback);
-    }
+    VALIDATION_REGISTRY.lock().insert(req_id, callback);
 
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -853,7 +830,7 @@ pub fn validate_credential_nb(
         Ok(())
     } else {
         // Request rejected — remove the callback and free the C credential.
-        let mut registry = VALIDATION_REGISTRY.lock().expect("mutex poisoned (security.rs)");
+        let mut registry = VALIDATION_REGISTRY.lock();
         registry.remove(&req_id);
         let mut cred_map = VALIDATION_CRED_MAP.lock().expect("mutex poisoned (security.rs)");
         if let Some(cred_ptr) = cred_map.remove(&req_id) {
@@ -1083,33 +1060,18 @@ mod tests {
         assert!(std::mem::size_of_val(&cb) > 0);
     }
 
-    // ── Registry and sequence counters ─────────────────────────────────────
+    // ── Registry tests ─────────────────────────────────────────────────────
 
-    #[test]
-    fn test_credential_seq_counter() {
-        let mut seq = CREDENTIAL_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        assert_eq!(*seq, before + 1);
-    }
-
-    #[test]
-    fn test_validation_seq_counter() {
-        let mut seq = VALIDATION_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        assert_eq!(*seq, before + 1);
-    }
 
     #[test]
     fn test_credential_registry_is_accessible() {
-        let registry = CREDENTIAL_REGISTRY.lock().unwrap();
+        let registry = CREDENTIAL_REGISTRY.lock();
         assert!(registry.is_empty());
     }
 
     #[test]
     fn test_validation_registry_is_accessible() {
-        let registry = VALIDATION_REGISTRY.lock().unwrap();
+        let registry = VALIDATION_REGISTRY.lock();
         assert!(registry.is_empty());
     }
 
@@ -1508,7 +1470,7 @@ mod tests {
             }
         }
         {
-            let mut registry = CREDENTIAL_REGISTRY.lock().unwrap();
+            let mut registry = CREDENTIAL_REGISTRY.lock();
             registry.insert(99999, Box::new(TestCb));
             assert_eq!(registry.len(), 1);
             registry.remove(&99999);
@@ -1524,7 +1486,7 @@ mod tests {
             fn on_complete(self: Box<Self>, _status: PmixStatus, _results: ValidationResults) {}
         }
         {
-            let mut registry = VALIDATION_REGISTRY.lock().unwrap();
+            let mut registry = VALIDATION_REGISTRY.lock();
             registry.insert(99998, Box::new(TestCb));
             assert_eq!(registry.len(), 1);
             registry.remove(&99998);
@@ -1679,7 +1641,7 @@ mod tests {
         // Register callback
         let req_id = 77777usize;
         {
-            let mut registry = CREDENTIAL_REGISTRY.lock().unwrap();
+            let mut registry = CREDENTIAL_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestCredCb));
         }
 
@@ -1739,7 +1701,7 @@ mod tests {
 
         let req_id = 66666usize;
         {
-            let mut registry = VALIDATION_REGISTRY.lock().unwrap();
+            let mut registry = VALIDATION_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestValCb));
         }
 

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,7 +1,7 @@
 //! Server submodule: data
 
 use super::*;
-use crate::cbdata::{decode_req_id, encode_req_id, next_req_id};
+use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::threading::invoke_user_callback;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -332,15 +332,12 @@ pub fn server_fence(
 // ─────────────────────────────────────────────────────────────────────────────
 
 // ── One-shot completion registries (issue #67) ───────────────────────────────
-static SERVER_FENCE_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static SERVER_FENCE_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static SERVER_CONNECT_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static SERVER_CONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-static SERVER_DISCONNECT_NB_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
-static SERVER_DISCONNECT_NB_REGISTRY: LazyLock<Mutex<HashMap<usize, FenceNbCallbackWrapper>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SERVER_FENCE_NB_REGISTRY: LazyLock<Registry<FenceNbCallbackWrapper>> =
+    LazyLock::new(Registry::new);
+static SERVER_CONNECT_NB_REGISTRY: LazyLock<Registry<FenceNbCallbackWrapper>> =
+    LazyLock::new(Registry::new);
+static SERVER_DISCONNECT_NB_REGISTRY: LazyLock<Registry<FenceNbCallbackWrapper>> =
+    LazyLock::new(Registry::new);
 
 pub(crate) extern "C" fn fence_nb_callback_bridge(status: i32, cbdata: *mut c_void) {
     if cbdata.is_null() {
@@ -348,7 +345,7 @@ pub(crate) extern "C" fn fence_nb_callback_bridge(status: i32, cbdata: *mut c_vo
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -366,7 +363,7 @@ pub(crate) extern "C" fn connect_nb_callback_bridge(status: i32, cbdata: *mut c_
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -384,7 +381,7 @@ pub(crate) extern "C" fn disconnect_nb_callback_bridge(status: i32, cbdata: *mut
     }
     let req_id = decode_req_id(cbdata);
     let cb = {
-        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let Some(cb_wrapper) = cb else {
@@ -441,9 +438,9 @@ pub fn server_fence_nb(
     _info: &[Info],
     callback: FenceNbCallbackWrapper,
 ) -> Result<(), PmixStatus> {
-    let req_id = next_req_id(&SERVER_FENCE_NB_SEQ);
+    let req_id = SERVER_FENCE_NB_REGISTRY.next_req_id();
     {
-        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
     let cbdata = encode_req_id(req_id);
@@ -470,7 +467,7 @@ pub fn server_fence_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = SERVER_FENCE_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_FENCE_NB_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -573,9 +570,9 @@ pub fn server_connect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let req_id = next_req_id(&SERVER_CONNECT_NB_SEQ);
+    let req_id = SERVER_CONNECT_NB_REGISTRY.next_req_id();
     {
-        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
     let cbdata = encode_req_id(req_id);
@@ -611,7 +608,7 @@ pub fn server_connect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_CONNECT_NB_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -710,9 +707,9 @@ pub fn server_disconnect_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let req_id = next_req_id(&SERVER_DISCONNECT_NB_SEQ);
+    let req_id = SERVER_DISCONNECT_NB_REGISTRY.next_req_id();
     {
-        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
     let cbdata = encode_req_id(req_id);
@@ -748,7 +745,7 @@ pub fn server_disconnect_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registry = SERVER_DISCONNECT_NB_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1556,8 +1556,8 @@ pub fn server_dmodex_request(
     }
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is properly aligned
-    // and non-null (req_id starts from 1; see crate::cbdata::encode_req_id).
+    // encode_req_id casts the request ID directly; Registry never returns 0,
+    // so cbdata is never null.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Get a pointer to the proc's internal pmix_proc_t for FFI.
@@ -1822,8 +1822,8 @@ pub fn server_setup_application(
     }
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is properly aligned
-    // and non-null (req_id starts from 1; see crate::cbdata::encode_req_id).
+    // encode_req_id casts the request ID directly; Registry never returns 0,
+    // so cbdata is never null.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Get the info array pointer and length.
@@ -2005,8 +2005,8 @@ pub fn server_setup_local_support(
     }
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is properly aligned
-    // and non-null (req_id starts from 1; see crate::cbdata::encode_req_id).
+    // encode_req_id casts the request ID directly; Registry never returns 0,
+    // so cbdata is never null.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Prepare info parameters.
@@ -2217,8 +2217,8 @@ pub fn server_iof_deliver(
     }
 
     // Encode the request ID as a non-null pointer for cbdata.
-    // We shift left by 2 to ensure the pointer is properly aligned
-    // and non-null (req_id starts from 1; see crate::cbdata::encode_req_id).
+    // encode_req_id casts the request ID directly; Registry never returns 0,
+    // so cbdata is never null.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Get a pointer to the source proc's internal pmix_proc_t for FFI.
@@ -2467,8 +2467,8 @@ pub fn server_collect_inventory(
     // Assign a unique request ID and register the callback.
     let req_id = COLLECT_INVENTORY_REGISTRY.next_req_id();
 
-    // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
-    // is never null (req_id starts at 1, so shifted value >= 4).
+    // SAFETY: encode_req_id casts the request ID directly; Registry never
+    // returns 0, so cbdata is never null.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     {
@@ -2666,8 +2666,8 @@ pub fn server_deliver_inventory(
     if let Some(cb) = callback {
         let req_id = DELIVER_INVENTORY_REGISTRY.next_req_id();
 
-        // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
-        // is never null (req_id starts at 1, so shifted value >= 4).
+        // SAFETY: encode_req_id casts the request ID directly; Registry never
+        // returns 0, so cbdata is never null.
         let cbdata = crate::cbdata::encode_req_id(req_id);
 
         {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,6 +69,7 @@
 
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::security::PmixCredential;
+use crate::cbdata::Registry;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, ffi};
 use std::ffi::{CStr, CString};
@@ -525,12 +526,9 @@ pub trait RegisterNspaceCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending register_nspace callbacks.
-type RegisterNspaceRegistry = std::collections::HashMap<usize, Box<dyn RegisterNspaceCallback>>;
-static REGISTER_NS_SPACE_REGISTRY: LazyLock<Mutex<RegisterNspaceRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static REGISTER_NS_SPACE_REGISTRY: LazyLock<Registry<Box<dyn RegisterNspaceCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing register_nspace request ID counter.
-static REGISTER_NS_SPACE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (register_nspace completion).
 ///
@@ -548,7 +546,7 @@ pub(crate) extern "C" fn register_nspace_callback_bridge(status: ffi::pmix_statu
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -644,13 +642,9 @@ pub fn server_register_nspace(
     };
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = REGISTER_NS_SPACE_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = REGISTER_NS_SPACE_REGISTRY.next_req_id();
     {
-        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -690,7 +684,7 @@ pub fn server_register_nspace(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_NS_SPACE_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -740,12 +734,9 @@ pub trait DeregisterNspaceCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending deregister_nspace callbacks.
-type DeregisterNspaceRegistry = std::collections::HashMap<usize, Box<dyn DeregisterNspaceCallback>>;
-static DEREGISTER_NS_SPACE_REGISTRY: LazyLock<Mutex<DeregisterNspaceRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static DEREGISTER_NS_SPACE_REGISTRY: LazyLock<Registry<Box<dyn DeregisterNspaceCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing deregister_nspace request ID counter.
-static DEREGISTER_NS_SPACE_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (deregister_nspace completion).
 ///
@@ -763,7 +754,7 @@ pub(crate) extern "C" fn deregister_nspace_callback_bridge(status: ffi::pmix_sta
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -849,13 +840,9 @@ pub fn server_deregister_nspace(nspace: &str, callback: Option<Box<dyn Deregiste
     match callback {
         Some(cb) => {
             // Non-blocking mode: register callback and pass bridge to FFI.
-            let req_id = {
-                let mut seq = DEREGISTER_NS_SPACE_SEQ.lock().unwrap();
-                *seq += 1;
-                *seq
-            };
+            let req_id = DEREGISTER_NS_SPACE_REGISTRY.next_req_id();
             {
-                let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+                let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock();
                 registry.insert(req_id, cb);
             }
 
@@ -903,12 +890,9 @@ pub trait RegisterClientCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending register_client callbacks.
-type RegisterClientRegistry = std::collections::HashMap<usize, Box<dyn RegisterClientCallback>>;
-static REGISTER_CLIENT_REGISTRY: LazyLock<Mutex<RegisterClientRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static REGISTER_CLIENT_REGISTRY: LazyLock<Registry<Box<dyn RegisterClientCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing register_client request ID counter.
-static REGISTER_CLIENT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (register_client completion).
 ///
@@ -926,7 +910,7 @@ pub(crate) extern "C" fn register_client_callback_bridge(status: ffi::pmix_statu
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = REGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_CLIENT_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1009,13 +993,9 @@ pub fn server_register_client(
     callback: Box<dyn RegisterClientCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = REGISTER_CLIENT_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = REGISTER_CLIENT_REGISTRY.next_req_id();
     {
-        let mut registry = REGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_CLIENT_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -1058,7 +1038,7 @@ pub fn server_register_client(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = REGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_CLIENT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1077,12 +1057,9 @@ pub trait DeregisterClientCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending deregister_client callbacks.
-type DeregisterClientRegistry = std::collections::HashMap<usize, Box<dyn DeregisterClientCallback>>;
-static DEREGISTER_CLIENT_REGISTRY: LazyLock<Mutex<DeregisterClientRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static DEREGISTER_CLIENT_REGISTRY: LazyLock<Registry<Box<dyn DeregisterClientCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing deregister_client request ID counter.
-static DEREGISTER_CLIENT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (deregister_client completion).
 ///
@@ -1100,7 +1077,7 @@ pub(crate) extern "C" fn deregister_client_callback_bridge(status: ffi::pmix_sta
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = DEREGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let mut registry = DEREGISTER_CLIENT_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1172,13 +1149,9 @@ pub fn server_deregister_client(proc: &Proc, callback: Option<Box<dyn Deregister
     match callback {
         Some(cb) => {
             // Non-blocking mode: register callback and pass bridge to FFI.
-            let req_id = {
-                let mut seq = DEREGISTER_CLIENT_SEQ.lock().unwrap();
-                *seq += 1;
-                *seq
-            };
+            let req_id = DEREGISTER_CLIENT_REGISTRY.next_req_id();
             {
-                let mut registry = DEREGISTER_CLIENT_REGISTRY.lock().unwrap();
+                let mut registry = DEREGISTER_CLIENT_REGISTRY.lock();
                 registry.insert(req_id, cb);
             }
 
@@ -1447,12 +1420,9 @@ pub trait DmodexRequestCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending dmodex_request callbacks.
-type DmodexRequestRegistry = std::collections::HashMap<usize, Box<dyn DmodexRequestCallback>>;
-static DMODEX_REQUEST_REGISTRY: LazyLock<Mutex<DmodexRequestRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static DMODEX_REQUEST_REGISTRY: LazyLock<Registry<Box<dyn DmodexRequestCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing dmodex_request ID counter.
-static DMODEX_REQUEST_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_dmodex_response_fn_t` (dmodex_request completion).
 ///
@@ -1490,7 +1460,7 @@ pub(crate) extern "C" fn dmodex_request_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = DMODEX_REQUEST_REGISTRY.lock().unwrap();
+        let mut registry = DMODEX_REQUEST_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1579,13 +1549,9 @@ pub fn server_dmodex_request(
     callback: Box<dyn DmodexRequestCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = DMODEX_REQUEST_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = DMODEX_REQUEST_REGISTRY.next_req_id();
     {
-        let mut registry = DMODEX_REQUEST_REGISTRY.lock().unwrap();
+        let mut registry = DMODEX_REQUEST_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -1618,7 +1584,7 @@ pub fn server_dmodex_request(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = DMODEX_REQUEST_REGISTRY.lock().unwrap();
+        let mut registry = DMODEX_REQUEST_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1651,12 +1617,9 @@ pub trait SetupApplicationCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending setup_application callbacks.
-type SetupApplicationRegistry = std::collections::HashMap<usize, Box<dyn SetupApplicationCallback>>;
-static SETUP_APPLICATION_REGISTRY: LazyLock<Mutex<SetupApplicationRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static SETUP_APPLICATION_REGISTRY: LazyLock<Registry<Box<dyn SetupApplicationCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing setup_application request ID counter.
-static SETUP_APPLICATION_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_setup_application_cbfunc_t`.
 ///
@@ -1752,7 +1715,7 @@ pub(crate) extern "C" fn setup_application_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = SETUP_APPLICATION_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_APPLICATION_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -1852,13 +1815,9 @@ pub fn server_setup_application(
     };
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = SETUP_APPLICATION_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = SETUP_APPLICATION_REGISTRY.next_req_id();
     {
-        let mut registry = SETUP_APPLICATION_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_APPLICATION_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -1905,7 +1864,7 @@ pub fn server_setup_application(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = SETUP_APPLICATION_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_APPLICATION_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -1926,13 +1885,9 @@ pub trait SetupLocalSupportCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending setup_local_support callbacks.
-type SetupLocalSupportRegistry =
-    std::collections::HashMap<usize, Box<dyn SetupLocalSupportCallback>>;
-static SETUP_LOCAL_SUPPORT_REGISTRY: LazyLock<Mutex<SetupLocalSupportRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static SETUP_LOCAL_SUPPORT_REGISTRY: LazyLock<Registry<Box<dyn SetupLocalSupportCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing setup_local_support request ID counter.
-static SETUP_LOCAL_SUPPORT_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (setup_local_support completion).
 ///
@@ -1950,7 +1905,7 @@ pub(crate) extern "C" fn setup_local_support_callback_bridge(status: ffi::pmix_s
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -2043,13 +1998,9 @@ pub fn server_setup_local_support(
     };
 
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = SETUP_LOCAL_SUPPORT_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = SETUP_LOCAL_SUPPORT_REGISTRY.next_req_id();
     {
-        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -2094,7 +2045,7 @@ pub fn server_setup_local_support(
         // callback will NOT be called.
         if pmix_status.to_raw() == -157 {
             // PMIX_OPERATION_SUCCEEDED — callback not called, so remove it.
-            let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock().unwrap();
+            let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock();
             registry.remove(&req_id);
             // Return success — the operation completed immediately.
             Ok(())
@@ -2105,7 +2056,7 @@ pub fn server_setup_local_support(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock().unwrap();
+        let mut registry = SETUP_LOCAL_SUPPORT_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -2133,12 +2084,9 @@ pub trait IOFDeliverCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending IOF_deliver callbacks.
-type IOFDeliverRegistry = std::collections::HashMap<usize, Box<dyn IOFDeliverCallback>>;
-static IOF_DELIVER_REGISTRY: LazyLock<Mutex<IOFDeliverRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static IOF_DELIVER_REGISTRY: LazyLock<Registry<Box<dyn IOFDeliverCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing IOF_deliver request ID counter.
-static IOF_DELIVER_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (IOF_deliver completion).
 ///
@@ -2157,7 +2105,7 @@ pub(crate) extern "C" fn iof_deliver_callback_bridge(status: ffi::pmix_status_t,
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = IOF_DELIVER_REGISTRY.lock().unwrap();
+        let mut registry = IOF_DELIVER_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -2262,13 +2210,9 @@ pub fn server_iof_deliver(
     callback: Box<dyn IOFDeliverCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = IOF_DELIVER_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = IOF_DELIVER_REGISTRY.next_req_id();
     {
-        let mut registry = IOF_DELIVER_REGISTRY.lock().unwrap();
+        let mut registry = IOF_DELIVER_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -2327,7 +2271,7 @@ pub fn server_iof_deliver(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = IOF_DELIVER_REGISTRY.lock().unwrap();
+        let mut registry = IOF_DELIVER_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -2390,15 +2334,12 @@ impl Drop for CollectInventoryResults {
     }
 }
 
-/// Monotonically increasing collect-inventory request ID counter.
-static COLLECT_INVENTORY_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// Global registry of pending collect-inventory callbacks.
 ///
 /// Maps request ID -> callback. Entries are removed when the callback fires.
-static COLLECT_INVENTORY_REGISTRY: LazyLock<
-    Mutex<std::collections::HashMap<usize, Box<dyn CollectInventoryCallback>>>,
-> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static COLLECT_INVENTORY_REGISTRY: LazyLock<Registry<Box<dyn CollectInventoryCallback>>> =
+    LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_info_cbfunc_t` (collect inventory completion).
 ///
@@ -2424,7 +2365,7 @@ pub(crate) extern "C" fn collect_inventory_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = COLLECT_INVENTORY_REGISTRY.lock().unwrap();
+        let mut registry = COLLECT_INVENTORY_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -2524,18 +2465,14 @@ pub fn server_collect_inventory(
     callback: Box<dyn CollectInventoryCallback>,
 ) -> Result<(), PmixStatus> {
     // Assign a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = COLLECT_INVENTORY_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = COLLECT_INVENTORY_REGISTRY.next_req_id();
 
     // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
     // is never null (req_id starts at 1, so shifted value >= 4).
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     {
-        let mut registry = COLLECT_INVENTORY_REGISTRY.lock().unwrap();
+        let mut registry = COLLECT_INVENTORY_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -2574,7 +2511,7 @@ pub fn server_collect_inventory(
         Ok(())
     } else {
         // Request was rejected — remove the callback so it doesn't leak.
-        let mut registry = COLLECT_INVENTORY_REGISTRY.lock().unwrap();
+        let mut registry = COLLECT_INVENTORY_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -2614,15 +2551,12 @@ pub trait DeliverInventoryCallback: Send + 'static {
     fn on_complete(self: Box<Self>, status: PmixStatus);
 }
 
-/// Monotonically increasing deliver-inventory request ID counter.
-static DELIVER_INVENTORY_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// Global registry of pending deliver-inventory callbacks.
 ///
 /// Maps request ID -> callback. Entries are removed when the callback fires.
-static DELIVER_INVENTORY_REGISTRY: LazyLock<
-    Mutex<std::collections::HashMap<usize, Box<dyn DeliverInventoryCallback>>>,
-> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static DELIVER_INVENTORY_REGISTRY: LazyLock<Registry<Box<dyn DeliverInventoryCallback>>> =
+    LazyLock::new(Registry::new);
 
 /// C bridge for `pmix_op_cbfunc_t` (deliver inventory completion).
 ///
@@ -2640,7 +2574,7 @@ pub(crate) extern "C" fn deliver_inventory_callback_bridge(status: ffi::pmix_sta
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = DELIVER_INVENTORY_REGISTRY.lock().unwrap();
+        let mut registry = DELIVER_INVENTORY_REGISTRY.lock();
         registry.remove(&req_id)
     };
     let cb = match cb {
@@ -2730,18 +2664,14 @@ pub fn server_deliver_inventory(
 ) -> Result<(), PmixStatus> {
     // If a callback is provided, register it for async completion.
     if let Some(cb) = callback {
-        let req_id = {
-            let mut seq = DELIVER_INVENTORY_SEQ.lock().unwrap();
-            *seq += 1;
-            *seq
-        };
+        let req_id = DELIVER_INVENTORY_REGISTRY.next_req_id();
 
         // SAFETY: We shift the request ID left by 2 bits to ensure cbdata
         // is never null (req_id starts at 1, so shifted value >= 4).
         let cbdata = crate::cbdata::encode_req_id(req_id);
 
         {
-            let mut registry = DELIVER_INVENTORY_REGISTRY.lock().unwrap();
+            let mut registry = DELIVER_INVENTORY_REGISTRY.lock();
             registry.insert(req_id, cb);
         }
 
@@ -2791,7 +2721,7 @@ pub fn server_deliver_inventory(
             Ok(())
         } else {
             // Request was rejected — remove the callback so it doesn't leak.
-            let mut registry = DELIVER_INVENTORY_REGISTRY.lock().unwrap();
+            let mut registry = DELIVER_INVENTORY_REGISTRY.lock();
             registry.remove(&req_id);
             Err(pmix_status)
         }

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -1,6 +1,7 @@
 //! Server submodule: pset
 
 use super::*;
+use crate::cbdata::Registry;
 use crate::threading::invoke_user_callback;
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
@@ -251,13 +252,9 @@ pub trait RegisterResourcesCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending register_resources callbacks.
-type RegisterResourcesRegistry =
-    std::collections::HashMap<usize, Box<dyn RegisterResourcesCallback>>;
-static REGISTER_RESOURCES_REGISTRY: LazyLock<Mutex<RegisterResourcesRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static REGISTER_RESOURCES_REGISTRY: LazyLock<Registry<Box<dyn RegisterResourcesCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing register_resources request ID counter.
-static REGISTER_RESOURCES_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (register_resources completion).
 ///
@@ -275,7 +272,7 @@ pub(crate) extern "C" fn register_resources_callback_bridge(status: ffi::pmix_st
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = REGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -349,13 +346,9 @@ pub fn server_register_resources(
     callback: Box<dyn RegisterResourcesCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = REGISTER_RESOURCES_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = REGISTER_RESOURCES_REGISTRY.next_req_id();
     {
-        let mut registry = REGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_RESOURCES_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -432,7 +425,7 @@ pub fn server_register_resources(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = REGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = REGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }
@@ -451,13 +444,9 @@ pub trait DeregisterResourcesCallback: Send {
 }
 
 /// Global registry mapping request IDs to pending deregister_resources callbacks.
-type DeregisterResourcesRegistry =
-    std::collections::HashMap<usize, Box<dyn DeregisterResourcesCallback>>;
-static DEREGISTER_RESOURCES_REGISTRY: LazyLock<Mutex<DeregisterResourcesRegistry>> =
-    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+static DEREGISTER_RESOURCES_REGISTRY: LazyLock<Registry<Box<dyn DeregisterResourcesCallback>>> =
+    LazyLock::new(Registry::new);
 
-/// Monotonically increasing deregister_resources request ID counter.
-static DEREGISTER_RESOURCES_SEQ: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
 
 /// C bridge for `pmix_op_cbfunc_t` (deregister_resources completion).
 ///
@@ -478,7 +467,7 @@ pub(crate) extern "C" fn deregister_resources_callback_bridge(
 
     // Look up and remove the callback from the registry.
     let cb = {
-        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id)
     };
 
@@ -552,13 +541,9 @@ pub fn server_deregister_resources(
     callback: Box<dyn DeregisterResourcesCallback>,
 ) -> Result<(), PmixStatus> {
     // Allocate a unique request ID and register the callback.
-    let req_id = {
-        let mut seq = DEREGISTER_RESOURCES_SEQ.lock().unwrap();
-        *seq += 1;
-        *seq
-    };
+    let req_id = DEREGISTER_RESOURCES_REGISTRY.next_req_id();
     {
-        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock();
         registry.insert(req_id, callback);
     }
 
@@ -635,7 +620,7 @@ pub fn server_deregister_resources(
     } else {
         // Immediate failure — remove the registered callback so it
         // will never be invoked.
-        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock().unwrap();
+        let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id);
         Err(pmix_status)
     }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -314,19 +314,13 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     // ── Registry and sequence ID tests ───────────────────────────────────────
 
-    #[test]
-    fn test_register_nspace_seq_is_accessible() {
-        let _seq = REGISTER_NS_SPACE_SEQ.lock().unwrap();
-    }
 
-    #[test]
-    fn test_deregister_nspace_seq_is_accessible() {
-        let _seq = DEREGISTER_NS_SPACE_SEQ.lock().unwrap();
-    }
+
+
 
     #[test]
     fn test_register_nspace_registry_is_empty() {
-        let registry = REGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let registry = REGISTER_NS_SPACE_REGISTRY.lock();
         assert!(
             registry.is_empty(),
             "Register nspace registry should be empty at test start"
@@ -335,7 +329,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[test]
     fn test_deregister_nspace_registry_is_empty() {
-        let registry = DEREGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+        let registry = DEREGISTER_NS_SPACE_REGISTRY.lock();
         assert!(
             registry.is_empty(),
             "Deregister nspace registry should be empty at test start"
@@ -385,7 +379,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: std::ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
@@ -559,41 +553,13 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     // ── Registry and sequence counter tests ────────────────────────────────
 
-    #[test]
-    fn test_register_nspace_seq_increments() {
-        let mut seq = REGISTER_NS_SPACE_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        let after = *seq;
-        assert_eq!(after, before + 1);
-    }
 
-    #[test]
-    fn test_deregister_nspace_seq_increments() {
-        let mut seq = DEREGISTER_NS_SPACE_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        let after = *seq;
-        assert_eq!(after, before + 1);
-    }
 
-    #[test]
-    fn test_register_client_seq_increments() {
-        let mut seq = REGISTER_CLIENT_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        let after = *seq;
-        assert_eq!(after, before + 1);
-    }
 
-    #[test]
-    fn test_deregister_client_seq_increments() {
-        let mut seq = DEREGISTER_CLIENT_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        let after = *seq;
-        assert_eq!(after, before + 1);
-    }
+
+
+
+
 
     // ── RegisterNspaceRegistry: insert and remove ──────────────────────────
 
@@ -605,7 +571,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         }
         let req_id = 99999;
         {
-            let mut registry = REGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+            let mut registry = REGISTER_NS_SPACE_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestRegCb));
             assert!(registry.contains_key(&req_id));
             let removed = registry.remove(&req_id);
@@ -624,7 +590,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         }
         let req_id = 99998;
         {
-            let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock().unwrap();
+            let mut registry = DEREGISTER_NS_SPACE_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestDeregCb));
             assert!(registry.contains_key(&req_id));
             let removed = registry.remove(&req_id);
@@ -643,7 +609,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         }
         let req_id = 99997;
         {
-            let mut registry = REGISTER_CLIENT_REGISTRY.lock().unwrap();
+            let mut registry = REGISTER_CLIENT_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestRegClientCb));
             assert!(registry.contains_key(&req_id));
             let removed = registry.remove(&req_id);
@@ -662,7 +628,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         }
         let req_id = 99996;
         {
-            let mut registry = DEREGISTER_CLIENT_REGISTRY.lock().unwrap();
+            let mut registry = DEREGISTER_CLIENT_REGISTRY.lock();
             registry.insert(req_id, Box::new(TestDeregClientCb));
             assert!(registry.contains_key(&req_id));
             let removed = registry.remove(&req_id);
@@ -960,7 +926,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
@@ -1087,7 +1053,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert_eq!(results.len(), 0);
@@ -1099,7 +1065,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         let debug_str = format!("{:?}", results);
@@ -1113,7 +1079,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: 0x1 as *mut ffi::pmix_info_t, // dummy non-null
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
@@ -1126,7 +1092,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         drop(results); // should be a no-op
@@ -1134,25 +1100,13 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     // ── CollectInventory seq & registry tests ──────────────────────────────
 
-    #[test]
-    fn test_collect_inventory_seq_is_accessible() {
-        // Verify the sequence counter is accessible.
-        let seq = COLLECT_INVENTORY_SEQ.lock().unwrap();
-        assert!(*seq >= 0);
-    }
 
-    #[test]
-    fn test_collect_inventory_seq_increments() {
-        let mut seq = COLLECT_INVENTORY_SEQ.lock().unwrap();
-        let before = *seq;
-        *seq += 1;
-        let after = *seq;
-        assert_eq!(after, before + 1);
-    }
+
+
 
     #[test]
     fn test_collect_inventory_registry_is_empty() {
-        let registry = COLLECT_INVENTORY_REGISTRY.lock().unwrap();
+        let registry = COLLECT_INVENTORY_REGISTRY.lock();
         // The registry may not be empty if other tests left entries,
         // but it should be accessible.
         let _len = registry.len();
@@ -1505,29 +1459,21 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     // ── Registry: register_client additional tests ─────────────────────────
 
-    #[test]
-    fn test_register_client_seq_is_accessible() {
-        let seq = REGISTER_CLIENT_SEQ.lock().unwrap();
-        assert!(*seq >= 0);
-    }
+
 
     #[test]
     fn test_register_client_registry_is_empty() {
-        let registry = REGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let registry = REGISTER_CLIENT_REGISTRY.lock();
         let _len = registry.len();
     }
 
     // ── Registry: deregister_client additional tests ───────────────────────
 
-    #[test]
-    fn test_deregister_client_seq_is_accessible() {
-        let seq = DEREGISTER_CLIENT_SEQ.lock().unwrap();
-        assert!(*seq >= 0);
-    }
+
 
     #[test]
     fn test_deregister_client_registry_is_empty() {
-        let registry = DEREGISTER_CLIENT_REGISTRY.lock().unwrap();
+        let registry = DEREGISTER_CLIENT_REGISTRY.lock();
         let _len = registry.len();
     }
 
@@ -1576,7 +1522,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         let results = CollectInventoryResults {
             handle: ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         boxed.on_complete(PmixStatus::from_raw(0), results);


### PR DESCRIPTION
Closes #386

## Summary

Replaces the crate's ~35 process-global `Mutex<usize>`/`Mutex<u64>` SEQ counters + `Mutex<HashMap>` registry pairs with a single atomic-backed `Registry<T>` (new in `src/cbdata.rs`):

- **Lock-free request-ID sequence**: `AtomicU64` + `compare_exchange_weak` (saturating, never 0), so allocating a request ID never takes the callback-map lock. An `_nb` op now pays ONE map lock acquisition instead of two (SEQ + map), and concurrent threads never serialize on the counter.
- **One-lock-per-op**: `Registry::insert_next(cb)` allocates the ID and inserts the callback under a single map lock; the failure path reuses the same registry (no third lock). Completion bridges are unchanged (`Registry::lock()` returns the same `MutexGuard<HashMap>` shape).
- **Correctness fix**: every former raw `*seq += 1` site (which could wrap to 0 → null cbdata) now goes through the saturating atomic path; `monitoring`'s `Mutex<u64>` split is unified with the common `usize` approach.
- **Stale comments removed**: the pre-`cbdata::encode_req_id` era "shift left by 2" comments in `src/data_ops/mod.rs` are gone.
- **Legacy helpers deleted**: `cbdata::next_req_id(&Mutex<usize>)`, `encode_req_id_u64`, `decode_req_id_u64` (and their tests) once the last callers were converted.

## Modules converted

`data_ops` (5 pairs), `groups` (5), `process_mgmt` (3), `query_log` (2), `security` (3), `allocation` (3), `monitoring` (1), `server/data.rs` (3), `server/pset.rs` (2), `server/mod.rs` (10). Utility IOF's registry has no sequence and was left unchanged.

## Test plan

- Full local lib suite (mock FFI, no daemon): 1820 passed, 0 failed.
- New `cbdata::Registry` unit tests: ID sequence starts at 1 and never returns 0; `insert_next`/`remove` round-trip; 8-thread concurrent uniqueness (800 unique IDs).
- All existing `_nb` tests across converted modules pass unchanged; obsolete `*_seq_increments` tests (which asserted the removed Mutex counters) were deleted.
- Daemon/DVM tests remain CI-only.