### PR TITLE
fix(info): InfoBuilder::build returns Result<Info, PmixStatus> instead of panicking

### DIFF
--- a/examples/external_progress_mt.rs
+++ b/examples/external_progress_mt.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let mut opts = pmix::InitOptions::new();
     opts.external_progress(true);
-    let info = opts.build();
+    let info = opts.build().expect("build info");
     eprintln!("connecting...");
     let client = pmix::PmixClient::connect_new(Some(info)).expect("connect");
     eprintln!("connected rank={:?}", client.rank());

--- a/examples/server_minimal.rs
+++ b/examples/server_minimal.rs
@@ -14,7 +14,7 @@ fn main() {
     println!("pmix-rs server_minimal");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     let server = match PmixServer::connect_new(Some(&module), &info) {
         Ok(s) => s,

--- a/examples/server_upcall_hop.rs
+++ b/examples/server_upcall_hop.rs
@@ -59,7 +59,7 @@ fn main() {
     module.fence_nb = Some(host_fence_nb);
     module.direct_modex = Some(host_direct_modex);
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let server = match PmixServer::connect_new(Some(&module), &info) {
         Ok(s) => s,
         Err(e) => {

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -1811,7 +1811,7 @@ use super::*;
     fn test_publish_error_path_with_mock() {
         let config = MockConfig::new().with_function_status("PMIx_Publish", PMIX_ERR_INIT);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 let err = publish(&info).expect_err("publish should fail under mock ErrInit");
                 assert_eq!(err, PmixStatus::Known(PmixError::ErrInit));
     }
@@ -1822,7 +1822,7 @@ use super::*;
         let config =
                     MockConfig::new().with_function_status("PMIx_Publish", PMIX_ERR_DUPLICATE_KEY);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 let err = publish(&info).expect_err("publish should fail under mock duplicate");
                 assert_eq!(err, PmixStatus::Known(PmixError::ErrDuplicateKey));
     }
@@ -2076,7 +2076,7 @@ use super::*;
         let proc = Proc::new("mock.ns", 0).unwrap();
         let mut builder = InfoBuilder::new();
         builder.add_string_key("pmix.qual.val", "true", PMIX_STRING as _);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
 
         let result = get_nb(&proc, "qualified.key", Some(&info), Box::new(DummyGet));
 
@@ -2293,7 +2293,7 @@ use super::*;
     #[test]
     fn test_mock_publish_get_unpublish_lifecycle() {
         let _guard = MockGuard::new();
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).expect("publish");
                 let proc = Proc::new("mock.ns", 0).unwrap();
                 let _ = get(&proc, "lifecycle", None).expect("get");
@@ -2309,7 +2309,7 @@ use super::*;
                     .with_function_status("PMIx_Fence", PMIX_ERR_TIMEOUT)
                     .with_function_status("PMIx_Unpublish", PMIX_ERR_INIT);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 assert!(matches!(
                     publish(&info),
                     Err(PmixStatus::Known(PmixError::ErrDuplicateKey))
@@ -2825,7 +2825,7 @@ use super::*;
     #[test]
     fn test_mock_publish_raw_success_conversion() {
         let _guard = MockGuard::new();
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).expect("publish success under mock");
     }
 
@@ -2834,7 +2834,7 @@ use super::*;
     fn test_mock_publish_error_result() {
         let config = MockConfig::new().with_function_status("PMIx_Publish", PMIX_ERROR);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 let err = publish(&info).unwrap_err();
                 assert_eq!(err, PmixStatus::Known(PmixError::Error));
     }
@@ -2844,7 +2844,7 @@ use super::*;
     fn test_mock_publish_timeout_error() {
         let config = MockConfig::new().with_function_status("PMIx_Publish", PMIX_ERR_TIMEOUT);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 assert_eq!(
                     publish(&info).unwrap_err(),
                     PmixStatus::Known(PmixError::ErrTimeout)
@@ -2856,7 +2856,7 @@ use super::*;
     fn test_mock_publish_stores_key_in_mock_store() {
         let _guard = MockGuard::new();
                 // Wrapper path: publish success; store is separate helper used by store_internal mock.
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).expect("publish");
                 mock_ffi::mock_store_value("pub.key", b"v", PMIX_STRING);
                 assert!(mock_ffi::mock_key_exists("pub.key"));
@@ -3290,7 +3290,7 @@ use super::*;
     fn test_mock_fence_procs_and_info() {
         let _guard = MockGuard::new();
                 let proc = Proc::new("f", 0).unwrap();
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 crate::fence(&proc, Some(info)).expect("fence with info");
     }
 
@@ -3523,7 +3523,7 @@ use super::*;
     #[test]
     fn test_mock_full_publish_get_unpublish_workflow() {
         let _guard = MockGuard::new();
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).unwrap();
                 let proc = Proc::new("wf", 0).unwrap();
                 let _v = get(&proc, "wf.key", None).unwrap();
@@ -3535,7 +3535,7 @@ use super::*;
     fn test_mock_error_workflow_all_fail() {
         let config = MockConfig::new().with_default_status(PMIX_ERR_INIT);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 assert!(publish(&info).is_err());
                 let proc = Proc::new("wf", 0).unwrap();
                 assert!(get(&proc, "k", None).is_err());
@@ -3585,7 +3585,7 @@ use super::*;
                     .with_function_status("PMIx_Publish", PMIX_SUCCESS)
                     .with_function_status("PMIx_Get", PMIX_ERR_NOT_FOUND);
                 let _guard = MockGuard::with_config(config);
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).unwrap();
                 let proc = Proc::new("m", 0).unwrap();
                 assert!(get(&proc, "x", None).is_err());
@@ -3734,7 +3734,7 @@ use super::*;
     #[test]
     fn test_mock_operation_cycle_status_checks() {
         let _guard = MockGuard::new();
-                let info = InfoBuilder::new().build();
+                let info = InfoBuilder::new().build().expect("build info");
                 publish(&info).unwrap();
                 let proc = Proc::new("c", 0).unwrap();
                 let _ = get(&proc, "k", None).unwrap();
@@ -3914,12 +3914,12 @@ use super::*;
         {
                     let config = MockConfig::new().with_function_status("PMIx_Publish", PMIX_ERR_INIT);
                     let _guard = MockGuard::with_config(config);
-                    let info = InfoBuilder::new().build();
+                    let info = InfoBuilder::new().build().expect("build info");
                     assert!(publish(&info).is_err());
                 }
                 {
                     let _guard = MockGuard::new();
-                    let info = InfoBuilder::new().build();
+                    let info = InfoBuilder::new().build().expect("build info");
                     publish(&info).unwrap();
                 }
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -41,7 +41,7 @@
 //!
 //! // Register a handler for job-abort events
 //! let codes = [pmix::PmixStatus::Known(pmix::PmixError::ErrJobAborted)];
-//! let info = InfoBuilder::new().build();
+//! let info = InfoBuilder::new().build().expect("build info");
 //! let handler_ref = register_event_handler(
 //!     &codes,
 //!     &info,

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -2223,7 +2223,7 @@ mod tests {
         // Create a dummy Info directive using InfoBuilder.
         let mut builder = crate::InfoBuilder::new();
         builder.collect_data();
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         let result = fabric_register(&mut fabric, &[info]);
         // Without PMIx server, expect error — but no crash.
         if let Ok(()) = result {
@@ -2322,7 +2322,7 @@ mod tests {
         let mut fabric = PmixFabric::new(Some("test_fabric")).unwrap();
         let mut builder = crate::InfoBuilder::new();
         builder.collect_data();
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         let result = fabric_register(&mut fabric, &[info]);
         assert!(result.is_ok());
         assert!(fabric.is_registered());

--- a/src/info.rs
+++ b/src/info.rs
@@ -6,14 +6,14 @@ pub use crate::{Info, InfoBuilder, InfoFlags, PmixStatus, info_with_string_key};
 
 /// Create an empty `Info` list (length 0).
 pub fn empty() -> Info {
-    InfoBuilder::new().build()
+    InfoBuilder::new().build().expect("build info")
 }
 
 /// Info list with `PMIX_COLLECT_DATA` set (common fence/get pattern).
 pub fn with_collect_data() -> Info {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    builder.build()
+    builder.build().expect("build info")
 }
 
 /// Single string key/value info entry (no 13-byte key limit).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3443,7 +3443,8 @@ impl InitOptions {
 
     /// Build an [`Info`] array from the configured options.
     ///
-    /// Returns an [`Info`] suitable for passing to [`init`].
+    /// Returns `Ok([`Info`])` suitable for passing to [`init`], or
+    /// `Err(PmixStatus)` if the info array cannot be allocated or loaded.
     /// Unset options are simply omitted from the resulting array.
     pub fn build(&self) -> Result<Info, PmixStatus> {
         let mut builder = InfoBuilder::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3254,11 +3254,12 @@ impl InfoBuilder {
         // would dangle by `build()`. Use bool_infos for correct lifetime.
         self.add_bool_key("pmix.collect", true)
     }
-    pub fn build(self) -> Info {
+    pub fn build(self) -> Result<Info, PmixStatus> {
         let n = self.infos.len() + self.string_infos.len() + self.bool_infos.len();
+        // SAFETY: PMIx allocates an array of `n` initialized info records.
         let info_ptr = unsafe { PMIx_Info_create(n) };
         if info_ptr.is_null() && n > 0 {
-            panic!("PMIx_Info_create({n}) returned null");
+            return Err(PmixStatus::from_raw(ffi::PMIX_ERR_NOMEM));
         }
         let mut idx: usize = 0;
 
@@ -3276,7 +3277,7 @@ impl InfoBuilder {
                 unsafe {
                     PMIx_Info_free(info_ptr, n);
                 }
-                panic!("Error loading info: {}", status);
+                return Err(PmixStatus::from_raw(status));
             }
             idx += 1;
         }
@@ -3295,7 +3296,7 @@ impl InfoBuilder {
                 unsafe {
                     PMIx_Info_free(info_ptr, n);
                 }
-                panic!("Error loading string-key info: {}", status);
+                return Err(PmixStatus::from_raw(status));
             }
             idx += 1;
         }
@@ -3314,16 +3315,16 @@ impl InfoBuilder {
                 unsafe {
                     PMIx_Info_free(info_ptr, n);
                 }
-                panic!("Error loading bool-key info: {}", status);
+                return Err(PmixStatus::from_raw(status));
             }
             idx += 1;
         }
 
-        Info {
+        Ok(Info {
             handle: info_ptr,
             len: idx,
             _not_thread_safe: std::marker::PhantomData,
-        }
+        })
     }
 }
 
@@ -3346,7 +3347,7 @@ impl InfoBuilder {
 /// options.external_progress(true);
 /// options.bind_progress_thread("0-3");
 ///
-/// let info = options.build();
+/// let info = options.build().expect("build info");
 /// let handle = pmix::init(None, None, info)?;
 /// ```
 ///
@@ -3444,7 +3445,7 @@ impl InitOptions {
     ///
     /// Returns an [`Info`] suitable for passing to [`init`].
     /// Unset options are simply omitted from the resulting array.
-    pub fn build(&self) -> Info {
+    pub fn build(&self) -> Result<Info, PmixStatus> {
         let mut builder = InfoBuilder::new();
 
         if let Some(external) = self.external_progress {
@@ -4080,7 +4081,7 @@ mod tests {
     #[test]
     fn test_info_drop_does_not_panic() {
         // Building and dropping Info must free via PMIx_Info_free without panic.
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         assert_eq!(info.len(), 0);
         drop(info);
         let info2 = info_with_string_key("pmix.srvr.uri", "tcp://127.0.0.1:1");
@@ -4091,7 +4092,7 @@ mod tests {
 
     #[test]
     fn test_info_into_raw_skips_drop_free() {
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let (ptr, len) = info.into_raw();
         // We own the pointer now — free explicitly so this test does not leak.
         if !ptr.is_null() {
@@ -5419,7 +5420,7 @@ mod tests {
     fn test_infobuilder_external_progress() {
         let mut builder = InfoBuilder::new();
         builder.external_progress(true);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5427,7 +5428,7 @@ mod tests {
     fn test_infobuilder_bind_progress_thread() {
         let mut builder = InfoBuilder::new();
         builder.bind_progress_thread("0-3");
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5435,7 +5436,7 @@ mod tests {
     fn test_infobuilder_bind_required() {
         let mut builder = InfoBuilder::new();
         builder.bind_required(true);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5445,7 +5446,7 @@ mod tests {
         builder.external_progress(true);
         builder.bind_progress_thread("4,5,6,7");
         builder.bind_required(false);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 3);
     }
 
@@ -5459,7 +5460,7 @@ mod tests {
             PMIX_BOOL as pmix_data_type_t,
         );
         builder.external_progress(true);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 2);
     }
 
@@ -5469,7 +5470,7 @@ mod tests {
 
     #[test]
     fn test_initoptions_empty() {
-        let info = InitOptions::new().build();
+        let info = InitOptions::new().build().expect("build info");
         assert_eq!(info.len(), 0);
     }
 
@@ -5477,7 +5478,7 @@ mod tests {
     fn test_initoptions_external_progress() {
         let mut opts = InitOptions::new();
         opts.external_progress(true);
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5485,7 +5486,7 @@ mod tests {
     fn test_initoptions_bind_progress_thread() {
         let mut opts = InitOptions::new();
         opts.bind_progress_thread("0-7");
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5493,7 +5494,7 @@ mod tests {
     fn test_initoptions_bind_required() {
         let mut opts = InitOptions::new();
         opts.bind_required(true);
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5503,7 +5504,7 @@ mod tests {
         opts.external_progress(true);
         opts.bind_progress_thread("0-3");
         opts.bind_required(true);
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 3);
     }
 
@@ -5512,7 +5513,7 @@ mod tests {
         // Only set bind_required, others should be omitted
         let mut opts = InitOptions::new();
         opts.bind_required(false);
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5520,7 +5521,7 @@ mod tests {
     fn test_infobuilder_progress_thread_flush() {
         let mut builder = InfoBuilder::new();
         builder.progress_thread_flush(true);
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5528,7 +5529,7 @@ mod tests {
     fn test_infobuilder_progress_thread_name() {
         let mut builder = InfoBuilder::new();
         builder.progress_thread_name("my-progress-thread");
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5536,7 +5537,7 @@ mod tests {
     fn test_initoptions_progress_thread_flush() {
         let mut opts = InitOptions::new();
         opts.progress_thread_flush(true);
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5544,7 +5545,7 @@ mod tests {
     fn test_initoptions_progress_thread_name() {
         let mut opts = InitOptions::new();
         opts.progress_thread_name("test-progress");
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         assert_eq!(info.len(), 1);
     }
 
@@ -5556,7 +5557,7 @@ mod tests {
         opts.bind_required(true);
         opts.progress_thread_flush(true);
         opts.progress_thread_name("full-test");
-        let info = opts.build();
+        let info = opts.build().expect("build info");
         // 5 options set
         assert_eq!(info.len(), 5);
     }

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -630,7 +630,7 @@ mod tests {
     #[test]
     fn test_process_monitor_with_success_error_code() {
         use crate::InfoBuilder;
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         let _ = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
     }
 
@@ -639,7 +639,7 @@ mod tests {
     fn test_heartbeat_and_process_monitor_coexist() {
         use crate::InfoBuilder;
         let _ = heartbeat();
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         let _ = process_monitor(&monitor, PmixStatus::from_raw(-109), &[]);
         let _ = heartbeat();
     }
@@ -686,7 +686,7 @@ mod tests {
     #[test]
     fn test_infobuilder_for_monitoring() {
         use crate::InfoBuilder;
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         assert!(info.is_empty());
         assert_eq!(info.len(), 0);
     }
@@ -800,7 +800,7 @@ mod tests {
     #[test]
     fn test_process_monitor_fails_without_init() {
         use crate::InfoBuilder;
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         let result = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
         assert!(
             result.is_err(),
@@ -815,7 +815,7 @@ mod tests {
     #[test]
     fn test_process_monitor_with_partial_success() {
         use crate::{InfoBuilder, PmixError};
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         // Partial success is treated as success by the wrapper — but without init,
         // the FFI call itself will fail, so we get an error.
         let result = process_monitor(
@@ -835,7 +835,7 @@ mod tests {
         use crate::InfoBuilder;
         let mut builder = InfoBuilder::new();
         builder.collect_data();
-        let monitor = builder.build();
+        let monitor = builder.build().expect("build info");
         assert!(!monitor.is_empty(), "collect_data should add an entry");
         let result = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
         assert!(result.is_err(), "should fail without PMIx_Init");
@@ -847,7 +847,7 @@ mod tests {
         use crate::InfoBuilder;
         let mut builder = InfoBuilder::new();
         builder.collect_data();
-        let monitor = builder.build();
+        let monitor = builder.build().expect("build info");
         assert_eq!(monitor.len(), 1);
         let _ = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
     }
@@ -856,7 +856,7 @@ mod tests {
     #[test]
     fn test_process_monitor_empty_monitor_zero_directives() {
         use crate::InfoBuilder;
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         assert!(monitor.is_empty());
         let result = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
         assert!(result.is_err());
@@ -870,10 +870,10 @@ mod tests {
         impl MonitorCallback for NoopCb {
             fn on_complete(&mut self, _: PmixStatus, _: Option<MonitorResults>) {}
         }
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         let mut dir_builder = InfoBuilder::new();
         dir_builder.collect_data();
-        let dirs = vec![dir_builder.build()];
+        let dirs = vec![dir_builder.build().expect("build info")];
         let result = process_monitor_nb(&monitor, PmixStatus::from_raw(0), &dirs, Box::new(NoopCb));
         assert!(result.is_err(), "should fail without PMIx_Init");
     }
@@ -886,7 +886,7 @@ mod tests {
             fn on_complete(&mut self, _: PmixStatus, _: Option<MonitorResults>) {}
         }
         use crate::InfoBuilder;
-        let monitor = InfoBuilder::new().build();
+        let monitor = InfoBuilder::new().build().expect("build info");
         let result = process_monitor_nb(
             &monitor,
             PmixStatus::Unknown(-109), // PMIX_MONITOR_HEARTBEAT_ALERT
@@ -936,7 +936,7 @@ mod tests {
         use crate::InfoBuilder;
         let mut builder = InfoBuilder::new();
         builder.collect_data();
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         assert!(!info.is_empty());
         assert_eq!(info.len(), 1);
     }
@@ -984,7 +984,7 @@ mod tests {
         use crate::InfoBuilder;
         for _ in 0..5 {
             let _ = heartbeat();
-            let monitor = InfoBuilder::new().build();
+            let monitor = InfoBuilder::new().build().expect("build info");
             let _ = process_monitor(&monitor, PmixStatus::from_raw(0), &[]);
             let _ = heartbeat();
         }

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -36,18 +36,18 @@
 //!     .maxprocs(4)
 //!     .build()
 //!     .expect("valid app");
-//! let job_info = vec![InfoBuilder::new().build()];
+//! let job_info = vec![InfoBuilder::new().build().expect("build info")];
 //! let result = spawn(&job_info, &[app]);
 //! // result is Ok(nspace) on success
 //!
 //! // Connect to a namespace
 //! let target = Proc::new("target_namespace", RANK_WILDCARD)
 //!     .expect("valid proc");
-//! let connect_info = InfoBuilder::new().build();
+//! let connect_info = InfoBuilder::new().build().expect("build info");
 //! let result = connect(&[target.clone()], &[connect_info]);
 //!
 //! // Disconnect from a previously connected set
-//! let disconnect_info = InfoBuilder::new().build();
+//! let disconnect_info = InfoBuilder::new().build().expect("build info");
 //! let result = disconnect(&[target], &[disconnect_info]);
 //! ```
 
@@ -1834,7 +1834,7 @@ mod tests {
     #[test]
     fn test_spawn_with_job_info_and_empty_apps() {
         // Even with job_info, empty apps should fail
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let result = spawn(&info, &[]);
         assert!(result.is_err());
         if let Err(status) = result {
@@ -1881,7 +1881,7 @@ mod tests {
 
     #[test]
     fn test_spawn_nb_with_job_info_and_empty_apps() {
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let wrapper = SpawnCallbackWrapper::new(|_, _| {});
         let result = spawn_nb(&info, &[], wrapper);
         assert!(result.is_err());
@@ -1943,7 +1943,7 @@ mod tests {
     #[test]
     fn test_connect_with_info() {
         let proc = crate::Proc::new("test_ns", 0).unwrap();
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let result = connect(&[proc], &info);
         assert!(result.is_err());
         if let Err(status) = result {
@@ -2000,7 +2000,7 @@ mod tests {
     #[test]
     fn test_disconnect_with_info() {
         let proc = crate::Proc::new("test_ns", 0).unwrap();
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let result = disconnect(&[proc], &info);
         assert!(result.is_err());
         if let Err(status) = result {
@@ -2036,7 +2036,7 @@ mod tests {
     #[test]
     fn test_connect_nb_with_info() {
         let proc = crate::Proc::new("test_ns", 0).unwrap();
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let wrapper = ConnectCallbackWrapper::new(|_| {});
         let result = connect_nb(&[proc], &info, wrapper);
         assert!(result.is_err());
@@ -2077,7 +2077,7 @@ mod tests {
     #[ignore] // Requires DVM — PMIx_Disconnect_nb segfaults without init
     fn test_disconnect_nb_with_info() {
         let proc = crate::Proc::new("test_ns", 0).unwrap();
-        let info = vec![crate::InfoBuilder::new().build()];
+        let info = vec![crate::InfoBuilder::new().build().expect("build info")];
         let wrapper = DisconnectCallbackWrapper::new(|_| {});
         let result = disconnect_nb(&[proc], &info, wrapper);
         assert!(result.is_err());

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -820,7 +820,7 @@ mod tests {
     #[test]
     fn test_pmix_query_with_qualifiers() {
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
-        let query = query.with_qualifiers(crate::InfoBuilder::new().build());
+        let query = query.with_qualifiers(crate::InfoBuilder::new().build().expect("build info"));
         assert!(!query._keys.is_empty());
     }
 
@@ -829,7 +829,7 @@ mod tests {
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
         let mut builder = crate::InfoBuilder::new();
         builder.collect_data();
-        let info = builder.build();
+        let info = builder.build().expect("build info");
         let query = query.with_qualifiers(info);
         assert!(!query._keys.is_empty());
     }
@@ -844,7 +844,7 @@ mod tests {
     #[test]
     fn test_pmix_query_drop_after_with_qualifiers() {
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let _query = query.with_qualifiers(info);
     }
 
@@ -1115,7 +1115,7 @@ mod tests {
 
     #[test]
     fn test_log_data_with_empty_info() {
-        let data = vec![crate::InfoBuilder::new().build()];
+        let data = vec![crate::InfoBuilder::new().build().expect("build info")];
         let directives = vec![];
         let result = log_data(&data, &directives);
         assert!(result.is_ok() || result.is_err());
@@ -1413,7 +1413,7 @@ mod tests {
     #[test]
     fn test_pmix_query_with_multiple_qualifier_calls() {
         let query = PmixQuery::new(&["PMIX_QUERY_JOB_SIZE"]).unwrap();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let _query = query.with_qualifiers(info);
     }
 
@@ -1508,7 +1508,7 @@ mod tests {
 
     #[test]
     fn test_info_builder_empty_for_log() {
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         assert!(info.is_empty());
         assert_eq!(info.len(), 0);
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,7 +19,7 @@
 //! use pmix::InfoBuilder;
 //!
 //! let module = PmixServerModule::default();
-//! let server = PmixServer::connect_new(Some(&module), &InfoBuilder::new().build())
+//! let server = PmixServer::connect_new(Some(&module), &InfoBuilder::new().build().expect("build info"))
 //!     .expect("server connect");
 //! // Clone is cheap (Arc); Drop does **not** finalize.
 //! let worker = server.clone();
@@ -437,7 +437,7 @@ pub use session::PmixServerHandle;
 /// use pmix::InfoBuilder;;
 ///
 /// let module = PmixServerModule::default();
-/// let handle = server_init(Some(&module), &InfoBuilder::new().build()).expect("server_init failed");
+/// let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info")).expect("server_init failed");
 /// server_finalize(handle).expect("server_finalize failed");
 /// ```
 pub fn server_init(
@@ -505,7 +505,7 @@ pub fn server_init_minimal(
 /// use pmix::InfoBuilder;;
 ///
 /// let module = PmixServerModule::default();
-/// let handle = server_init(Some(&module), &InfoBuilder::new().build()).expect("server_init failed");
+/// let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info")).expect("server_init failed");
 /// server_finalize(handle).expect("server_finalize failed");
 /// ```
 pub fn server_finalize(handle: PmixServerHandle) -> Result<(), PmixStatus> {
@@ -624,9 +624,9 @@ pub(crate) extern "C" fn register_nspace_callback_bridge(status: ffi::pmix_statu
 /// }
 ///
 /// let module = PmixServerModule::default();
-/// let _handle = server_init(Some(&module), &InfoBuilder::new().build()).expect("server_init failed");
+/// let _handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info")).expect("server_init failed");
 ///
-/// server_register_nspace("myjob.12345", 4, &InfoBuilder::new().build(), Box::new(MyNspaceCallback))
+/// server_register_nspace("myjob.12345", 4, &InfoBuilder::new().build().expect("build info"), Box::new(MyNspaceCallback))
 ///     .expect("register_nspace request rejected");
 /// ```
 pub fn server_register_nspace(
@@ -713,7 +713,7 @@ pub fn server_register_nspace(
 /// assert!(!is_server_initialized());
 ///
 /// let module = PmixServerModule::default();
-/// let handle = server_init(Some(&module), &InfoBuilder::new().build()).expect("server_init failed");
+/// let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info")).expect("server_init failed");
 /// assert!(is_server_initialized());
 ///
 /// server_finalize(handle).expect("server_finalize failed");
@@ -1244,7 +1244,7 @@ pub fn server_deregister_client(proc: &Proc, callback: Option<Box<dyn Deregister
 /// use pmix::Proc;
 ///
 /// let module = PmixServerModule::default();
-/// let _handle = server_init(Some(&module), &InfoBuilder::new().build()).expect("server_init failed");
+/// let _handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info")).expect("server_init failed");
 ///
 /// let proc = Proc::new("myjob.12345", 0).expect("proc creation failed");
 /// let env = server_setup_fork(&proc, None).expect("setup_fork failed");
@@ -1795,7 +1795,7 @@ pub(crate) extern "C" fn setup_application_callback_bridge(
 /// }
 ///
 /// // After registering the namespace...
-/// server_setup_application("myapp.ns", &InfoBuilder::new().build(), Box::new(MySetupCallback))
+/// server_setup_application("myapp.ns", &InfoBuilder::new().build().expect("build info"), Box::new(MySetupCallback))
 ///     .expect("setup_application rejected");
 /// ```
 pub fn server_setup_application(
@@ -1977,7 +1977,7 @@ pub(crate) extern "C" fn setup_local_support_callback_bridge(status: ffi::pmix_s
 /// // Setup local support for a namespace
 /// server_setup_local_support(
 ///     "myapp.12345",
-///     &InfoBuilder::new().build(),
+///     &InfoBuilder::new().build().expect("build info"),
 ///     Box::new(MySetupLocalCallback),
 /// )
 /// .expect("setup_local_support rejected");
@@ -2198,7 +2198,7 @@ pub(crate) extern "C" fn iof_deliver_callback_bridge(status: ffi::pmix_status_t,
 ///     &source,
 ///     channel,
 ///     &data,
-///     &InfoBuilder::new().build(),
+///     &InfoBuilder::new().build().expect("build info"),
 ///     Box::new(MyIOFCallback),
 /// ).expect("IOF_deliver rejected");
 /// ```
@@ -2454,7 +2454,7 @@ pub(crate) extern "C" fn collect_inventory_callback_bridge(
 ///     }
 /// }
 ///
-/// let directives = InfoBuilder::new().build();
+/// let directives = InfoBuilder::new().build().expect("build info");
 /// server_collect_inventory(
 ///     &directives,
 ///     Box::new(MyInventoryCallback),
@@ -2649,8 +2649,8 @@ pub(crate) extern "C" fn deliver_inventory_callback_bridge(status: ffi::pmix_sta
 ///     }
 /// }
 ///
-/// let inventory = InfoBuilder::new().build();
-/// let directives = InfoBuilder::new().build();
+/// let inventory = InfoBuilder::new().build().expect("build info");
+/// let directives = InfoBuilder::new().build().expect("build info");
 /// server_deliver_inventory(
 ///     &inventory,
 ///     &directives,

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -337,7 +337,7 @@ pub(crate) extern "C" fn register_resources_callback_bridge(status: ffi::pmix_st
 /// }
 ///
 /// // Register with no info keys (e.g., to clear previous registration)
-/// let info = InfoBuilder::new().build();
+/// let info = InfoBuilder::new().build().expect("build info");
 /// server_register_resources(&info, Box::new(MyResourceCallback))
 ///     .expect("register_resources request rejected");
 /// ```
@@ -532,7 +532,7 @@ pub(crate) extern "C" fn deregister_resources_callback_bridge(
 /// }
 ///
 /// // Deregister all previously registered non-namespace resources
-/// let info = InfoBuilder::new().build();
+/// let info = InfoBuilder::new().build().expect("build info");
 /// server_deregister_resources(&info, Box::new(MyResourceCallback))
 ///     .expect("deregister_resources request rejected");
 /// ```

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -973,7 +973,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterNspaceCallback for DummyRegCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_register_nspace("test\0nspace", 1, &info, Box::new(DummyRegCb));
         assert!(
             result.is_err(),
@@ -1194,7 +1194,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_server_publish_empty_info() {
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_publish(&handle, "testnspace", &info);
         let _ = result;
     }
@@ -1357,7 +1357,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_server_connect_rejects_empty_procs_with_info() {
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_connect(&handle, &[], &[info]);
         assert!(result.is_err());
     }
@@ -1365,7 +1365,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[test]
     fn test_server_disconnect_rejects_empty_procs_with_info() {
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_disconnect(&handle, &[], &[info]);
         assert!(result.is_err());
     }
@@ -1378,7 +1378,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterNspaceCallback for DummyRegCb2 {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         // Empty string is valid for CString but may fail on FFi.
         // We just verify it doesn't panic.
         let result = server_register_nspace("", 1, &info, Box::new(DummyRegCb2));
@@ -1391,7 +1391,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterNspaceCallback for DummyRegCb3 {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         // Negative nlocalprocs — FFi may reject or accept.
         // We just verify no panic.
         let result = server_register_nspace("test", -1, &info, Box::new(DummyRegCb3));
@@ -1404,7 +1404,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterNspaceCallback for DummyRegCb4 {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_register_nspace("test", 0, &info, Box::new(DummyRegCb4));
         let _ = result;
     }
@@ -2487,7 +2487,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     fn test_mock_wrapper_server_publish_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_publish(&handle, "test.nspace", &info);
         assert!(result.is_ok(), "server_publish wrapper should succeed with mocks");
     }
@@ -2498,7 +2498,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
             .with_function_status("PMIx_server_publish", crate::mock_ffi::PMIX_ERR_NOT_FOUND);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_publish(&handle, "test.nspace", &info);
         assert!(result.is_err(), "server_publish wrapper should fail with configured error");
     }
@@ -2661,7 +2661,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterResourcesCallback for TestResCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let cb = Box::new(TestResCb {});
         let result = server_register_resources(&info, cb);
         assert!(result.is_ok(), "server_register_resources wrapper should succeed with mocks");
@@ -2676,7 +2676,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl RegisterResourcesCallback for TestResCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let cb = Box::new(TestResCb {});
         let result = server_register_resources(&info, cb);
         assert!(result.is_err(), "server_register_resources should fail with configured error");
@@ -2689,7 +2689,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl DeregisterResourcesCallback for TestDeregResCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let cb = Box::new(TestDeregResCb {});
         let result = server_deregister_resources(&info, cb);
         assert!(result.is_ok(), "server_deregister_resources wrapper should succeed with mocks");
@@ -2704,7 +2704,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         impl DeregisterResourcesCallback for TestDeregResCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let cb = Box::new(TestDeregResCb {});
         let result = server_deregister_resources(&info, cb);
         assert!(result.is_err(), "server_deregister_resources should fail with configured error");
@@ -2714,7 +2714,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     fn test_mock_wrapper_server_tool_attach_returns_success() {
         let _guard = crate::mock_ffi::MockGuard::new();
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_tool_attach_to_server(&handle, None, false, &info);
         assert!(result.is_ok(), "server_tool_attach_to_server wrapper should succeed with mocks");
     }
@@ -2725,7 +2725,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
             .with_function_status("PMIx_server_tool_attach_to_server", crate::mock_ffi::PMIX_ERR_BAD_PARAM);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
         let handle = PmixServer::new();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = server_tool_attach_to_server(&handle, None, false, &info);
         assert!(result.is_err(), "server_tool_attach_to_server should fail with configured error");
     }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -21,7 +21,7 @@
 //! use pmix::tool::PmixTool;
 //! use pmix::InfoBuilder;
 //!
-//! let info = InfoBuilder::new().build();
+//! let info = InfoBuilder::new().build().expect("build info");
 //! let tool = PmixTool::connect_new(None, &info).expect("tool connect");
 //! let proc = tool.require_proc();
 //! println!("Tool nspace: {:?}, rank: {:?}", proc.nspace(), proc.rank());
@@ -325,7 +325,7 @@ pub fn is_tool_initialized() -> bool {
 /// use pmix::tool::{tool_init, tool_finalize, PmixToolHandle};
 /// use pmix::InfoBuilder;
 ///
-/// let info = InfoBuilder::new().build();
+/// let info = InfoBuilder::new().build().expect("build info");
 /// let handle = tool_init(None, &info).expect("tool_init failed");
 /// println!("Tool identity: nspace={:?}, rank={:?} ",
 ///           handle.proc().as_ref().and_then(|p| p.nspace()), handle.rank().unwrap_or(0));
@@ -510,11 +510,11 @@ impl PmixServerHandle {
 /// use pmix::InfoBuilder;
 ///
 /// // Initialize the tool first
-/// let handle = tool_init(None, &InfoBuilder::new().build())
+/// let handle = tool_init(None, &InfoBuilder::new().build().expect("build info"))
 ///     .expect("tool_init failed");
 ///
 /// // Attach to a specific server (requires a PMIx server running)
-/// // let info = InfoBuilder::new().build(); // with PMIX_SERVER_URI etc.
+/// // let info = InfoBuilder::new().build().expect("build info"); // with PMIX_SERVER_URI etc.
 /// // let result = tool_attach_to_server(Some(handle.proc()), true, &info);
 ///
 /// tool_finalize(handle).expect("tool_finalize failed");
@@ -636,11 +636,11 @@ pub fn tool_attach_to_server(
 /// use pmix::InfoBuilder;
 ///
 /// // Initialize the tool
-/// let handle = tool_init(None, &InfoBuilder::new().build())
+/// let handle = tool_init(None, &InfoBuilder::new().build().expect("build info"))
 ///     .expect("tool_init failed");
 ///
 /// // Attach to a server (requires a running PMIx server)
-/// // let info = InfoBuilder::new().build();
+/// // let info = InfoBuilder::new().build().expect("build info");
 /// // let (_, server) = tool_attach_to_server(Some(handle.proc()), true, &info)?;
 /// // if let Some(s) = server {
 /// //     // Disconnect from that server
@@ -709,7 +709,7 @@ pub fn tool_disconnect(server: &Proc) -> Result<(), PmixStatus> {
 /// let handle = tool_init_minimal().expect("tool_init failed");
 ///
 /// // Connect to a server
-/// let info = InfoBuilder::new().build();
+/// let info = InfoBuilder::new().build().expect("build info");
 /// let conn = tool_connect_to_server(None, &info).expect("connect failed");
 ///
 /// tool_finalize(handle).expect("tool_finalize failed");
@@ -871,10 +871,10 @@ pub fn tool_get_servers() -> Result<Vec<Proc>, PmixStatus> {
 /// let handle = tool_init_minimal().expect("tool_init failed");
 ///
 /// // Attach to a server (requires a running PMIx server)
-/// // let info = InfoBuilder::new().build();
+/// // let info = InfoBuilder::new().build().expect("build info");
 /// // let (_, server) = tool_attach_to_server(Some(handle.proc()), true, &info)?;
 /// // if let Some(s) = server {
-/// //     tool_set_server(s.proc(), &InfoBuilder::new().build())
+/// //     tool_set_server(s.proc(), &InfoBuilder::new().build().expect("build info"))
 /// //         .expect("set_server failed");
 /// // }
 ///
@@ -1058,7 +1058,7 @@ mod tests {
 
     #[test]
     fn test_info_builder_empty_build() {
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         assert_eq!(info.len, 0);
     }
 
@@ -1257,7 +1257,7 @@ mod tests {
     #[test]
     fn test_tool_connect_to_server_with_info_builder() {
         let server = Proc::new("test_server", 0).unwrap();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = tool_connect_to_server(Some(&server), &info);
         match result {
             Ok(_) => {}
@@ -1291,7 +1291,7 @@ mod tests {
     #[test]
     fn test_tool_set_server_with_info_builder() {
         let server = Proc::new("test_server", 0).unwrap();
-        let info = crate::InfoBuilder::new().build();
+        let info = crate::InfoBuilder::new().build().expect("build info");
         let result = tool_set_server(&server, &info);
         match result {
             Ok(_) => {}

--- a/tests/allocation_deep.rs
+++ b/tests/allocation_deep.rs
@@ -997,10 +997,10 @@ fn compiletime_pmix_status_send_sync() {
 // 12. InfoBuilder integration with allocation functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// InfoBuilder::new().build() produces an Info that can be used with allocation_request.
+/// InfoBuilder::new().build().expect("build info") produces an Info that can be used with allocation_request.
 #[test]
 fn infobuilder_empty_build_for_allocation() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // We can't pass a single Info as &[Info] easily since Info doesn't implement
     // Deref or similar, but we verify the Info type compiles and the build works.
     let _ = info;
@@ -1011,7 +1011,7 @@ fn infobuilder_empty_build_for_allocation() {
 fn infobuilder_collect_data_for_allocation() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1257,7 +1257,7 @@ fn job_control_nb_full_lifecycle() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn allocation_request_with_info() {
     // let _ = pmix::PmixClient::connect_new(None);
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // // Note: allocation_request takes &[Info], and InfoBuilder produces a single Info.
     // // The caller would need to wrap it in a Vec to pass as slice.
     // pmix::finalize(None).unwrap();
@@ -1268,6 +1268,6 @@ fn allocation_request_with_info() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn job_control_with_info() {
     // let _ = pmix::PmixClient::connect_new(None);
-    // let directives = InfoBuilder::new().build();
+    // let directives = InfoBuilder::new().build().expect("build info");
     // pmix::finalize(None).unwrap();
 }

--- a/tests/daemon_data_ops_via_daemon.rs
+++ b/tests/daemon_data_ops_via_daemon.rs
@@ -103,12 +103,12 @@ fn test_data_ops_all_ffi_operations() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let proc = Proc::new("test-nspace", 0).expect("proc");
     let procs = vec![proc.clone()];
-    let directive = InfoBuilder::new().build();
+    let directive = InfoBuilder::new().build().expect("build info");
     let key = "test_data_key";
 
     // ── get ──

--- a/tests/daemon_data_serialization_via_daemon.rs
+++ b/tests/daemon_data_serialization_via_daemon.rs
@@ -29,7 +29,7 @@ fn test_data_serialization_all_ffi_operations() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
 
     let module = pmix::server::PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = pmix::server::server_init(Some(&module), &info).expect("server_init");
 
     // ── data_buffer_create ──

--- a/tests/daemon_events_minimal.rs
+++ b/tests/daemon_events_minimal.rs
@@ -11,7 +11,7 @@ use pmix::{InfoBuilder, PmixDataRange, PmixStatus, Proc};
 fn test_server_init_only() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
     eprintln!("[daemon_events_minimal] server_init succeeded");
     let _ = server_finalize(handle);
@@ -23,12 +23,12 @@ fn test_server_init_only() {
 fn test_register_event_handler_only() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
     eprintln!("[daemon_events_minimal] server_init succeeded");
 
     let codes = vec![PmixStatus::Known(pmix::PmixError::Error)];
-    let reg_info = InfoBuilder::new().build();
+    let reg_info = InfoBuilder::new().build().expect("build info");
     eprintln!("[daemon_events_minimal] calling register_event_handler...");
     let reg_result = register_event_handler(&codes, &reg_info, None, None);
     eprintln!(
@@ -50,12 +50,12 @@ fn test_register_event_handler_only() {
 fn test_notify_event_only() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
     eprintln!("[daemon_events_minimal] server_init succeeded");
 
     let source = Proc::new("test-nspace", 0).expect("proc");
-    let notify_info = InfoBuilder::new().build();
+    let notify_info = InfoBuilder::new().build().expect("build info");
 
     eprintln!("[daemon_events_minimal] calling notify_event with Session...");
     let _ = notify_event(

--- a/tests/daemon_events_via_daemon.rs
+++ b/tests/daemon_events_via_daemon.rs
@@ -88,7 +88,7 @@ fn test_events_all_ffi_operations() {
 
     // Initialize as server
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     // Use None for callbacks — they are Option<extern "C" fn ...>
@@ -99,7 +99,7 @@ fn test_events_all_ffi_operations() {
 
     // ── Blocking register event handler ──
     let codes = vec![PmixStatus::Known(pmix::PmixError::Error)];
-    let reg_info = InfoBuilder::new().build();
+    let reg_info = InfoBuilder::new().build().expect("build info");
     let reg_result = register_event_handler(&codes, &reg_info, notification_fn, reg_cb);
 
     // If registration succeeded, try to deregister

--- a/tests/daemon_groups_via_daemon.rs
+++ b/tests/daemon_groups_via_daemon.rs
@@ -107,7 +107,7 @@ fn test_groups_all_ffi_operations() {
 
     // Initialize as server — do NOT use shared tool handle first
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let member = Proc::new("test-nspace", 0).expect("proc");

--- a/tests/daemon_monitoring_minimal.rs
+++ b/tests/daemon_monitoring_minimal.rs
@@ -28,7 +28,7 @@ fn test_process_monitor_only() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let _handle = daemon_helper::get_tool_handle().expect("shared tool handle");
     eprintln!("[monitoring_minimal] calling process_monitor...");
-    let monitor_info = pmix::InfoBuilder::new().build();
+    let monitor_info = pmix::InfoBuilder::new().build().expect("build info");
     let result = process_monitor(
         &monitor_info,
         pmix::PmixStatus::Known(pmix::PmixError::MonitorHeartbeatAlert),

--- a/tests/daemon_monitoring_via_daemon.rs
+++ b/tests/daemon_monitoring_via_daemon.rs
@@ -66,7 +66,7 @@ fn test_monitor_callback_trait_object() {
 
 #[test]
 fn test_process_monitor_before_init() {
-    let monitor_info = InfoBuilder::new().build();
+    let monitor_info = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor_info, PmixStatus::Known(PmixError::Success), &[]);
     // Before init this returns ErrInit — after shared handle init, behavior depends on PMIx state
     assert!(
@@ -81,7 +81,7 @@ fn test_process_monitor_nb_before_init() {
     impl MonitorCallback for DummyCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor_info = InfoBuilder::new().build();
+    let monitor_info = InfoBuilder::new().build().expect("build info");
     let cb: Box<dyn MonitorCallback> = Box::new(DummyCb);
     let result = process_monitor_nb(
         &monitor_info,
@@ -116,8 +116,8 @@ fn test_monitoring_all_ffi_operations() {
     let handle = daemon_helper::get_tool_handle().expect("shared tool handle");
     let _ = handle; // handle lives for the duration; we just need it initialized
 
-    let _info = InfoBuilder::new().build();
-    let directives = vec![InfoBuilder::new().build()];
+    let _info = InfoBuilder::new().build().expect("build info");
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
 
     // ── 1. heartbeat ──
     let hb_result = heartbeat();
@@ -133,7 +133,7 @@ fn test_monitoring_all_ffi_operations() {
     }
 
     // ── 2. process_monitor with MonitorHeartbeatAlert ──
-    let monitor_info = InfoBuilder::new().build();
+    let monitor_info = InfoBuilder::new().build().expect("build info");
     let monitor_result = process_monitor(
         &monitor_info,
         PmixStatus::Known(PmixError::MonitorHeartbeatAlert),

--- a/tests/daemon_process_mgmt_via_daemon.rs
+++ b/tests/daemon_process_mgmt_via_daemon.rs
@@ -147,7 +147,7 @@ fn test_process_mgmt_all_ffi_operations() {
 
     let proc = Proc::new("test-nspace", 0).expect("proc");
     let procs = vec![proc];
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let nspace = "test-nspace";
 
     // ── 1. connect_nb (non-blocking — returns immediately, callback may fire in-place) ──

--- a/tests/daemon_query_log_via_daemon.rs
+++ b/tests/daemon_query_log_via_daemon.rs
@@ -142,7 +142,7 @@ fn test_pmix_query_with_qualifiers() {
     let _ = daemon_helper::get_tool_handle().expect("shared tool handle");
 
     let query = PmixQuery::new(&["pmix.version"]).expect("PmixQuery::new");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _query_with_qual = query.with_qualifiers(info);
 }
 

--- a/tests/daemon_security_via_daemon.rs
+++ b/tests/daemon_security_via_daemon.rs
@@ -188,7 +188,7 @@ fn test_security_all_ffi_via_daemon() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let _handle = daemon_helper::get_tool_handle().expect("daemon handle");
 
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
 
     // ── 1. PmixCredential lifecycle ──
     let empty = PmixCredential::empty();

--- a/tests/daemon_server.rs
+++ b/tests/daemon_server.rs
@@ -484,7 +484,7 @@ fn test_server_init_with_info_type() {
 #[test]
 fn test_server_init_no_module_type() {
     // Same as test_server_init_with_info_type — just verifies None module works
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _info_ref: &pmix::Info = &info;
     // Type check only — actual FFI call would corrupt state with test_server_init_minimal_calls_ffi
 }
@@ -548,7 +548,7 @@ fn test_server_register_nspace_with_callback() {
     impl RegisterNspaceCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_register_nspace("test-nspace", 1, &info, Box::new(Cb));
     // We don't assert is_err since the callback might be invoked asynchronously
 }
@@ -591,7 +591,7 @@ fn test_server_setup_application_with_callback() {
     impl SetupApplicationCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_setup_application("test-nspace", &info, Box::new(Cb));
 }
 
@@ -601,7 +601,7 @@ fn test_server_setup_local_support_with_callback() {
     impl SetupLocalSupportCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_setup_local_support("test-nspace", &info, Box::new(Cb));
 }
 
@@ -611,14 +611,14 @@ fn test_server_collect_inventory_with_callback() {
     impl CollectInventoryCallback for Cb {
         fn on_complete(&self, _status: PmixStatus, _inventory: CollectInventoryResults) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_collect_inventory(&info, Box::new(Cb));
 }
 
 #[test]
 fn test_server_deliver_inventory_no_callback() {
-    let info = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let _result = server_deliver_inventory(&info, &directives, None);
 }
 
@@ -628,7 +628,7 @@ fn test_server_register_resources_with_callback() {
     impl RegisterResourcesCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_register_resources(&info, Box::new(Cb));
 }
 
@@ -638,6 +638,6 @@ fn test_server_deregister_resources_with_callback() {
     impl DeregisterResourcesCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_deregister_resources(&info, Box::new(Cb));
 }

--- a/tests/daemon_tool_via_daemon.rs
+++ b/tests/daemon_tool_via_daemon.rs
@@ -95,7 +95,7 @@ fn test_tool_all_ffi_operations() {
     // Ensure shared handle is initialized — this gives us the daemon connection
     let _shared = daemon_helper::get_tool_handle().expect("shared tool handle");
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // ── is_tool_initialized ──
     let initialized = is_tool_initialized();

--- a/tests/data_ops_Fence_nb.rs
+++ b/tests/data_ops_Fence_nb.rs
@@ -123,7 +123,7 @@ fn fence_nb_with_info_before_init_returns_err_init() {
 
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let procs: &[Proc] = &[];
 
     let result = fence_nb(procs, Some(&info), Box::new(InfoCheckCallback));
@@ -207,7 +207,7 @@ fn fence_nb_empty_params() {
         }
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let procs: &[Proc] = &[];
 
     let result = fence_nb(procs, Some(&info), Box::new(EmptyCallback));
@@ -276,7 +276,7 @@ fn fence_nb_collect_data_before_init() {
 
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let proc = Proc::new("test_namespace", 0).expect("should create proc");
     let procs = vec![proc];
 
@@ -364,7 +364,7 @@ fn fence_nb_with_collect_data() {
 
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let _ctx = daemon_helper::ensure_pmix_init();
     let proc = _ctx.require_proc();
     let procs = vec![proc];
@@ -474,7 +474,7 @@ fn fence_nb_full_params() {
 
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let _ctx = daemon_helper::ensure_pmix_init();
     let proc = _ctx.require_proc();
     let procs = vec![proc];
@@ -507,7 +507,7 @@ fn fence_nb_put_commit_fence_pattern() {
 
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let result = fence_nb(&procs, Some(&info), Box::new(PatternCallback));
     assert!(
         result.is_ok(),

--- a/tests/data_ops_Lookup.rs
+++ b/tests/data_ops_Lookup.rs
@@ -212,7 +212,7 @@ fn lookup_nb_returns_result_type() {
 fn lookup_with_info_builder() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
 
     let mut data = vec![PmixPdata::new("test_key")];
     let result = lookup(&mut data, Some(&info));
@@ -438,7 +438,7 @@ fn publish_fence_lookup_pattern() {
     let ctx = daemon_helper::ensure_pmix_init();
 
     // Publish data.
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let publish_result = pmix::data_ops::publish(&info);
     assert!(publish_result.is_ok(), "publish should succeed");
 

--- a/tests/data_ops_Publish.rs
+++ b/tests/data_ops_Publish.rs
@@ -58,7 +58,7 @@ fn publish_callback_trait_object() {
 #[test]
 fn publish_before_init_returns_err_init() {
     // Build an empty info array.
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     let result = publish(&info);
     assert!(result.is_err(), "publish should fail without PMIx_Init");
@@ -77,7 +77,7 @@ fn publish_before_init_returns_err_init() {
 /// The non-blocking variant also requires initialization.
 #[test]
 fn publish_nb_before_init_returns_err_init() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     struct InitCheckCallback;
     impl PublishCallback for InitCheckCallback {
@@ -101,7 +101,7 @@ fn publish_nb_before_init_returns_err_init() {
 /// `publish` returns a `Result` type with proper error handling.
 #[test]
 fn publish_returns_result_type() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result: Result<(), PmixStatus> = publish(&info);
 
     // Verify the error is a known PMIx error code.
@@ -126,7 +126,7 @@ fn publish_returns_result_type() {
 /// `publish_nb` returns a `Result` type with proper error handling.
 #[test]
 fn publish_nb_returns_result_type() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     struct ResultTypeCallback;
     impl PublishCallback for ResultTypeCallback {
@@ -167,7 +167,7 @@ fn publish_with_info_builder() {
     // verify the builder constructs a valid Info that publish accepts.
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
 
     let result = publish(&info);
     assert!(result.is_err(), "should fail without PMIx_Init");
@@ -187,7 +187,7 @@ fn publish_callback_receives_pmix_status() {
         }
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(StatusCallback));
     assert!(result.is_err(), "should fail without PMIx_Init");
 }
@@ -207,7 +207,7 @@ fn publish_after_init() {
     // Build info with a simple key-value to publish.
     // The InfoBuilder requires static key bytes matching PMIx key format.
     // For now, just test with an empty info (publish metadata only).
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     let result = publish(&info);
     assert!(
@@ -236,7 +236,7 @@ fn publish_nb_after_init() {
         }
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(NbCallback));
     assert!(result.is_ok(), "publish_nb should accept the request");
 
@@ -257,7 +257,7 @@ fn publish_nb_after_init() {
 #[ignore = "requires PMIx daemon"]
 fn publish_duplicate_key_returns_error() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // First publish should succeed.
     let result1 = publish(&info);
@@ -284,7 +284,7 @@ fn publish_fence_pattern() {
     let ctx = daemon_helper::ensure_pmix_init();
 
     // Publish data.
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish(&info);
     assert!(result.is_ok(), "publish should succeed");
 
@@ -311,7 +311,7 @@ fn publish_nb_callback_not_invoked_on_failure() {
         }
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(NoInvokeCallback));
 
     // Should fail immediately without invoking callback.
@@ -325,8 +325,8 @@ fn publish_nb_callback_not_invoked_on_failure() {
 /// `publish` with empty info array is a valid call (returns error from PMIx).
 #[test]
 fn publish_empty_info_array() {
-    let info = InfoBuilder::new().build();
-    // Empty info array — InfoBuilder::new().build() produces zero-length info.
+    let info = InfoBuilder::new().build().expect("build info");
+    // Empty info array — InfoBuilder::new().build().expect("build info") produces zero-length info.
     // (info.len is private, so we just verify the call behavior.)
 
     let result = publish(&info);
@@ -337,7 +337,7 @@ fn publish_empty_info_array() {
 /// `publish` is callable multiple times (idempotent error behavior).
 #[test]
 fn publish_multiple_calls_consistent_error() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // Call publish multiple times — each should return the same error.
     for i in 0..5 {
@@ -359,7 +359,7 @@ fn publish_multiple_calls_consistent_error() {
 /// `publish_nb` is callable multiple times (idempotent error behavior).
 #[test]
 fn publish_nb_multiple_calls_consistent_error() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     for i in 0..5 {
         struct MultiCallback;

--- a/tests/data_ops_Publish_nb.rs
+++ b/tests/data_ops_Publish_nb.rs
@@ -10,7 +10,7 @@ fn publish_nb_compiles() {
     impl PublishCallback for TestCallback {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(TestCallback));
     assert!(result.is_err(), "publish_nb should fail without PMIx_Init");
     assert_eq!(result.unwrap_err().to_raw(), -31, "should be PMIX_ERR_INIT");
@@ -37,7 +37,7 @@ fn publish_nb_callback_not_invoked_on_failure() {
             INVOKED.store(true, Ordering::SeqCst);
         }
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(NoInvokeCallback));
     assert!(result.is_err());
     assert!(

--- a/tests/data_ops_Unpublish.rs
+++ b/tests/data_ops_Unpublish.rs
@@ -128,7 +128,7 @@ fn unpublish_multiple_keys_before_init() {
 /// Test that the info parameter is accepted (even though the call fails).
 #[test]
 fn unpublish_with_info_before_init() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = unpublish(Some(&["FOOBAR"]), Some(&info));
     assert!(result.is_err(), "unpublish should fail without PMIx_Init");
     assert_eq!(
@@ -392,7 +392,7 @@ fn publish_unpublish_cycle() {
     let ctx = daemon_helper::ensure_pmix_init();
 
     // Publish data (simplified — real test would use proper InfoBuilder).
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let publish_result = publish(&info);
     assert!(publish_result.is_ok(), "publish should succeed");
 

--- a/tests/data_ops_deep.rs
+++ b/tests/data_ops_deep.rs
@@ -215,7 +215,7 @@ fn test_proc_drop_loop() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -223,7 +223,7 @@ fn test_infobuilder_build_empty() {
 fn test_infobuilder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -236,7 +236,7 @@ fn test_infobuilder_collect_data() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_publish_empty_info() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish(&info);
     assert!(result.is_ok(), "publish should succeed");
 }
@@ -247,7 +247,7 @@ fn test_publish_with_collect_info() {
     daemon_helper::ensure_pmix_init();
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let result = publish(&info);
     assert!(result.is_ok());
 }
@@ -256,7 +256,7 @@ fn test_publish_with_collect_info() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_publish_multiple_times() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for _ in 0..3 {
         let result = publish(&info);
         assert!(result.is_ok());
@@ -273,7 +273,7 @@ fn test_publish_nb_success() {
     impl PublishCallback for NoopPublishCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(NoopPublishCb));
     assert!(result.is_ok());
 }
@@ -304,7 +304,7 @@ fn test_get_empty_key() {
 fn test_get_with_info() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("test_ns", 0).expect("create");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = get(&proc, "key", Some(&info));
     let _ = result;
 }
@@ -316,7 +316,7 @@ fn test_get_with_collect_info() {
     let proc = Proc::new("test_ns", 0).expect("create");
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let result = get(&proc, "key", Some(&info));
     let _ = result;
 }
@@ -356,7 +356,7 @@ fn test_get_nb_with_info() {
         fn on_result(self: Box<Self>, _status: PmixStatus, _value: Option<pmix::PmixOwnedValue>) {}
     }
     let proc = Proc::new("test_ns", 0).expect("create");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = get_nb(&proc, "key", Some(&info), Box::new(NoopGetCb));
     assert!(result.is_ok());
 }
@@ -420,7 +420,7 @@ fn test_lookup_single_key() {
 fn test_lookup_with_info() {
     daemon_helper::ensure_pmix_init();
     let mut pdata = vec![PmixPdata::new("info_key")];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = lookup(&mut pdata, Some(&info));
     assert!(result.is_ok());
 }
@@ -447,7 +447,7 @@ fn test_lookup_nb_with_info() {
     impl LookupCallback for NoopLookupCb {
         fn on_result(self: Box<Self>, _status: PmixStatus, _data: Vec<PmixPdata>) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = lookup_nb(&["nb_info_key"], Some(&info), Box::new(NoopLookupCb));
     assert!(result.is_ok());
 }
@@ -506,7 +506,7 @@ fn test_unpublish_multiple_keys() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_unpublish_with_info() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = unpublish(Some(&["test_key"]), Some(&info));
     assert!(result.is_ok());
 }
@@ -533,7 +533,7 @@ fn test_unpublish_nb_with_info() {
     impl UnpublishCallback for NoopUnpublishCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = unpublish_nb(Some(&["test_key"]), Some(&info), Box::new(NoopUnpublishCb));
     assert!(result.is_ok());
 }
@@ -637,7 +637,7 @@ fn test_fence_nb_with_info() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
     let proc = Proc::new("test_ns", 0).expect("create");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = fence_nb(&[proc], Some(&info), Box::new(NoopFenceCb));
     assert!(result.is_ok());
 }
@@ -648,7 +648,7 @@ fn test_fence_nb_with_info() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_publish_then_unpublish() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     publish(&info).expect("publish");
     unpublish(Some(&["test_key"]), None).expect("unpublish");
 }

--- a/tests/data_ops_publish_get_test.rs
+++ b/tests/data_ops_publish_get_test.rs
@@ -3,14 +3,14 @@ use pmix::data_ops::*;
 
 #[test]
 fn test_publish_without_init() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = publish(&info);
     println!("publish result: {:?}", result);
 }
 
 #[test]
 fn test_publish_nb_without_init() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct NoOp;
     impl PublishCallback for NoOp {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
@@ -40,7 +40,7 @@ fn test_get_nb_without_init() {
 #[test]
 fn test_get_nb_with_info_without_init() {
     let proc = pmix::Proc::new("test_ns", 0).unwrap();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct NoOp;
     impl GetValueCallback for NoOp {
         fn on_result(self: Box<Self>, _status: PmixStatus, _value: Option<pmix::PmixOwnedValue>) {}

--- a/tests/data_ops_publish_lookup_wrapper.rs
+++ b/tests/data_ops_publish_lookup_wrapper.rs
@@ -26,7 +26,7 @@ use pmix::{PmixStatus, Proc};
 /// publish without PMIx init returns error.
 #[test]
 fn test_publish_no_init() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = publish(&info);
     assert!(result.is_err());
 }
@@ -34,7 +34,7 @@ fn test_publish_no_init() {
 /// publish with empty Info returns error (not initialized).
 #[test]
 fn test_publish_empty_info() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = publish(&info);
     assert!(result.is_err());
 }
@@ -42,7 +42,7 @@ fn test_publish_empty_info() {
 /// publish returns consistent error on repeated calls.
 #[test]
 fn test_publish_repeated_calls() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let r1 = publish(&info);
     let r2 = publish(&info);
     assert_eq!(r1.is_err(), r2.is_err());
@@ -67,7 +67,7 @@ fn test_publish_nb_no_init() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = publish_nb(
         &info,
         Box::new(Cb {
@@ -88,7 +88,7 @@ fn test_publish_nb_empty_info() {
     impl PublishCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = publish_nb(&info, Box::new(Cb));
     assert!(result.is_err());
 }
@@ -109,7 +109,7 @@ fn test_get_no_init() {
 #[test]
 fn test_get_with_info() {
     let proc = Proc::new("test_ns", 0).unwrap();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = get(&proc, "test_key", Some(&info));
     assert!(result.is_err());
 }
@@ -197,7 +197,7 @@ fn test_get_nb_no_init() {
 #[test]
 fn test_get_nb_with_info() {
     let proc = Proc::new("test_ns", 0).unwrap();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct Cb;
     impl GetValueCallback for Cb {
         fn on_result(self: Box<Self>, _status: PmixStatus, _value: Option<pmix::PmixOwnedValue>) {}
@@ -278,7 +278,7 @@ fn test_lookup_no_init() {
 #[test]
 fn test_lookup_with_info() {
     let mut data: Vec<pmix::data_ops::PmixPdata> = Vec::new();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = lookup(&mut data, Some(&info));
     assert!(result.is_err());
 }
@@ -344,7 +344,7 @@ fn test_lookup_nb_no_init() {
 #[test]
 fn test_lookup_nb_with_info() {
     let keys = vec!["test_key"];
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct Cb;
     impl LookupCallback for Cb {
         fn on_result(
@@ -406,7 +406,7 @@ fn test_unpublish_no_init() {
 /// unpublish with Info returns error.
 #[test]
 fn test_unpublish_with_info() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = unpublish(Some(&["test_key"]), Some(&info));
     assert!(result.is_err());
 }
@@ -477,7 +477,7 @@ fn test_unpublish_nb_no_init() {
 /// unpublish_nb with Info returns error.
 #[test]
 fn test_unpublish_nb_with_info() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct Cb;
     impl UnpublishCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
@@ -535,7 +535,7 @@ fn test_fence_nb_no_init() {
 #[test]
 fn test_fence_nb_with_info() {
     let procs: Vec<Proc> = Vec::new();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     struct Cb;
     impl FenceCallback for Cb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}

--- a/tests/data_ops_unit.rs
+++ b/tests/data_ops_unit.rs
@@ -159,7 +159,7 @@ fn test_unpublish_callback_is_send() {
 
 #[test]
 fn test_publish_empty_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     assert!(info.is_empty());
     let result = publish(&info);
     match result {
@@ -175,7 +175,7 @@ fn test_publish_with_directive() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let result = publish(&info);
     match result {
@@ -188,7 +188,7 @@ fn test_publish_with_directive() {
 
 #[test]
 fn test_publish_consistent_error() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let mut first: Option<PmixStatus> = None;
     for _ in 0..10 {
         let result = publish(&info);
@@ -207,7 +207,7 @@ fn test_publish_consistent_error() {
 
 #[test]
 fn test_publish_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| publish(&info));
     assert!(result.is_ok(), "publish should not panic");
 }
@@ -218,7 +218,7 @@ fn test_publish_does_not_panic() {
 
 #[test]
 fn test_publish_nb_empty_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let cb: Box<dyn PublishCallback> = Box::new(RecordingPublishCb {
         calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
     });
@@ -233,7 +233,7 @@ fn test_publish_nb_empty_info() {
 
 #[test]
 fn test_publish_nb_error_does_not_leak_callback() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for _ in 0..20 {
         let cb: Box<dyn PublishCallback> = Box::new(RecordingPublishCb {
             calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -248,7 +248,7 @@ fn test_publish_nb_with_directive() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let cb: Box<dyn PublishCallback> = Box::new(RecordingPublishCb {
         calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -296,7 +296,7 @@ fn test_get_with_info_directive() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let result = get(&proc, "test_key", Some(&info));
     match result {
@@ -376,7 +376,7 @@ fn test_get_nb_with_info() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let cb: Box<dyn GetValueCallback> = Box::new(RecordingGetCb {
         calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -454,7 +454,7 @@ fn test_lookup_with_info() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let result = lookup(&mut data, Some(&info));
     match result {
@@ -605,7 +605,7 @@ fn test_unpublish_with_info() {
     let info = {
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     };
     let result = unpublish(Some(&keys), Some(&info));
     match result {

--- a/tests/events_Deregister_event_handler.rs
+++ b/tests/events_Deregister_event_handler.rs
@@ -265,7 +265,7 @@ fn deregister_error_codes_to_string() {
 /// InfoBuilder produces valid Info for use with event APIs.
 #[test]
 fn info_builder_for_events() {
-    let _info = InfoBuilder::new().build();
+    let _info = InfoBuilder::new().build().expect("build info");
     // Info should be creatable even without PMIx_Init.
     // We can't check .len (private field), but the fact that it compiled
     // and didn't panic is sufficient.
@@ -291,7 +291,7 @@ fn register_then_deregister_lifecycle() {
     // let _ = pmix::lifecycle::init(None, &[]);
     //
     // // Register a handler
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let handler_ref = register_event_handler(&[], &info, None, None)
     //     .expect("register should succeed after PMIx_Init");
     // assert!(handler_ref > 0, "handler ref should be positive");
@@ -317,7 +317,7 @@ fn register_multiple_deregister_each() {
     daemon_helper::ensure_pmix_init();
     // let _ = pmix::lifecycle::init(None, &[]);
     //
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let codes1 = vec![PmixStatus::Known(PmixError::ErrJobAborted)];
     // let codes2 = vec![PmixStatus::Known(PmixError::EventJobEnd)];
     //
@@ -359,7 +359,7 @@ fn deregister_nb_lifecycle() {
 
     // let _ = pmix::lifecycle::init(None, &[]);
     //
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let handler_ref = register_event_handler(&[], &info, None, None)
     //     .expect("register should succeed");
     //
@@ -391,7 +391,7 @@ fn deregister_before_finalize() {
     daemon_helper::ensure_pmix_init();
     // let _ = pmix::lifecycle::init(None, &[]);
     //
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let handler_ref = register_event_handler(&[], &info, None, None)
     //     .expect("register");
     //

--- a/tests/events_Notify_event.rs
+++ b/tests/events_Notify_event.rs
@@ -28,7 +28,7 @@ use std::ptr;
 #[test]
 fn notify_event_without_init_fails() {
     let proc = Proc::new("", 0).expect("create wildcard proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &proc,
@@ -48,7 +48,7 @@ fn notify_event_without_init_fails() {
 #[test]
 fn notify_event_namespace_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobCanceled),
         &proc,
@@ -64,7 +64,7 @@ fn notify_event_namespace_range_without_init_fails() {
 #[test]
 fn notify_event_local_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::EventProcTerminated),
         &proc,
@@ -80,7 +80,7 @@ fn notify_event_local_range_without_init_fails() {
 #[test]
 fn notify_event_proc_local_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::EventJobEnd),
         &proc,
@@ -94,7 +94,7 @@ fn notify_event_proc_local_range_without_init_fails() {
 #[test]
 fn notify_event_global_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrProcFailedToStart),
         &proc,
@@ -108,7 +108,7 @@ fn notify_event_global_range_without_init_fails() {
 #[test]
 fn notify_event_rm_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrLostConnection),
         &proc,
@@ -122,7 +122,7 @@ fn notify_event_rm_range_without_init_fails() {
 #[test]
 fn notify_event_custom_range_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrTimeout),
         &proc,
@@ -145,7 +145,7 @@ fn notify_event_nb_without_init_fails() {
     extern "C" fn dummy_op_cb(_status: i32, _cbdata: *mut c_void) {}
 
     let proc = Proc::new("", 0).expect("create wildcard proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::EventJobEnd),
         &proc,
@@ -167,7 +167,7 @@ fn notify_event_nb_namespace_range_without_init_fails() {
     extern "C" fn dummy_op_cb(_status: i32, _cbdata: *mut c_void) {}
 
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &proc,
@@ -185,7 +185,7 @@ fn notify_event_nb_proc_local_without_init_fails() {
     extern "C" fn dummy_op_cb(_status: i32, _cbdata: *mut c_void) {}
 
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::EventJobStart),
         &proc,
@@ -208,7 +208,7 @@ fn notify_event_nb_proc_local_without_init_fails() {
 fn notify_event_unknown_code_without_init_fails() {
     let user_code = PmixStatus::Unknown(-5000);
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(user_code, &proc, PmixDataRange::Session, &info);
     assert!(result.is_err(), "should fail without init for unknown code");
 }
@@ -227,7 +227,7 @@ fn notify_event_various_codes_without_init_fail() {
         PmixStatus::Known(PmixError::ErrProcRequestedAbort),
     ];
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for code in &codes {
         let result = notify_event(*code, &proc, PmixDataRange::Session, &info);
         assert!(
@@ -247,7 +247,7 @@ fn notify_event_various_codes_without_init_fail() {
 #[test]
 fn notify_event_wildcard_proc_without_init_fails() {
     let proc = Proc::new("", 0).expect("create wildcard proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &proc,
@@ -261,7 +261,7 @@ fn notify_event_wildcard_proc_without_init_fails() {
 #[test]
 fn notify_event_named_proc_without_init_fails() {
     let proc = Proc::new("my_job", 42).expect("create named proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobCanceled),
         &proc,
@@ -275,7 +275,7 @@ fn notify_event_named_proc_without_init_fails() {
 #[test]
 fn notify_event_rank_zero_without_init_fails() {
     let proc = Proc::new("job_12345", 0).expect("create proc at rank 0");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::EventProcTerminated),
         &proc,
@@ -289,7 +289,7 @@ fn notify_event_rank_zero_without_init_fails() {
 #[test]
 fn notify_event_high_rank_without_init_fails() {
     let proc = Proc::new("large_job", 1024).expect("create high rank proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &proc,
@@ -307,7 +307,7 @@ fn notify_event_high_rank_without_init_fails() {
 #[test]
 fn notify_event_empty_info_without_init_fails() {
     let proc = Proc::new("test_namespace", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Info built with empty builder should have no entries
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
@@ -375,7 +375,7 @@ fn notify_event_full_lifecycle() {
     daemon_helper::ensure_pmix_init();
     // let _ = pmix::lifecycle::init(None, &[]);
     // let proc = pmix::Proc::new("test_job", 0).unwrap();
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     //
     // // Register a handler first
     // let handler_ref = register_event_handler(
@@ -421,7 +421,7 @@ fn notify_event_nb_lifecycle() {
     //
     // let mut done = false;
     // let proc = pmix::Proc::new("test_job", 0).unwrap();
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     //
     // notify_event_nb(
     //     PmixStatus::Known(PmixError::EventJobEnd),

--- a/tests/events_Notify_event_nb.rs
+++ b/tests/events_Notify_event_nb.rs
@@ -5,7 +5,7 @@ use pmix::{InfoBuilder, PmixDataRange, PmixError, PmixStatus, Proc};
 
 #[test]
 fn notify_event_nb_compiles() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let proc = Proc::new("test_ns", 0).unwrap();
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::Success),

--- a/tests/events_Register_event_handler.rs
+++ b/tests/events_Register_event_handler.rs
@@ -55,7 +55,7 @@ fn op_cb_fn_can_be_none() {
 /// rather than panicking or segfaulting.
 #[test]
 fn register_event_handler_without_init_fails() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&[], &info, None, None);
     assert!(
         result.is_err(),
@@ -77,7 +77,7 @@ fn register_event_handler_with_codes_without_init_fails() {
         PmixStatus::Known(PmixError::ErrJobAborted),
         PmixStatus::Known(PmixError::EventJobEnd),
     ];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&codes, &info, None, None);
     assert!(
         result.is_err(),
@@ -106,7 +106,7 @@ fn register_event_handler_with_callback_without_init_fails() {
         // Should never be called without PMIx_Init.
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&[], &info, Some(dummy_notification_handler), None);
     assert!(
         result.is_err(),
@@ -151,7 +151,7 @@ fn deregister_event_handler_nb_without_init_fails() {
 #[test]
 fn notify_event_without_init_fails() {
     let proc = pmix::Proc::new("", 0).expect("create wildcard proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &proc,
@@ -171,7 +171,7 @@ fn notify_event_nb_without_init_fails() {
     extern "C" fn dummy_op_cb(_status: i32, _cbdata: *mut c_void) {}
 
     let proc = pmix::Proc::new("", 0).expect("create wildcard proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::EventJobEnd),
         &proc,
@@ -235,7 +235,7 @@ fn register_multiple_event_codes_without_init_fails() {
         PmixStatus::Known(PmixError::EventJobEnd),
         PmixStatus::Known(PmixError::EventJobStart),
     ];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&codes, &info, None, None);
     assert!(
         result.is_err(),
@@ -247,7 +247,7 @@ fn register_multiple_event_codes_without_init_fails() {
 /// Registering with empty codes (match all) without init should fail.
 #[test]
 fn register_all_events_without_init_fails() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&[], &info, None, None);
     assert!(
         result.is_err(),
@@ -264,7 +264,7 @@ fn register_all_events_without_init_fails() {
 fn register_event_handler_nb_without_init_fails() {
     extern "C" fn dummy_reg_cb(_status: i32, _refid: EventHandlerRef, _cbdata: *mut c_void) {}
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler_nb(&[], &info, None, Some(dummy_reg_cb), ptr::null_mut());
     assert!(
         result.is_err(),
@@ -310,7 +310,7 @@ fn register_deregister_lifecycle() {
     // as a template for when PMIx_Init is available.
     //
     // let _ = pmix::lifecycle::init(None, &[]);
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let handler_ref = register_event_handler(&[], &info, None, None)
     //     .expect("register should succeed after PMIx_Init");
     // assert!(handler_ref > 0, "handler ref should be positive");
@@ -329,7 +329,7 @@ fn register_with_codes_deregister_lifecycle() {
     // Same as above but with specific event codes.
     // let _ = pmix::lifecycle::init(None, &[]);
     // let codes = vec![PmixStatus::Known(PmixError::ErrJobAborted)];
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // let handler_ref = register_event_handler(&codes, &info, None, None)
     //     .expect("register should succeed");
     // deregister_event_handler(handler_ref, None)
@@ -346,7 +346,7 @@ fn notify_event_lifecycle() {
     daemon_helper::ensure_pmix_init();
     // let _ = pmix::lifecycle::init(None, &[]);
     // let proc = pmix::Proc::new("", 0).unwrap();
-    // let info = InfoBuilder::new().build();
+    // let info = InfoBuilder::new().build().expect("build info");
     // notify_event(
     //     PmixStatus::Known(PmixError::EventJobEnd),
     //     &proc,

--- a/tests/events_Register_event_handler_nb.rs
+++ b/tests/events_Register_event_handler_nb.rs
@@ -8,7 +8,7 @@ use pmix::events::{HandlerRegCbFn, NotificationFn, register_event_handler_nb};
 /// `register_event_handler_nb` compiles with correct signature.
 #[test]
 fn register_event_handler_nb_compiles() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler_nb(
         &[],
         &info,

--- a/tests/events_unit.rs
+++ b/tests/events_unit.rs
@@ -131,7 +131,7 @@ fn test_data_range_is_send_and_sync() {
 
 #[test]
 fn test_register_event_handler_empty_codes_no_handler() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&[], &info, None, None);
     match result {
         Ok(_) => {} // rare: PMIx is initialized
@@ -144,7 +144,7 @@ fn test_register_event_handler_empty_codes_no_handler() {
 #[test]
 fn test_register_event_handler_single_code_no_handler() {
     let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&codes, &info, None, None);
     match result {
         Ok(_) => {}
@@ -161,7 +161,7 @@ fn test_register_event_handler_multiple_codes() {
         PmixStatus::Known(PmixError::ErrTimeout),
         PmixStatus::Known(PmixError::ErrNotSupported),
     ];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&codes, &info, None, None);
     match result {
         Ok(_) => {}
@@ -186,7 +186,7 @@ fn test_register_event_handler_with_notification_fn() {
     ) {
     }
     let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler(&codes, &info, Some(dummy_handler), None);
     match result {
         Ok(_) => {}
@@ -199,7 +199,7 @@ fn test_register_event_handler_with_notification_fn() {
 #[test]
 fn test_register_event_handler_consistent_error() {
     let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let mut first: Option<PmixStatus> = None;
     for _ in 0..10 {
         let result = register_event_handler(&codes, &info, None, None);
@@ -224,7 +224,7 @@ fn test_register_event_handler_consistent_error() {
 fn test_register_event_handler_nb_reaches_ffi() {
     extern "C" fn dummy_reg_cb(_: i32, _: EventHandlerRef, _: *mut std::os::raw::c_void) {}
     let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler_nb(
         &codes,
         &info,
@@ -243,7 +243,7 @@ fn test_register_event_handler_nb_reaches_ffi() {
 #[test]
 fn test_register_event_handler_nb_empty_codes() {
     extern "C" fn dummy_reg_cb(_: i32, _: EventHandlerRef, _: *mut std::os::raw::c_void) {}
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result =
         register_event_handler_nb(&[], &info, None, Some(dummy_reg_cb), std::ptr::null_mut());
     match result {
@@ -270,7 +270,7 @@ fn test_register_event_handler_nb_with_notification_fn() {
     ) {
     }
     let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = register_event_handler_nb(
         &codes,
         &info,
@@ -369,7 +369,7 @@ fn test_deregister_event_handler_nb_zero_ref() {
 #[test]
 fn test_notify_event_reaches_ffi() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &source,
@@ -387,7 +387,7 @@ fn test_notify_event_reaches_ffi() {
 #[test]
 fn test_notify_event_with_all_ranges() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for range in [
         PmixDataRange::Undef,
         PmixDataRange::Rm,
@@ -416,7 +416,7 @@ fn test_notify_event_with_all_ranges() {
 #[test]
 fn test_notify_event_with_wildcard_source() {
     let source = Proc::new("", u32::MAX).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event(
         PmixStatus::Known(PmixError::ErrNotSupported),
         &source,
@@ -434,7 +434,7 @@ fn test_notify_event_with_wildcard_source() {
 #[test]
 fn test_notify_event_various_status_codes() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let statuses = [
         PmixStatus::Known(PmixError::Success),
         PmixStatus::Known(PmixError::Error),
@@ -467,7 +467,7 @@ fn test_notify_event_various_status_codes() {
 #[test]
 fn test_notify_event_does_not_panic() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| {
         notify_event(
             PmixStatus::Known(PmixError::ErrJobAborted),
@@ -482,7 +482,7 @@ fn test_notify_event_does_not_panic() {
 #[test]
 fn test_notify_event_consistent_error() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let mut first: Option<PmixStatus> = None;
     for _ in 0..10 {
         let result = notify_event(
@@ -512,7 +512,7 @@ fn test_notify_event_consistent_error() {
 fn test_notify_event_nb_reaches_ffi() {
     extern "C" fn dummy_op_cb(_: i32, _: *mut std::os::raw::c_void) {}
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::ErrJobAborted),
         &source,
@@ -532,7 +532,7 @@ fn test_notify_event_nb_reaches_ffi() {
 #[test]
 fn test_notify_event_nb_with_none_cbfunc() {
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = notify_event_nb(
         PmixStatus::Known(PmixError::ErrTimeout),
         &source,
@@ -553,7 +553,7 @@ fn test_notify_event_nb_with_none_cbfunc() {
 fn test_notify_event_nb_various_ranges() {
     extern "C" fn dummy_op_cb(_: i32, _: *mut std::os::raw::c_void) {}
     let source = Proc::new("test_job", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for range in [
         PmixDataRange::Undef,
         PmixDataRange::Rm,
@@ -607,7 +607,7 @@ fn test_proc_wildcard_for_events() {
 
 #[test]
 fn test_info_empty_for_register() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     assert!(info.is_empty());
     assert_eq!(info.len(), 0);
 }

--- a/tests/fabric_Fabric_register_nb.rs
+++ b/tests/fabric_Fabric_register_nb.rs
@@ -78,7 +78,7 @@ fn test_register_nb_empty_directives() {
 fn test_register_nb_single_directive() {
     daemon_helper::ensure_pmix_init();
     let mut fabric = PmixFabric::unamed();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[Info] = std::slice::from_ref(&info);
     let result = fabric_register_nb(&mut fabric, directives, Box::new(NopCallback));
     assert!(result.is_err() || result.is_ok());
@@ -90,7 +90,7 @@ fn test_register_nb_single_directive() {
 fn test_register_nb_multiple_directives() {
     daemon_helper::ensure_pmix_init();
     let mut fabric = PmixFabric::unamed();
-    let directives = vec![InfoBuilder::new().build(), InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
     let result = fabric_register_nb(&mut fabric, &directives, Box::new(NopCallback));
     assert!(result.is_err() || result.is_ok());
 }

--- a/tests/fabric_deep.rs
+++ b/tests/fabric_deep.rs
@@ -217,7 +217,7 @@ fn test_cpuset_drop_does_not_panic() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -227,7 +227,7 @@ fn test_infobuilder_collect_data() {
     // — just verify the type compiles
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/fabric_fabric_comprehensive.rs
+++ b/tests/fabric_fabric_comprehensive.rs
@@ -94,7 +94,7 @@ fn test_cpuset_debug() {
 #[test]
 fn test_fabric_register_without_init() {
     let mut fabric = PmixFabric::new(Some("test")).expect("fabric new failed");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = std::slice::from_ref(&info);
     assert!(
         fabric_register(&mut fabric, directives).is_err(),
@@ -136,7 +136,7 @@ fn test_fabric_register_nb_without_init() {
     // Do NOT call ensure_pmix_init() — that is the DVM/client path and would
     // invert the "without init" contract this test is named for.
     let mut fabric = PmixFabric::new(Some("test")).expect("fabric new failed");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = std::slice::from_ref(&info);
     struct NopFabricCb;
     impl FabricCallback for NopFabricCb {
@@ -251,7 +251,7 @@ fn test_compute_distances_callback_requires_send() {
 fn test_compute_distances_without_init() {
     let mut topo = PmixTopology::new(None).expect("topology new failed");
     let mut cpuset = PmixCpuset::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = std::slice::from_ref(&info);
     assert!(
         compute_distances(&mut topo, &mut cpuset, directives).is_err(),
@@ -266,7 +266,7 @@ fn test_compute_distances_nb_without_init() {
     // invert the "without init" contract this test is named for.
     let mut topo = PmixTopology::new(None).expect("topology new failed");
     let mut cpuset = PmixCpuset::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = std::slice::from_ref(&info);
     struct TestDistCb;
     impl ComputeDistancesCallback for TestDistCb {

--- a/tests/fabric_registration.rs
+++ b/tests/fabric_registration.rs
@@ -161,7 +161,7 @@ fn test_register_with_empty_directives() {
 #[test]
 fn test_register_with_single_directive() {
     let mut fabric = PmixFabric::new(Some("single_dir")).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[Info] = std::slice::from_ref(&info);
     let result = fabric_register(&mut fabric, directives);
     assert!(result.is_err());
@@ -172,8 +172,8 @@ fn test_register_with_single_directive() {
 #[test]
 fn test_register_with_multiple_directives() {
     let mut fabric = PmixFabric::new(Some("multi_dir")).unwrap();
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let directives = vec![info1, info2];
     let result = fabric_register(&mut fabric, &directives);
     assert!(result.is_err());
@@ -215,7 +215,7 @@ fn test_register_nb_empty_directives() {
 fn test_register_nb_single_directive() {
     daemon_helper::ensure_pmix_init();
     let mut fabric = PmixFabric::unamed();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives: &[Info] = std::slice::from_ref(&info);
     let result = fabric_register_nb(&mut fabric, directives, Box::new(NopCallback));
     assert!(result.is_err());
@@ -227,8 +227,8 @@ fn test_register_nb_single_directive() {
 fn test_register_nb_multiple_directives() {
     daemon_helper::ensure_pmix_init();
     let mut fabric = PmixFabric::unamed();
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let directives = vec![info1, info2];
     let result = fabric_register_nb(&mut fabric, &directives, Box::new(NopCallback));
     assert!(result.is_err());

--- a/tests/groups_ConstructDestruct_wrapper.rs
+++ b/tests/groups_ConstructDestruct_wrapper.rs
@@ -56,7 +56,7 @@ fn test_group_construct_no_init() {
 #[test]
 fn test_group_construct_with_directives() {
     let proc = Proc::new("test_ns", 0).expect("create proc");
-    let directive = InfoBuilder::new().build();
+    let directive = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_construct("test_group", &[proc], &[directive]));
     assert!(!err.is_success());
 }
@@ -176,7 +176,7 @@ fn test_group_construct_nb_with_info() {
         },
     );
     let proc = Proc::new("test_ns", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_construct_nb("test_group", &[proc], &[info], cb));
     assert!(!err.is_success());
 }
@@ -238,7 +238,7 @@ fn test_group_destruct_no_init() {
 /// group_destruct with info returns error (not initialized).
 #[test]
 fn test_group_destruct_with_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_destruct("test_group", &[info]));
     assert!(!err.is_success());
 }
@@ -264,8 +264,8 @@ fn test_group_destruct_idempotent() {
 /// group_destruct with multiple info entries returns error.
 #[test]
 fn test_group_destruct_multiple_info() {
-    let i1 = InfoBuilder::new().build();
-    let i2 = InfoBuilder::new().build();
+    let i1 = InfoBuilder::new().build().expect("build info");
+    let i2 = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_destruct("test_group", &[i1, i2]));
     assert!(!err.is_success());
 }
@@ -319,7 +319,7 @@ fn test_group_destruct_nb_with_info() {
     let cb = GroupDestructCallbackWrapper::new(move |_status: PmixStatus| {
         called_clone.store(true, Ordering::SeqCst);
     });
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_destruct_nb("test_group", &[info], cb));
     assert!(!err.is_success());
 }

--- a/tests/groups_InviteJoin_wrapper.rs
+++ b/tests/groups_InviteJoin_wrapper.rs
@@ -56,7 +56,7 @@ fn test_group_invite_no_init() {
 #[test]
 fn test_group_invite_with_info() {
     let proc = Proc::new("test_ns", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_invite("test_group", &[proc], &[info]));
     assert!(!err.is_success());
 }
@@ -164,7 +164,7 @@ fn test_group_invite_nb_with_info() {
             called_clone.store(true, Ordering::SeqCst);
         });
     let proc = Proc::new("test_ns", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_invite_nb("test_group", &[proc], &[info], cb));
     assert!(!err.is_success());
 }
@@ -236,7 +236,7 @@ fn test_group_join_no_init() {
 #[test]
 fn test_group_join_with_info() {
     let leader = Proc::new("test_ns", 0).expect("create proc");
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_join(
         "test_group",
         &leader,
@@ -308,8 +308,8 @@ fn test_group_join_idempotent() {
 #[test]
 fn test_group_join_multiple_info() {
     let leader = Proc::new("test_ns", 0).expect("create proc");
-    let i1 = InfoBuilder::new().build();
-    let i2 = InfoBuilder::new().build();
+    let i1 = InfoBuilder::new().build().expect("build info");
+    let i2 = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_join(
         "test_group",
         &leader,
@@ -386,7 +386,7 @@ fn test_group_join_nb_with_info() {
         GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
             called_clone.store(true, Ordering::SeqCst);
         });
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_join_nb(
         "test_group",
         &leader,

--- a/tests/groups_Leave_wrapper.rs
+++ b/tests/groups_Leave_wrapper.rs
@@ -46,7 +46,7 @@ fn test_group_leave_no_init() {
 /// group_leave with info returns error (not initialized).
 #[test]
 fn test_group_leave_with_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_leave("test_group", &[info]));
     assert!(!err.is_success());
 }
@@ -72,8 +72,8 @@ fn test_group_leave_idempotent() {
 /// group_leave with multiple info entries returns error.
 #[test]
 fn test_group_leave_multiple_info() {
-    let i1 = InfoBuilder::new().build();
-    let i2 = InfoBuilder::new().build();
+    let i1 = InfoBuilder::new().build().expect("build info");
+    let i2 = InfoBuilder::new().build().expect("build info");
     let err = extract_err(group_leave("test_group", &[i1, i2]));
     assert!(!err.is_success());
 }
@@ -135,7 +135,7 @@ fn test_group_leave_nb_with_info() {
     let cb = GroupLeaveCallbackWrapper::new(move |_status: PmixStatus| {
         called_clone.store(true, Ordering::SeqCst);
     });
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_leave_nb("test_group", &[info], cb));
     assert!(!err.is_success());
 }
@@ -182,8 +182,8 @@ fn test_group_leave_nb_multiple_info() {
     let cb = GroupLeaveCallbackWrapper::new(move |_status: PmixStatus| {
         called_clone.store(true, Ordering::SeqCst);
     });
-    let i1 = InfoBuilder::new().build();
-    let i2 = InfoBuilder::new().build();
+    let i1 = InfoBuilder::new().build().expect("build info");
+    let i2 = InfoBuilder::new().build().expect("build info");
     let err = unwrap_err_result(group_leave_nb("test_group", &[i1, i2], cb));
     assert!(!err.is_success());
 }

--- a/tests/groups_deep.rs
+++ b/tests/groups_deep.rs
@@ -96,7 +96,7 @@ fn test_destruct_callback_wrapper() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -104,7 +104,7 @@ fn test_infobuilder_build_empty() {
 fn test_infobuilder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -275,7 +275,7 @@ fn test_group_construct_multiple_procs() {
 fn test_group_construct_with_directives() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("ns", 0).expect("proc");
-    let dirs = vec![InfoBuilder::new().build()];
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_construct("directed_group", &[proc], &dirs);
     let _ = result;
 }
@@ -313,7 +313,7 @@ fn test_group_construct_nb_success() {
 fn test_group_construct_nb_with_info() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("ns", 0).expect("proc");
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let cb = GroupConstructCallbackWrapper::new(|_s, _i| {});
     let result = group_construct_nb("nb_group", &[proc], &info, cb);
     assert!(result.is_ok());
@@ -345,7 +345,7 @@ fn test_group_invite_multiple_procs() {
 fn test_group_invite_with_directives() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("ns", 0).expect("proc");
-    let dirs = vec![InfoBuilder::new().build()];
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_invite("invite_group", &[proc], &dirs);
     let _ = result;
 }
@@ -383,7 +383,7 @@ fn test_group_join_success() {
 fn test_group_join_with_info() {
     daemon_helper::ensure_pmix_init();
     let leader = Proc::new("ns", 0).expect("leader");
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_join(
         "join_group",
         &leader,
@@ -425,7 +425,7 @@ fn test_group_leave_success() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_group_leave_with_info() {
     daemon_helper::ensure_pmix_init();
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_leave("leave_group", &info);
     let _ = result;
 }
@@ -455,7 +455,7 @@ fn test_group_destruct_success() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_group_destruct_with_info() {
     daemon_helper::ensure_pmix_init();
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_destruct("destruct_group", &info);
     let _ = result;
 }

--- a/tests/groups_unit.rs
+++ b/tests/groups_unit.rs
@@ -46,7 +46,7 @@ fn test_group_construct_with_special_group_ids() {
 #[test]
 fn test_group_construct_with_directives() {
     let procs = test_procs(2);
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_construct("test_grp", &procs, &directives);
     match result {
         Ok(_) => {}
@@ -99,7 +99,7 @@ fn test_group_construct_nb_with_special_group_ids() {
 #[test]
 fn test_group_construct_nb_with_info_directives() {
     let procs = test_procs(1);
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let cb = GroupConstructCallbackWrapper::new(|_, _| {});
     let result = group_construct_nb("test_grp", &procs, &info, cb);
     match result {
@@ -117,7 +117,7 @@ fn test_group_construct_nb_with_info_directives() {
 #[test]
 fn test_group_invite_with_directives() {
     let procs = test_procs(1);
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_invite("invite_grp", &procs, &directives);
     match result {
         Ok(_) => {}
@@ -146,7 +146,7 @@ fn test_group_invite_with_multiple_procs() {
 #[test]
 fn test_group_join_with_directives() {
     let leader = test_proc(0);
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_join(
         "join_grp",
         &leader,
@@ -186,7 +186,7 @@ fn test_group_join_with_different_leaders() {
 
 #[test]
 fn test_group_leave_with_directives() {
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_leave("leave_grp", &directives);
     match result {
         Ok(_) => {}
@@ -198,7 +198,7 @@ fn test_group_leave_with_directives() {
 
 #[test]
 fn test_group_leave_with_multiple_directives() {
-    let directives = vec![InfoBuilder::new().build(), InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
     let result = group_leave("leave_grp", &directives);
     match result {
         Ok(_) => {}
@@ -214,7 +214,7 @@ fn test_group_leave_with_multiple_directives() {
 
 #[test]
 fn test_group_destruct_with_directives() {
-    let directives = vec![InfoBuilder::new().build()];
+    let directives = vec![InfoBuilder::new().build().expect("build info")];
     let result = group_destruct("destruct_grp", &directives);
     match result {
         Ok(_) => {}
@@ -299,7 +299,7 @@ fn test_group_construct_with_infobuilder_directives() {
     let procs = test_procs(1);
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let directives = vec![builder.build()];
+    let directives = vec![builder.build().expect("build info")];
     let result = group_construct("test_grp", &procs, &directives);
     match result {
         Ok(_) => {}
@@ -314,7 +314,7 @@ fn test_group_invite_with_infobuilder_directives() {
     let procs = test_procs(1);
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let directives = vec![builder.build()];
+    let directives = vec![builder.build().expect("build info")];
     let result = group_invite("test_grp", &procs, &directives);
     match result {
         Ok(_) => {}

--- a/tests/lib_core_api.rs
+++ b/tests/lib_core_api.rs
@@ -195,7 +195,7 @@ fn test_context_proc_with_nspace() {
 #[test]
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_init_with_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = pmix::PmixClient::connect_new(Some(info));
     assert!(result.is_ok(), "init with info should succeed");
 }
@@ -229,7 +229,7 @@ fn test_fence_after_init() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_fence_with_info() {
     let context = daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = pmix::fence(&context.require_proc(), Some(info));
     assert!(result.is_ok(), "fence with info should succeed");
 }
@@ -476,13 +476,13 @@ fn test_pmix_data_type_traits() {
 
 #[test]
 fn test_info_builder_build() {
-    let _info = InfoBuilder::new().build();
+    let _info = InfoBuilder::new().build().expect("build info");
 }
 
 #[test]
 fn test_info_builder_independent() {
-    let _info1 = InfoBuilder::new().build();
-    let _info2 = InfoBuilder::new().build();
+    let _info1 = InfoBuilder::new().build().expect("build info");
+    let _info2 = InfoBuilder::new().build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/lib_core_lifecycle.rs
+++ b/tests/lib_core_lifecycle.rs
@@ -224,7 +224,7 @@ fn init_without_dvm_returns_err() {
 /// `PmixClient::connect_new(Some(info))` without DVM returns `Err`.
 #[test]
 fn init_with_info_without_dvm_returns_err() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     assert!(
         PmixClient::connect_new(Some(info)).is_err(),
         "PmixClient::connect_new(Some(info)) without DVM should return Err"
@@ -260,7 +260,7 @@ fn init_does_not_panic_on_error() {
 /// `init` with empty InfoBuilder also returns error without DVM.
 #[test]
 fn init_with_empty_info_returns_err() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     assert!(
         PmixClient::connect_new(Some(info)).is_err(),
         "init with empty InfoBuilder should fail without DVM"
@@ -272,7 +272,7 @@ fn init_with_empty_info_returns_err() {
 fn init_with_collect_data_info_returns_err() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     assert!(
         PmixClient::connect_new(Some(info)).is_err(),
         "init with collect_data info should fail without DVM"
@@ -406,7 +406,7 @@ fn multiple_finalize_without_init_safe() {
 /// `finalize(Some(info))` without prior init completes without crashing.
 #[test]
 fn finalize_with_info_without_init_safe() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = finalize(Some(info));
 }
 
@@ -481,8 +481,8 @@ fn initialized_consistent_after_failed_lifecycle() {
 /// init with info, then finalize with info: init fails, finalize completes.
 #[test]
 fn init_with_info_then_finalize_with_info() {
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
 
     let init_result = PmixClient::connect_new(Some(info1));
     assert!(

--- a/tests/lib_type_coverage.rs
+++ b/tests/lib_type_coverage.rs
@@ -1561,12 +1561,12 @@ fn test_pmix_owned_value_into_raw() {
 fn test_info_builder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 #[test]
 fn test_info_builder_build_empty() {
-    let _info = InfoBuilder::new().build();
+    let _info = InfoBuilder::new().build().expect("build info");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/monitoring_ProcessMonitor_wrapper.rs
+++ b/tests/monitoring_ProcessMonitor_wrapper.rs
@@ -22,7 +22,7 @@ use pmix::{InfoBuilder, PmixError, PmixStatus};
 /// process_monitor with empty directives returns error.
 #[test]
 fn test_process_monitor_empty_directives() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     assert!(result.is_err());
 }
@@ -30,8 +30,8 @@ fn test_process_monitor_empty_directives() {
 /// process_monitor with directives returns error (not initialized).
 #[test]
 fn test_process_monitor_with_directives() {
-    let monitor = InfoBuilder::new().build();
-    let directive = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let directive = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(PmixError::Success),
@@ -43,9 +43,9 @@ fn test_process_monitor_with_directives() {
 /// process_monitor with multiple directives returns error.
 #[test]
 fn test_process_monitor_multiple_directives() {
-    let monitor = InfoBuilder::new().build();
-    let d1 = InfoBuilder::new().build();
-    let d2 = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let d1 = InfoBuilder::new().build().expect("build info");
+    let d2 = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[d1, d2]);
     assert!(result.is_err());
 }
@@ -53,7 +53,7 @@ fn test_process_monitor_multiple_directives() {
 /// process_monitor is deterministic.
 #[test]
 fn test_process_monitor_deterministic() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let r1 = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     let r2 = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     assert_eq!(r1.is_err(), r2.is_err());
@@ -62,7 +62,7 @@ fn test_process_monitor_deterministic() {
 /// process_monitor with error status returns error.
 #[test]
 fn test_process_monitor_error_status() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     assert!(result.is_err());
 }
@@ -70,7 +70,7 @@ fn test_process_monitor_error_status() {
 /// process_monitor repeated calls are idempotent.
 #[test]
 fn test_process_monitor_idempotent() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let r1 = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     let r2 = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     let r3 = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
@@ -97,7 +97,7 @@ fn test_process_monitor_nb_empty_directives() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(PmixError::Success),
@@ -128,8 +128,8 @@ fn test_process_monitor_nb_with_directives() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let monitor = InfoBuilder::new().build();
-    let directive = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let directive = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(PmixError::Success),
@@ -160,9 +160,9 @@ fn test_process_monitor_nb_multiple_directives() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let monitor = InfoBuilder::new().build();
-    let d1 = InfoBuilder::new().build();
-    let d2 = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let d1 = InfoBuilder::new().build().expect("build info");
+    let d2 = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(PmixError::Success),
@@ -193,7 +193,7 @@ fn test_process_monitor_nb_deterministic() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let r1 = process_monitor_nb(
         &monitor,
         PmixStatus::Known(PmixError::Success),
@@ -231,7 +231,7 @@ fn test_process_monitor_nb_error_status() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(PmixError::ErrNotFound),

--- a/tests/monitoring_Process_monitor.rs
+++ b/tests/monitoring_Process_monitor.rs
@@ -131,7 +131,7 @@ fn test_process_monitor_signature() {
 /// process_monitor returns Err without daemon.
 #[test]
 fn test_process_monitor_without_daemon_returns_err() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = &[];
     let result = process_monitor(
         &monitor,
@@ -164,7 +164,7 @@ fn test_process_monitor_nb_signature() {
 /// process_monitor_nb returns Err without daemon.
 #[test]
 fn test_process_monitor_nb_without_daemon_returns_err() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = &[];
     let cb: Box<dyn MonitorCallback> = Box::new(TestMonitorCallback);
     let result = process_monitor_nb(

--- a/tests/monitoring_comprehensive.rs
+++ b/tests/monitoring_comprehensive.rs
@@ -125,14 +125,14 @@ fn test_process_monitor_signature() {
 /// process_monitor can be called with empty directives.
 #[test]
 fn test_process_monitor_empty_directives() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let _result = process_monitor(&monitor, PmixStatus::from_raw(-109), &[]);
 }
 
 /// process_monitor accepts various error status codes.
 #[test]
 fn test_process_monitor_error_codes() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
 
     let _ = process_monitor(&monitor, PmixStatus::from_raw(-109), &[]);
     let _ = process_monitor(&monitor, PmixStatus::from_raw(-110), &[]);
@@ -142,7 +142,7 @@ fn test_process_monitor_error_codes() {
 /// process_monitor with multiple calls doesn't corrupt state.
 #[test]
 fn test_process_monitor_multiple_calls() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for i in 0..5 {
         let _ = process_monitor(&monitor, PmixStatus::from_raw(i as i32), &[]);
     }
@@ -151,7 +151,7 @@ fn test_process_monitor_multiple_calls() {
 /// process_monitor returns error without server (PMIX_ERR_INIT expected).
 #[test]
 fn test_process_monitor_returns_error_without_server() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::from_raw(-109), &[]);
 
     match result {
@@ -185,7 +185,7 @@ fn test_process_monitor_nb_accepts_callback() {
         fn on_complete(&mut self, _s: PmixStatus, _r: Option<pmix::monitoring::MonitorResults>) {}
     }
 
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::from_raw(-109),
@@ -218,7 +218,7 @@ fn test_process_monitor_nb_stateful_callback() {
         called: Arc::clone(&called),
     });
 
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let _ = process_monitor_nb(&monitor, PmixStatus::from_raw(-109), &[], cb);
 }
 
@@ -230,7 +230,7 @@ fn test_process_monitor_nb_unique_request_ids() {
         fn on_complete(&mut self, _s: PmixStatus, _r: Option<pmix::monitoring::MonitorResults>) {}
     }
 
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for _ in 0..20 {
         let _ = process_monitor_nb(&monitor, PmixStatus::from_raw(-109), &[], Box::new(DummyCb));
     }
@@ -244,7 +244,7 @@ fn test_process_monitor_nb_empty_directives() {
         fn on_complete(&mut self, _s: PmixStatus, _r: Option<pmix::monitoring::MonitorResults>) {}
     }
 
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let _ = process_monitor_nb(&monitor, PmixStatus::from_raw(0), &[], Box::new(DummyCb));
 }
 
@@ -340,7 +340,7 @@ fn test_monitor_alternating_calls() {
         fn on_complete(&mut self, _s: PmixStatus, _r: Option<pmix::monitoring::MonitorResults>) {}
     }
 
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
 
     for _ in 0..5 {
         let _ = process_monitor(&monitor, PmixStatus::from_raw(-109), &[]);
@@ -351,7 +351,7 @@ fn test_monitor_alternating_calls() {
 /// InfoBuilder can construct monitoring info entries.
 #[test]
 fn test_infobuilder_for_monitoring() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     assert!(info.is_empty());
     assert_eq!(info.len(), 0);
 }

--- a/tests/monitoring_coverage.rs
+++ b/tests/monitoring_coverage.rs
@@ -19,15 +19,15 @@ use pmix::{InfoBuilder, PmixError, PmixStatus};
 #[test]
 fn test_process_monitor_without_init_returns_error() {
     // Without PMIx_Init, process_monitor should return an error, not panic.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     assert!(result.is_err(), "process_monitor without init should fail");
 }
 
 #[test]
 fn test_process_monitor_with_directives_without_init() {
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build(), InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrTimeout), &dirs);
     assert!(
         result.is_err(),
@@ -37,7 +37,7 @@ fn test_process_monitor_with_directives_without_init() {
 
 #[test]
 fn test_process_monitor_success_error_code_without_init() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::Success), &[]);
     // Without init, even a "success" error code will fail at the FFI layer
     assert!(result.is_err());
@@ -45,7 +45,7 @@ fn test_process_monitor_success_error_code_without_init() {
 
 #[test]
 fn test_process_monitor_multiple_calls_without_init() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for i in 0..5 {
         let result = process_monitor(&monitor, PmixStatus::from_raw(-100 - i as i32), &[]);
         assert!(result.is_err(), "iteration {} should fail", i);
@@ -67,7 +67,7 @@ impl MonitorCallback for CountingMonitorCb {
 
 #[test]
 fn test_process_monitor_nb_without_init_returns_error() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let cb = Box::new(CountingMonitorCb {
         count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     });
@@ -80,8 +80,8 @@ fn test_process_monitor_nb_without_init_returns_error() {
 
 #[test]
 fn test_process_monitor_nb_with_directives_without_init() {
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     struct NoopCb;
     impl MonitorCallback for NoopCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
@@ -99,7 +99,7 @@ fn test_process_monitor_nb_with_directives_without_init() {
 fn test_process_monitor_nb_callback_not_invoked_on_error() {
     // When process_monitor_nb fails immediately (no init), the callback
     // should NOT be registered — it's cleaned up in the error path.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     struct NoopCb;
     impl MonitorCallback for NoopCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
@@ -117,7 +117,7 @@ fn test_process_monitor_nb_callback_not_invoked_on_error() {
 
 #[test]
 fn test_process_monitor_nb_multiple_fails_are_consistent() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     struct NoopCb;
     impl MonitorCallback for NoopCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
@@ -273,7 +273,7 @@ fn test_monitor_callback_send_bound() {
 fn test_monitor_with_collect_data_info() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let monitor = builder.build();
+    let monitor = builder.build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     // Without init, still fails — but the Info construction path is exercised
     assert!(result.is_err());
@@ -281,11 +281,11 @@ fn test_monitor_with_collect_data_info() {
 
 #[test]
 fn test_monitor_directives_multiple_info_objects() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let dirs = vec![
-        InfoBuilder::new().build(),
-        InfoBuilder::new().build(),
-        InfoBuilder::new().build(),
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
     ];
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &dirs);
     assert!(result.is_err());

--- a/tests/monitoring_coverage.rs
+++ b/tests/monitoring_coverage.rs
@@ -27,7 +27,10 @@ fn test_process_monitor_without_init_returns_error() {
 #[test]
 fn test_process_monitor_with_directives_without_init() {
     let monitor = InfoBuilder::new().build().expect("build info");
-    let dirs = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
+    let dirs = vec![
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
+    ];
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrTimeout), &dirs);
     assert!(
         result.is_err(),

--- a/tests/monitoring_deep.rs
+++ b/tests/monitoring_deep.rs
@@ -160,7 +160,10 @@ fn test_process_monitor_timeout_error_code() {
 fn test_process_monitor_multiple_directives() {
     daemon_helper::ensure_pmix_init();
     let monitor = InfoBuilder::new().build().expect("build info");
-    let dirs = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
+    let dirs = vec![
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
+    ];
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),

--- a/tests/monitoring_deep.rs
+++ b/tests/monitoring_deep.rs
@@ -66,7 +66,7 @@ fn test_monitor_callback_closure() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -74,7 +74,7 @@ fn test_infobuilder_build_empty() {
 fn test_infobuilder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -110,7 +110,7 @@ fn test_heartbeat_multiple_does_not_panic() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_empty_directives() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -123,8 +123,8 @@ fn test_process_monitor_empty_directives() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_with_directives() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -137,7 +137,7 @@ fn test_process_monitor_with_directives() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_success_error_code() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(pmix::PmixError::Success), &[]);
     let _ = result;
 }
@@ -146,7 +146,7 @@ fn test_process_monitor_success_error_code() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_timeout_error_code() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrTimeout),
@@ -159,8 +159,8 @@ fn test_process_monitor_timeout_error_code() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_multiple_directives() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build(), InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -173,7 +173,7 @@ fn test_process_monitor_multiple_directives() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_result_has_len() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -196,7 +196,7 @@ fn test_process_monitor_with_collect_info() {
     daemon_helper::ensure_pmix_init();
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let monitor = builder.build();
+    let monitor = builder.build().expect("build info");
     let result = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -215,7 +215,7 @@ fn test_process_monitor_nb_success() {
     impl MonitorCallback for NoopMonitorCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -233,8 +233,8 @@ fn test_process_monitor_nb_with_directives() {
     impl MonitorCallback for NoopMonitorCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -252,7 +252,7 @@ fn test_process_monitor_nb_success_error_code() {
     impl MonitorCallback for NoopMonitorCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor_nb(
         &monitor,
         PmixStatus::Known(pmix::PmixError::Success),
@@ -270,7 +270,7 @@ fn test_process_monitor_nb_multiple_callbacks() {
     impl MonitorCallback for NoopMonitorCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for _ in 0..3 {
         let result = process_monitor_nb(
             &monitor,
@@ -321,7 +321,7 @@ fn test_monitor_then_heartbeat() {
     impl MonitorCallback for NoopMonitorCb {
         fn on_complete(&mut self, _status: PmixStatus, _results: Option<MonitorResults>) {}
     }
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let _ = process_monitor_nb(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),
@@ -335,7 +335,7 @@ fn test_monitor_then_heartbeat() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_monitor_sync_then_heartbeat() {
     daemon_helper::ensure_pmix_init();
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let _ = process_monitor(
         &monitor,
         PmixStatus::Known(pmix::PmixError::ErrNotFound),

--- a/tests/monitoring_unit.rs
+++ b/tests/monitoring_unit.rs
@@ -197,7 +197,7 @@ fn test_monitor_callback_box_dyn_is_sized() {
 #[test]
 fn test_process_monitor_empty_monitor_empty_directives() {
     // Both monitor and directives are empty Info objects.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     assert!(monitor.is_empty());
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     assert!(result.is_err(), "should fail without PMIx_Init");
@@ -205,11 +205,11 @@ fn test_process_monitor_empty_monitor_empty_directives() {
 
 #[test]
 fn test_process_monitor_with_single_directive() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let dirs = vec![{
         let mut b = InfoBuilder::new();
         b.collect_data();
-        b.build()
+        b.build().expect("build info")
     }];
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrTimeout), &dirs);
     assert!(result.is_err());
@@ -217,15 +217,15 @@ fn test_process_monitor_with_single_directive() {
 
 #[test]
 fn test_process_monitor_with_multiple_directives() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let dirs = vec![
         {
             let mut b = InfoBuilder::new();
             b.collect_data();
-            b.build()
+            b.build().expect("build info")
         },
-        InfoBuilder::new().build(),
-        InfoBuilder::new().build(),
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
     ];
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &dirs);
     assert!(result.is_err());
@@ -233,7 +233,7 @@ fn test_process_monitor_with_multiple_directives() {
 
 #[test]
 fn test_process_monitor_with_various_error_codes() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let error_codes = vec![
         PmixStatus::Known(PmixError::Success),
         PmixStatus::Known(PmixError::Error),
@@ -259,7 +259,7 @@ fn test_process_monitor_with_various_error_codes() {
 
 #[test]
 fn test_process_monitor_error_status_value() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     match result {
         Err(status) => {
@@ -273,7 +273,7 @@ fn test_process_monitor_error_status_value() {
 #[test]
 fn test_process_monitor_repeated_calls_same_error() {
     // Multiple calls should produce the same error consistently.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let mut first_error: Option<PmixStatus> = None;
     for _ in 0..10 {
         let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
@@ -297,7 +297,7 @@ fn test_process_monitor_repeated_calls_same_error() {
 
 #[test]
 fn test_process_monitor_nb_empty_monitor_no_directives() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let cb = Box::new(CounterMonitorCb {
         counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     });
@@ -307,8 +307,8 @@ fn test_process_monitor_nb_empty_monitor_no_directives() {
 
 #[test]
 fn test_process_monitor_nb_with_directives() {
-    let monitor = InfoBuilder::new().build();
-    let dirs = vec![InfoBuilder::new().build()];
+    let monitor = InfoBuilder::new().build().expect("build info");
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let cb = Box::new(CounterMonitorCb {
         counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     });
@@ -326,7 +326,7 @@ fn test_process_monitor_nb_error_does_not_leak_callback() {
     // When process_monitor_nb fails, the callback should be cleaned up from
     // the registry. We verify this by making many calls — if callbacks leaked,
     // the registry would grow unbounded.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for _ in 0..20 {
         let cb = Box::new(CounterMonitorCb {
             counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -339,7 +339,7 @@ fn test_process_monitor_nb_error_does_not_leak_callback() {
 
 #[test]
 fn test_process_monitor_nb_various_error_codes() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let error_codes = vec![
         PmixStatus::Known(PmixError::Success),
         PmixStatus::Known(PmixError::Error),
@@ -360,7 +360,7 @@ fn test_process_monitor_nb_various_error_codes() {
 #[test]
 fn test_process_monitor_nb_multiple_different_callbacks() {
     // Each call uses a different callback implementation.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
 
     // Call 1: CounterMonitorCb
     let cb1 = Box::new(CounterMonitorCb {
@@ -481,7 +481,7 @@ fn test_monitor_seq_increments_with_each_nb_call() {
     // request IDs would collide and callbacks could interfere.
     // Since all calls fail (no init), each callback is cleaned up,
     // and we can make many calls without issues.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     for _ in 0..50 {
         let cb = Box::new(CounterMonitorCb {
             counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -496,7 +496,7 @@ fn test_monitor_seq_increments_with_each_nb_call() {
 #[test]
 fn test_monitor_seq_no_collision_with_many_calls() {
     // Stress test: many rapid calls should all produce unique request IDs.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let num_calls = 100;
     for i in 0..num_calls {
         let cb = Box::new(CounterMonitorCb {
@@ -540,7 +540,7 @@ fn test_process_monitor_with_collect_data_monitor() {
     // Use a monitor with collect_data set.
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let monitor = builder.build();
+    let monitor = builder.build().expect("build info");
     assert!(!monitor.is_empty());
     let result = process_monitor(&monitor, PmixStatus::Known(PmixError::ErrNotFound), &[]);
     assert!(result.is_err());
@@ -550,7 +550,7 @@ fn test_process_monitor_with_collect_data_monitor() {
 fn test_process_monitor_nb_with_collect_data_monitor() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let monitor = builder.build();
+    let monitor = builder.build().expect("build info");
     let cb = Box::new(CounterMonitorCb {
         counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     });
@@ -560,8 +560,8 @@ fn test_process_monitor_nb_with_collect_data_monitor() {
 
 #[test]
 fn test_process_monitor_empty_info_len() {
-    // Verify InfoBuilder::new().build() produces an empty Info (len=0).
-    let info = InfoBuilder::new().build();
+    // Verify InfoBuilder::new().build().expect("build info") produces an empty Info (len=0).
+    let info = InfoBuilder::new().build().expect("build info");
     assert_eq!(info.len(), 0);
     assert!(info.is_empty());
 }
@@ -571,7 +571,7 @@ fn test_process_monitor_nonempty_info_len() {
     // Verify InfoBuilder with entries produces a non-empty Info.
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     assert_eq!(info.len(), 1);
     assert!(!info.is_empty());
 }
@@ -582,7 +582,7 @@ fn test_process_monitor_nonempty_info_len() {
 
 #[test]
 fn test_process_monitor_with_unknown_status() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     // Use an unknown/unrecognized status code.
     let result = process_monitor(&monitor, PmixStatus::Unknown(-12345), &[]);
     assert!(result.is_err());
@@ -590,7 +590,7 @@ fn test_process_monitor_with_unknown_status() {
 
 #[test]
 fn test_process_monitor_nb_with_unknown_status() {
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let cb = Box::new(CounterMonitorCb {
         counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     });
@@ -601,7 +601,7 @@ fn test_process_monitor_nb_with_unknown_status() {
 #[test]
 fn test_process_monitor_with_positive_status() {
     // Positive status codes are informational/success range.
-    let monitor = InfoBuilder::new().build();
+    let monitor = InfoBuilder::new().build().expect("build info");
     let result = process_monitor(&monitor, PmixStatus::Unknown(42), &[]);
     assert!(result.is_err()); // Still fails without init
 }

--- a/tests/monitoring_via_prterun.rs
+++ b/tests/monitoring_via_prterun.rs
@@ -44,7 +44,7 @@ fn test_monitor_results_empty() {
 #[test]
 fn test_process_monitor_fails_without_init() {
     if !is_dvm_launched() {
-        let monitor_info = pmix::InfoBuilder::new().build();
+        let monitor_info = pmix::InfoBuilder::new().build().expect("build info");
         let result =
             pmix::monitoring::process_monitor(&monitor_info, PmixStatus::from_raw(-46), &[]);
         assert!(result.is_err());
@@ -86,7 +86,7 @@ fn test_heartbeat_via_dvm() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_process_monitor_via_dvm() {
     daemon_helper::ensure_pmix_init();
-    let monitor_info = pmix::InfoBuilder::new().build();
+    let monitor_info = pmix::InfoBuilder::new().build().expect("build info");
     let result = pmix::monitoring::process_monitor(&monitor_info, PmixStatus::from_raw(-46), &[]);
     match result {
         Ok(results) => {
@@ -107,6 +107,6 @@ fn test_monitoring_lifecycle_via_dvm() {
     let _ = pmix::monitoring::heartbeat();
 
     // Process monitor
-    let monitor_info = pmix::InfoBuilder::new().build();
+    let monitor_info = pmix::InfoBuilder::new().build().expect("build info");
     let _ = pmix::monitoring::process_monitor(&monitor_info, PmixStatus::from_raw(-46), &[]);
 }

--- a/tests/process_mgmt_coverage.rs
+++ b/tests/process_mgmt_coverage.rs
@@ -29,7 +29,7 @@ fn test_spawn_empty_apps_rejected() {
 
 #[test]
 fn test_spawn_empty_apps_with_info_rejected() {
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = spawn(&info, &[]);
     assert!(result.is_err());
 }
@@ -60,7 +60,7 @@ fn test_connect_empty_procs_rejected() {
 
 #[test]
 fn test_connect_empty_procs_with_info_rejected() {
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = connect(&[], &info);
     assert!(result.is_err());
 }
@@ -80,7 +80,7 @@ fn test_disconnect_empty_procs_rejected() {
 
 #[test]
 fn test_disconnect_empty_procs_with_info_rejected() {
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = disconnect(&[], &info);
     assert!(result.is_err());
 }

--- a/tests/process_mgmt_deep.rs
+++ b/tests/process_mgmt_deep.rs
@@ -212,7 +212,7 @@ fn test_spawn_empty_apps_rejected() {
 
 #[test]
 fn test_spawn_empty_apps_with_info_rejected() {
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = spawn(&info, &[]);
     assert!(result.is_err());
 }
@@ -343,7 +343,7 @@ fn test_spawn_single_app() {
 fn test_spawn_with_info() {
     daemon_helper::ensure_pmix_init();
     let app = PmixApp::builder().cmd("/bin/true").build().expect("build");
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = spawn(&info, &[app]);
     let _ = result;
 }
@@ -404,7 +404,7 @@ fn test_connect_multiple_procs() {
 fn test_connect_with_info() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("ns", 0).expect("proc");
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = connect(&[proc], &info);
     let _ = result;
 }
@@ -437,7 +437,7 @@ fn test_disconnect_single_proc() {
 fn test_disconnect_with_info() {
     daemon_helper::ensure_pmix_init();
     let proc = Proc::new("ns", 0).expect("proc");
-    let info = vec![InfoBuilder::new().build()];
+    let info = vec![InfoBuilder::new().build().expect("build info")];
     let result = disconnect(&[proc], &info);
     let _ = result;
 }

--- a/tests/query_log_Log_wrapper.rs
+++ b/tests/query_log_Log_wrapper.rs
@@ -27,7 +27,7 @@ fn test_log_data_empty() {
 /// log_data with data but no directives returns error.
 #[test]
 fn test_log_data_with_data() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let data = vec![info];
     let directives: Vec<pmix::Info> = vec![];
     let result = log_data(&data, &directives);
@@ -38,7 +38,7 @@ fn test_log_data_with_data() {
 #[test]
 fn test_log_data_with_directives() {
     let data: Vec<pmix::Info> = vec![];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives = vec![info];
     let result = log_data(&data, &directives);
     assert!(result.is_err());
@@ -47,8 +47,8 @@ fn test_log_data_with_directives() {
 /// log_data with both data and directives returns error.
 #[test]
 fn test_log_data_with_both() {
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let data = vec![info1];
     let directives = vec![info2];
     let result = log_data(&data, &directives);
@@ -58,8 +58,8 @@ fn test_log_data_with_both() {
 /// log_data with multiple data entries returns error.
 #[test]
 fn test_log_data_multiple_entries() {
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let data = vec![info1, info2];
     let directives: Vec<pmix::Info> = vec![];
     let result = log_data(&data, &directives);
@@ -126,7 +126,7 @@ fn test_log_data_nb_with_data() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let data = vec![info];
     let directives: Vec<pmix::Info> = vec![];
     let result = log_data_nb(
@@ -159,7 +159,7 @@ fn test_log_data_nb_with_directives() {
         }
     }
     let data: Vec<pmix::Info> = vec![];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let directives = vec![info];
     let result = log_data_nb(
         &data,
@@ -190,8 +190,8 @@ fn test_log_data_nb_with_both() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let data = vec![info1];
     let directives = vec![info2];
     let result = log_data_nb(

--- a/tests/query_log_Query_wrapper.rs
+++ b/tests/query_log_Query_wrapper.rs
@@ -76,7 +76,7 @@ fn test_query_new_deterministic() {
 #[test]
 fn test_query_with_qualifiers() {
     let query = PmixQuery::new(&["test_key"]).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _query_with_qual = query.with_qualifiers(info);
 }
 
@@ -84,7 +84,7 @@ fn test_query_with_qualifiers() {
 #[test]
 fn test_query_with_empty_qualifiers() {
     let query = PmixQuery::new(&["test_key"]).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _query_with_qual = query.with_qualifiers(info);
 }
 

--- a/tests/query_log_coverage.rs
+++ b/tests/query_log_coverage.rs
@@ -101,14 +101,14 @@ fn test_query_multiple_independent() {
 
 #[test]
 fn test_query_with_empty_qualifiers() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let query = PmixQuery::new(&["test_key"]).expect("create");
     let _query = query.with_qualifiers(info);
 }
 
 #[test]
 fn test_query_with_qualifiers_chained() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _query = PmixQuery::new(&["test_key"])
         .expect("create")
         .with_qualifiers(info);
@@ -116,7 +116,7 @@ fn test_query_with_qualifiers_chained() {
 
 #[test]
 fn test_query_with_qualifiers_transfers_ownership() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let query = PmixQuery::new(&["test_key"]).expect("create");
     let _query = query.with_qualifiers(info);
     // info is consumed — can't use it anymore
@@ -241,7 +241,7 @@ fn test_log_callback_send_bound() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -249,7 +249,7 @@ fn test_infobuilder_build_empty() {
 fn test_infobuilder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 #[test]
@@ -257,7 +257,7 @@ fn test_infobuilder_multiple_collect() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/query_log_deep.rs
+++ b/tests/query_log_deep.rs
@@ -89,14 +89,14 @@ fn test_query_drop_loop() {
 
 #[test]
 fn test_query_with_empty_qualifiers() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let query = PmixQuery::new(&["test_key"]).expect("create");
     let _query = query.with_qualifiers(info);
 }
 
 #[test]
 fn test_query_with_qualifiers_chained() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _query = PmixQuery::new(&["test_key"])
         .expect("create")
         .with_qualifiers(info);
@@ -142,7 +142,7 @@ fn test_query_new_nul_does_not_panic() {
 
 #[test]
 fn test_infobuilder_build_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = info;
 }
 
@@ -150,7 +150,7 @@ fn test_infobuilder_build_empty() {
 fn test_infobuilder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let _info = builder.build();
+    let _info = builder.build().expect("build info");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -207,7 +207,7 @@ fn test_query_info_result_has_len() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_query_info_with_qualifiers() {
     daemon_helper::ensure_pmix_init();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let query = PmixQuery::new(&["test_key"])
         .expect("create")
         .with_qualifiers(info);
@@ -270,7 +270,7 @@ fn test_log_data_empty() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_log_data_with_data() {
     daemon_helper::ensure_pmix_init();
-    let data = vec![InfoBuilder::new().build()];
+    let data = vec![InfoBuilder::new().build().expect("build info")];
     let result = log_data(&data, &[]);
     let _ = result;
 }
@@ -279,8 +279,8 @@ fn test_log_data_with_data() {
 #[ignore = "requires DVM-launched process (prterun)"]
 fn test_log_data_with_directives() {
     daemon_helper::ensure_pmix_init();
-    let data = vec![InfoBuilder::new().build()];
-    let dirs = vec![InfoBuilder::new().build()];
+    let data = vec![InfoBuilder::new().build().expect("build info")];
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = log_data(&data, &dirs);
     let _ = result;
 }
@@ -290,9 +290,9 @@ fn test_log_data_with_directives() {
 fn test_log_data_multiple_entries() {
     daemon_helper::ensure_pmix_init();
     let data = vec![
-        InfoBuilder::new().build(),
-        InfoBuilder::new().build(),
-        InfoBuilder::new().build(),
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
     ];
     let result = log_data(&data, &[]);
     let _ = result;
@@ -304,7 +304,7 @@ fn test_log_data_with_collect_info() {
     daemon_helper::ensure_pmix_init();
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let data = vec![builder.build()];
+    let data = vec![builder.build().expect("build info")];
     let result = log_data(&data, &[]);
     let _ = result;
 }
@@ -331,7 +331,7 @@ fn test_log_data_nb_with_data() {
     impl LogCallback for NoopLogCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let data = vec![InfoBuilder::new().build()];
+    let data = vec![InfoBuilder::new().build().expect("build info")];
     let result = log_data_nb(&data, &[], Box::new(NoopLogCb));
     let _ = result;
 }
@@ -344,8 +344,8 @@ fn test_log_data_nb_with_directives() {
     impl LogCallback for NoopLogCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let data = vec![InfoBuilder::new().build()];
-    let dirs = vec![InfoBuilder::new().build()];
+    let data = vec![InfoBuilder::new().build().expect("build info")];
+    let dirs = vec![InfoBuilder::new().build().expect("build info")];
     let result = log_data_nb(&data, &dirs, Box::new(NoopLogCb));
     let _ = result;
 }
@@ -358,7 +358,7 @@ fn test_query_then_log() {
     daemon_helper::ensure_pmix_init();
     let query = PmixQuery::new(&["test_key"]).expect("create");
     let _ = query_info(&[query]);
-    let data = vec![InfoBuilder::new().build()];
+    let data = vec![InfoBuilder::new().build().expect("build info")];
     let _ = log_data(&data, &[]);
 }
 

--- a/tests/security_Credential_operations.rs
+++ b/tests/security_Credential_operations.rs
@@ -74,8 +74,8 @@ fn test_validation_results_is_empty_true() {
 /// get_credential with multiple info entries returns error.
 #[test]
 fn test_get_credential_multiple_info() {
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let result = get_credential(&[info1, info2]);
     assert!(result.is_err());
 }
@@ -98,8 +98,8 @@ fn test_get_credential_idempotent() {
 /// validate_credential with multiple info entries returns error.
 #[test]
 fn test_validate_credential_multiple_info() {
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let cred = PmixCredential::from_bytes(&[1, 2, 3]);
     let result = validate_credential(&cred, &[info1, info2]);
     assert!(result.is_err());
@@ -150,8 +150,8 @@ fn test_get_credential_nb_multiple_info() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let result = get_credential_nb(
         &[info1, info2],
         Box::new(Cb {
@@ -181,8 +181,8 @@ fn test_validate_credential_nb_multiple_info() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info1 = InfoBuilder::new().build();
-    let info2 = InfoBuilder::new().build();
+    let info1 = InfoBuilder::new().build().expect("build info");
+    let info2 = InfoBuilder::new().build().expect("build info");
     let cred = PmixCredential::from_bytes(&[1, 2, 3]);
     let result = validate_credential_nb(
         &cred,

--- a/tests/security_Credential_wrapper.rs
+++ b/tests/security_Credential_wrapper.rs
@@ -111,7 +111,7 @@ fn test_get_credential_empty_info() {
 /// get_credential with info returns error (not initialized).
 #[test]
 fn test_get_credential_with_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = get_credential(&[info]);
     assert!(result.is_err());
 }
@@ -183,7 +183,7 @@ fn test_get_credential_nb_with_info() {
             self.c.store(true, Ordering::SeqCst);
         }
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = get_credential_nb(
         &[info],
         Box::new(Cb {
@@ -222,7 +222,7 @@ fn test_validate_credential_with_data() {
 /// validate_credential with info returns error.
 #[test]
 fn test_validate_credential_with_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let cred = PmixCredential::from_bytes(&[1, 2, 3]);
     let result = validate_credential(&cred, &[info]);
     assert!(result.is_err());

--- a/tests/server_connection_via_daemon.rs
+++ b/tests/server_connection_via_daemon.rs
@@ -75,7 +75,7 @@ fn test_server_connect_empty_procs_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_connect(&handle, &[], &[]);
@@ -95,7 +95,7 @@ fn test_server_connect_with_proc_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("test_nspace", 0).expect("invalid nspace")];
@@ -113,11 +113,11 @@ fn test_server_connect_with_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("info_connect_test", 0).expect("invalid nspace")];
-    let connect_info = vec![InfoBuilder::new().build()];
+    let connect_info = vec![InfoBuilder::new().build().expect("build info")];
     let result = server_connect(&handle, &procs, &connect_info);
     let _ = result;
 
@@ -132,7 +132,7 @@ fn test_server_connect_nb_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("nb_connect_test", 0).expect("invalid nspace")];
@@ -151,7 +151,7 @@ fn test_server_disconnect_empty_procs_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_disconnect(&handle, &[], &[]);
@@ -171,7 +171,7 @@ fn test_server_disconnect_with_proc_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("disconnect_test", 0).expect("invalid nspace")];
@@ -189,11 +189,11 @@ fn test_server_disconnect_with_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("info_disconnect_test", 0).expect("invalid nspace")];
-    let disconnect_info = vec![InfoBuilder::new().build()];
+    let disconnect_info = vec![InfoBuilder::new().build().expect("build info")];
     let result = server_disconnect(&handle, &procs, &disconnect_info);
     let _ = result;
 
@@ -208,7 +208,7 @@ fn test_server_disconnect_nb_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("nb_disconnect_test", 0).expect("invalid nspace")];
@@ -227,7 +227,7 @@ fn test_server_connect_disconnect_cycle_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let procs = vec![Proc::new("connect_disconnect_cycle", 0).expect("invalid nspace")];

--- a/tests/server_core_via_daemon.rs
+++ b/tests/server_core_via_daemon.rs
@@ -54,7 +54,7 @@ fn test_server_init_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
     assert!(is_server_initialized(), "server should be initialized");
     server_finalize(handle).expect("server_finalize should succeed");
@@ -106,7 +106,7 @@ fn test_server_finalize_ok_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
     let result: Result<(), PmixStatus> = server_finalize(handle);
     assert!(result.is_ok(), "server_finalize should return Ok");
@@ -121,7 +121,7 @@ fn test_server_init_with_callbacks_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle =
         server_init(Some(&module), &info).expect("server_init with callbacks should succeed");
     assert!(is_server_initialized());
@@ -159,7 +159,7 @@ fn test_server_module_default_with_daemon() {
     assert!(module.spawn.is_none());
 
     // Verify it works with daemon
-    let handle = server_init(Some(&module), &InfoBuilder::new().build())
+    let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info"))
         .expect("server_init with default module should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -176,7 +176,7 @@ fn test_server_module_as_c_ptr_with_daemon() {
     assert!(!ptr.is_null(), "as_c_ptr should not return null");
 
     // Verify it works with daemon
-    let handle = server_init(Some(&module), &InfoBuilder::new().build())
+    let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info"))
         .expect("server_init should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -190,7 +190,7 @@ fn test_server_init_with_callbacks_config_with_daemon() {
 
     // Module with one callback set
     let mut module = PmixServerModule::default();
-    let handle = server_init(Some(&module), &InfoBuilder::new().build())
+    let handle = server_init(Some(&module), &InfoBuilder::new().build().expect("build info"))
         .expect("server_init with one callback should succeed");
     assert!(is_server_initialized());
     server_finalize(handle).expect("server_finalize should succeed");

--- a/tests/server_deep.rs
+++ b/tests/server_deep.rs
@@ -70,7 +70,7 @@ fn test_server_module_debug() {
 
 #[test]
 fn test_server_init_with_none_module() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_init(None, &info);
     // Without PRTE daemon, server_init fails gracefully
     assert!(result.is_err() || result.is_ok());
@@ -82,7 +82,7 @@ fn test_server_init_with_none_module() {
 #[test]
 fn test_server_init_with_default_module() {
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_init(Some(&module), &info);
     assert!(result.is_err() || result.is_ok());
     if let Ok(handle) = result {
@@ -126,7 +126,7 @@ impl RegisterNspaceCallback for TestRegisterNspaceCb {
 
 #[test]
 fn test_register_nspace_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace("", 0, &info, Box::new(TestRegisterNspaceCb));
     // Empty nspace should fail gracefully
     assert!(result.is_err());
@@ -134,21 +134,21 @@ fn test_register_nspace_empty() {
 
 #[test]
 fn test_register_nspace_normal() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace("test_nspace", 4, &info, Box::new(TestRegisterNspaceCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_register_nspace_zero_localprocs() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace("zero_procs", 0, &info, Box::new(TestRegisterNspaceCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_register_nspace_large_localprocs() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result =
         server_register_nspace("large_procs", 10000, &info, Box::new(TestRegisterNspaceCb));
     assert!(result.is_err() || result.is_ok());
@@ -156,7 +156,7 @@ fn test_register_nspace_large_localprocs() {
 
 #[test]
 fn test_register_nspace_unicode() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result =
         server_register_nspace("テスト_命名空間", 2, &info, Box::new(TestRegisterNspaceCb));
     assert!(result.is_err() || result.is_ok());
@@ -338,21 +338,21 @@ impl SetupApplicationCallback for TestSetupAppCb {
 
 #[test]
 fn test_setup_application_normal() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("test_ns", &info, Box::new(TestSetupAppCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_setup_application_empty_nspace() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("", &info, Box::new(TestSetupAppCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_setup_application_unicode_nspace() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("テスト", &info, Box::new(TestSetupAppCb));
     assert!(result.is_err() || result.is_ok());
 }
@@ -368,21 +368,21 @@ impl SetupLocalSupportCallback for TestSetupLocalCb {
 
 #[test]
 fn test_setup_local_support_normal() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_local_support("test_ns", &info, Box::new(TestSetupLocalCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_setup_local_support_empty_nspace() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_local_support("", &info, Box::new(TestSetupLocalCb));
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_setup_local_support_unicode_nspace() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_local_support("テスト", &info, Box::new(TestSetupLocalCb));
     assert!(result.is_err() || result.is_ok());
 }
@@ -400,7 +400,7 @@ impl IOFDeliverCallback for TestIOFDeliverCb {
 fn test_iof_deliver_stdout() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &proc,
         IOFChannelFlags::STDOUT,
@@ -415,7 +415,7 @@ fn test_iof_deliver_stdout() {
 fn test_iof_deliver_stderr() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &proc,
         IOFChannelFlags::STDERR,
@@ -430,7 +430,7 @@ fn test_iof_deliver_stderr() {
 fn test_iof_deliver_stdin() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &proc,
         IOFChannelFlags::STDIN,
@@ -445,7 +445,7 @@ fn test_iof_deliver_stdin() {
 fn test_iof_deliver_all_channels() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &proc,
         IOFChannelFlags::ALL_CHANNELS,
@@ -460,7 +460,7 @@ fn test_iof_deliver_all_channels() {
 fn test_iof_deliver_no_channels() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &proc,
         IOFChannelFlags::NO_CHANNELS,
@@ -475,7 +475,7 @@ fn test_iof_deliver_no_channels() {
 fn test_iof_deliver_combined_channels() {
     let proc = Proc::new("test_ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let channel = IOFChannelFlags::STDOUT | IOFChannelFlags::STDERR;
     let result = server_iof_deliver(&proc, channel, &bo, &info, Box::new(TestIOFDeliverCb));
     assert!(result.is_err() || result.is_ok());
@@ -661,7 +661,7 @@ fn test_compile_deregister_resources_callback_wrapper() {
 
 #[test]
 fn test_server_init_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| server_init(None, &info));
     assert!(result.is_ok());
 }
@@ -680,7 +680,7 @@ fn test_is_server_initialized_does_not_panic() {
 
 #[test]
 fn test_register_nspace_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| {
         server_register_nspace("test", 0, &info, Box::new(TestRegisterNspaceCb))
     });
@@ -722,7 +722,7 @@ fn test_setup_fork_does_not_panic() {
 
 #[test]
 fn test_setup_application_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| {
         server_setup_application("test", &info, Box::new(TestSetupAppCb))
     });
@@ -731,7 +731,7 @@ fn test_setup_application_does_not_panic() {
 
 #[test]
 fn test_setup_local_support_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| {
         server_setup_local_support("test", &info, Box::new(TestSetupLocalCb))
     });
@@ -742,7 +742,7 @@ fn test_setup_local_support_does_not_panic() {
 fn test_iof_deliver_does_not_panic() {
     let proc = Proc::new("ns", 0).expect("proc");
     let bo = PmixByteObject::new();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| {
         server_iof_deliver(
             &proc,
@@ -770,7 +770,7 @@ impl DmodexRequestCallback for TestDmodexRequestCb {
 
 #[test]
 fn test_collect_inventory_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     struct TestCollectCb;
     impl CollectInventoryCallback for TestCollectCb {
         fn on_complete(&self, _status: PmixStatus, _inventory: CollectInventoryResults) {}
@@ -782,8 +782,8 @@ fn test_collect_inventory_does_not_panic() {
 
 #[test]
 fn test_deliver_inventory_does_not_panic() {
-    let info = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = std::panic::catch_unwind(|| server_deliver_inventory(&info, &directives, None));
     assert!(result.is_ok());
 }
@@ -802,7 +802,7 @@ fn test_delete_process_set_does_not_panic() {
 
 #[test]
 fn test_register_resources_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     struct TestRegResCb;
     impl RegisterResourcesCallback for TestRegResCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
@@ -814,7 +814,7 @@ fn test_register_resources_does_not_panic() {
 
 #[test]
 fn test_deregister_resources_does_not_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     struct TestDeregResCb;
     impl DeregisterResourcesCallback for TestDeregResCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
@@ -833,7 +833,7 @@ fn test_deregister_resources_does_not_panic() {
 fn test_server_init_then_finalize() {
     daemon_helper::ensure_pmix_init();
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init failed");
     assert!(is_server_initialized());
     server_finalize(handle).expect("server_finalize failed");
@@ -844,10 +844,10 @@ fn test_server_init_then_finalize() {
 fn test_register_nspace_then_deregister() {
     daemon_helper::ensure_pmix_init();
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init failed");
 
-    let reg_info = InfoBuilder::new().build();
+    let reg_info = InfoBuilder::new().build().expect("build info");
     server_register_nspace("test_ns", 2, &reg_info, Box::new(TestRegisterNspaceCb))
         .expect("register_nspace failed");
 
@@ -860,7 +860,7 @@ fn test_register_nspace_then_deregister() {
 fn test_register_client_then_deregister() {
     daemon_helper::ensure_pmix_init();
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init failed");
 
     let proc = Proc::new("test_ns", 0).expect("proc");
@@ -877,11 +877,11 @@ fn test_register_client_then_deregister() {
 fn test_full_server_lifecycle() {
     daemon_helper::ensure_pmix_init();
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init failed");
 
     // Register nspace
-    let reg_info = InfoBuilder::new().build();
+    let reg_info = InfoBuilder::new().build().expect("build info");
     let _ = server_register_nspace("full_ns", 4, &reg_info, Box::new(TestRegisterNspaceCb));
 
     // Register client
@@ -892,11 +892,11 @@ fn test_full_server_lifecycle() {
     let _ = server_setup_fork(&proc, Some(vec!["PATH=/usr/bin"]));
 
     // Setup application
-    let app_info = InfoBuilder::new().build();
+    let app_info = InfoBuilder::new().build().expect("build info");
     let _ = server_setup_application("full_ns", &app_info, Box::new(TestSetupAppCb));
 
     // Setup local support
-    let local_info = InfoBuilder::new().build();
+    let local_info = InfoBuilder::new().build().expect("build info");
     let _ = server_setup_local_support("full_ns", &local_info, Box::new(TestSetupLocalCb));
 
     // Deregister
@@ -920,7 +920,7 @@ fn test_server_handle_debug() {
 fn test_server_handle_default() {
     // PmixServerHandle doesn't implement Default, but we can verify
     // it's constructible from server_init result
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = server_init(None, &info);
 }
 
@@ -930,7 +930,7 @@ fn test_server_handle_default() {
 
 #[test]
 fn test_register_nspace_nul_byte() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // NUL byte in nspace should return error gracefully
     let result = server_register_nspace("test\0nspace", 0, &info, Box::new(TestRegisterNspaceCb));
     assert!(result.is_err());
@@ -944,7 +944,7 @@ fn test_deregister_nspace_nul_byte() {
 
 #[test]
 fn test_setup_application_nul_byte() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("test\0ns", &info, Box::new(TestSetupAppCb));
     assert!(result.is_err());
 }
@@ -955,16 +955,16 @@ fn test_setup_application_nul_byte() {
 
 #[test]
 fn test_deliver_inventory_blocking() {
-    let info = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_deliver_inventory(&info, &directives, None);
     assert!(result.is_err() || result.is_ok());
 }
 
 #[test]
 fn test_deliver_inventory_async() {
-    let info = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     struct TestDeliverCb;
     impl DeliverInventoryCallback for TestDeliverCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}

--- a/tests/server_dmodex_inventory.rs
+++ b/tests/server_dmodex_inventory.rs
@@ -275,7 +275,7 @@ fn collect_inventory_before_init_err_init() {
     impl CollectInventoryCallback for Nop {
         fn on_complete(&self, _: PmixStatus, _: CollectInventoryResults) {}
     }
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_collect_inventory(&directives, Box::new(Nop));
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_raw(), -31);
@@ -288,7 +288,7 @@ fn collect_inventory_empty_directives() {
     impl CollectInventoryCallback for Nop {
         fn on_complete(&self, _: PmixStatus, _: CollectInventoryResults) {}
     }
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_collect_inventory(&directives, Box::new(Nop));
     assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrInit));
 }
@@ -318,7 +318,7 @@ fn collect_inventory_with_initialized_server() {
     }
     let module = PmixServerModule::default();
     let _handle = server_init_minimal(Some(&module)).expect("server_init");
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let _ = server_collect_inventory(&directives, Box::new(Cb));
 }
 
@@ -368,16 +368,16 @@ fn deliver_inventory_with_callback() {
     impl DeliverInventoryCallback for Nop {
         fn on_complete(self: Box<Self>, _: PmixStatus) {}
     }
-    let inventory = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let _result = server_deliver_inventory(&inventory, &directives, Some(Box::new(Nop)));
 }
 
 /// server_deliver_inventory accepts None (blocking mode).
 #[test]
 fn deliver_inventory_blocking_mode() {
-    let inventory = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let _result = server_deliver_inventory(&inventory, &directives, None);
 }
 
@@ -388,8 +388,8 @@ fn deliver_inventory_empty_params() {
     impl DeliverInventoryCallback for Nop {
         fn on_complete(self: Box<Self>, _: PmixStatus) {}
     }
-    let inventory = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let _result = server_deliver_inventory(&inventory, &directives, Some(Box::new(Nop)));
 }
 
@@ -451,8 +451,8 @@ fn deliver_inventory_with_initialized_server() {
     }
     let module = PmixServerModule::default();
     let _handle = server_init_minimal(Some(&module)).expect("server_init");
-    let inventory = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
     let _ = server_deliver_inventory(&inventory, &directives, Some(Box::new(Nop)));
 }
 
@@ -800,7 +800,7 @@ fn iof_deliver_stdout_with_data() {
     }
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(b"hello".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(&source, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
 }
 
@@ -813,7 +813,7 @@ fn iof_deliver_stderr_with_data() {
     }
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(b"error".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(&source, IOFChannelFlags::STDERR, &bo, &info, Box::new(Nop));
 }
 
@@ -826,7 +826,7 @@ fn iof_deliver_stdin_with_data() {
     }
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(b"input".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(&source, IOFChannelFlags::STDIN, &bo, &info, Box::new(Nop));
 }
 
@@ -839,7 +839,7 @@ fn iof_deliver_empty_byte_object() {
     }
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(Vec::new());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(&source, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
 }
 
@@ -853,7 +853,7 @@ fn iof_deliver_large_byte_object() {
     let source = Proc::new("test_ns", 0).unwrap();
     let large: Vec<u8> = (0..65536).map(|i| (i % 256) as u8).collect();
     let bo = PmixByteObject::from(large);
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(&source, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
 }
 
@@ -867,7 +867,7 @@ fn iof_deliver_different_sources() {
     let source1 = Proc::new("job1", 0).unwrap();
     let source2 = Proc::new("job2", 42).unwrap();
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _r1 = server_iof_deliver(&source1, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
     let _r2 = server_iof_deliver(&source2, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
 }
@@ -881,7 +881,7 @@ fn iof_deliver_consistent_result() {
     }
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let first =
         server_iof_deliver(&source, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop)).is_ok();
     for _ in 0..4 {
@@ -951,7 +951,7 @@ fn iof_deliver_with_initialized_server() {
     let _handle = server_init_minimal(Some(&module)).expect("server_init");
     let source = Proc::new("test_ns", 0).unwrap();
     let bo = PmixByteObject::from(b"hello".to_vec());
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = server_iof_deliver(&source, IOFChannelFlags::STDOUT, &bo, &info, Box::new(Nop));
 }
 
@@ -1014,10 +1014,10 @@ fn proc_construction_rejects_nul() {
     assert!(result.is_err());
 }
 
-/// InfoBuilder::new().build() produces a valid Info.
+/// InfoBuilder::new().build().expect("build info") produces a valid Info.
 #[test]
 fn info_builder_empty_builds() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Info is usable as a parameter — we verify by passing it to a function.
     struct Nop;
     impl DeliverInventoryCallback for Nop {
@@ -1047,7 +1047,7 @@ fn all_eight_functions_callable_smoke() {
     impl CollectInventoryCallback for CollectNop {
         fn on_complete(&self, _: PmixStatus, _: CollectInventoryResults) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = server_collect_inventory(&info, Box::new(CollectNop));
 
     // 3. server_deliver_inventory

--- a/tests/server_init_finalize.rs
+++ b/tests/server_init_finalize.rs
@@ -256,7 +256,7 @@ fn test_register_multiple_deregister_all_then_finalize() {
 
 #[ignore] // requires daemon isolation — C-level PMIx state corrupts between tests
 fn test_server_init_none_module() {
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(None, &info).expect("server_init with None module should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -266,7 +266,7 @@ fn test_server_init_none_module() {
 #[ignore] // requires daemon isolation — C-level PMIx state corrupts between tests
 fn test_server_init_with_empty_info() {
     let module = PmixServerModule::default();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -340,7 +340,7 @@ fn test_full_lifecycle_init_register_deregister_finalize() {
 #[ignore] // requires daemon isolation — C-level PMIx state corrupts between tests
 fn test_full_lifecycle_with_server_init() {
     let module = PmixServerModule::default();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
 
     let proc = pmix::Proc::new("full.lifecycle.init.test", 0).expect("invalid nspace");
@@ -552,7 +552,7 @@ fn test_is_server_initialized_signature() {
 #[ignore] // requires daemon isolation — C-level PMIx state corrupts between tests
 fn test_server_init_no_panic() {
     let module = PmixServerModule::default();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result = std::panic::catch_unwind(|| {
         let _ = server_init(Some(&module), &info);
     });
@@ -862,7 +862,7 @@ fn test_server_init_with_callbacks_set() {
         client_connected: None,
         ..Default::default()
     };
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }

--- a/tests/server_kvs_via_daemon.rs
+++ b/tests/server_kvs_via_daemon.rs
@@ -106,11 +106,11 @@ fn test_server_publish_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Publish data — returns ErrUnreach from server context (no client connection).
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let result = server_publish(&handle, "test-nspace", &key_val);
     assert!(
         result.is_err(),
@@ -134,7 +134,7 @@ fn test_server_lookup_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Lookup — returns ErrUnreach from server context.
@@ -155,7 +155,7 @@ fn test_server_delete_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Delete — returns ErrUnreach from server context.
@@ -176,7 +176,7 @@ fn test_server_fence_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Fence — returns ErrUnreach from server context.
@@ -197,7 +197,7 @@ fn test_server_fence_with_timeout_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Fence with a non-zero timeout.
@@ -218,10 +218,10 @@ fn test_server_publish_returns_pmix_status_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let result: Result<PmixStatus, PmixStatus> = server_publish(&handle, "test-nspace", &key_val);
     assert!(
         result.is_err(),
@@ -239,7 +239,7 @@ fn test_server_fence_returns_pmix_status_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let result: Result<PmixStatus, PmixStatus> = server_fence(&handle, &[], 0);
@@ -259,7 +259,7 @@ fn test_server_delete_returns_pmix_status_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let result: Result<PmixStatus, PmixStatus> = server_delete(&handle, "test-nspace", "some-key");
@@ -280,11 +280,11 @@ fn test_server_kvs_with_callbacks_module_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Publish with callbacks module — returns ErrUnreach from server context.
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let publish_result = server_publish(&handle, "test-nspace", &key_val);
     assert!(
         publish_result.is_err(),
@@ -309,11 +309,11 @@ fn test_server_all_kvs_ops_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Publish — ErrUnreach from server context.
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let publish_result = server_publish(&handle, "test-nspace", &key_val);
     assert!(publish_result.is_err(), "publish should return Err");
 
@@ -340,7 +340,7 @@ fn test_server_lookup_not_found_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Lookup a key that was never published — returns ErrUnreach from server context.
@@ -361,11 +361,11 @@ fn test_server_publish_fence_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Publish data — ErrUnreach from server context.
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let publish_result = server_publish(&handle, "test-nspace", &key_val);
     assert!(publish_result.is_err(), "publish should return Err");
 
@@ -384,11 +384,11 @@ fn test_server_publish_delete_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Publish data — ErrUnreach from server context.
-    let key_val = InfoBuilder::new().build();
+    let key_val = InfoBuilder::new().build().expect("build info");
     let publish_result = server_publish(&handle, "test-nspace", &key_val);
     assert!(publish_result.is_err(), "publish should return Err");
 

--- a/tests/server_nspace_resources.rs
+++ b/tests/server_nspace_resources.rs
@@ -52,7 +52,7 @@ fn test_register_nspace_no_panic_valid_params() {
     impl RegisterNspaceCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_register_nspace("job.12345", 4, &info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -67,7 +67,7 @@ fn test_register_nspace_no_panic_zero_procs() {
     impl RegisterNspaceCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_register_nspace("job.00000", 0, &info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -82,7 +82,7 @@ fn test_register_nspace_nul_byte_returns_error() {
     impl RegisterNspaceCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| {
         let res = server_register_nspace("job\x00bad", 1, &info, Box::new(Dummy));
         assert!(res.is_err(), "NUL byte in nspace should return Err");
@@ -97,7 +97,7 @@ fn test_register_nspace_return_type() {
     impl RegisterNspaceCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> = server_register_nspace("test", 1, &info, Box::new(Dummy));
 }
 
@@ -220,7 +220,7 @@ fn test_register_resources_no_panic_valid_params() {
     impl RegisterResourcesCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_register_resources(&info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -235,7 +235,7 @@ fn test_register_resources_return_type() {
     impl RegisterResourcesCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> = server_register_resources(&info, Box::new(Dummy));
 }
 
@@ -297,7 +297,7 @@ fn test_deregister_resources_no_panic_valid_params() {
     impl DeregisterResourcesCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_deregister_resources(&info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -312,7 +312,7 @@ fn test_deregister_resources_return_type() {
     impl DeregisterResourcesCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> = server_deregister_resources(&info, Box::new(Dummy));
 }
 
@@ -374,7 +374,7 @@ fn test_setup_application_no_panic_valid_params() {
     impl SetupApplicationCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_setup_application("job.12345", &info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -389,7 +389,7 @@ fn test_setup_application_return_type() {
     impl SetupApplicationCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_setup_application("job.12345", &info, Box::new(Dummy));
 }
@@ -401,7 +401,7 @@ fn test_setup_application_nul_byte_returns_error() {
     impl SetupApplicationCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| {
         let res = server_setup_application("bad\x00nspace", &info, Box::new(Dummy));
         assert!(res.is_err(), "NUL byte in nspace should return Err");
@@ -552,7 +552,7 @@ fn test_setup_local_support_no_panic_valid_params() {
     impl SetupLocalSupportCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| server_setup_local_support("job.12345", &info, Box::new(Dummy)));
     assert!(
         result.is_ok(),
@@ -567,7 +567,7 @@ fn test_setup_local_support_return_type() {
     impl SetupLocalSupportCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_setup_local_support("job.12345", &info, Box::new(Dummy));
 }
@@ -579,7 +579,7 @@ fn test_setup_local_support_nul_byte_returns_error() {
     impl SetupLocalSupportCallback for Dummy {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = catch_unwind(|| {
         let res = server_setup_local_support("bad\x00nspace", &info, Box::new(Dummy));
         assert!(res.is_err(), "NUL byte in nspace should return Err");
@@ -637,7 +637,7 @@ fn test_all_seven_functions_no_panic() {
     impl RegisterNspaceCallback for DummyRegNs {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let r = catch_unwind(|| server_register_nspace("job.12345", 4, &info, Box::new(DummyRegNs)));
     assert!(r.is_ok(), "register_nspace panicked");
 
@@ -730,7 +730,7 @@ fn test_multiple_calls_consistency() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let proc = Proc::new("job.12345", 0).expect("proc creation failed");
 
     for _ in 0..3 {

--- a/tests/server_security_via_daemon.rs
+++ b/tests/server_security_via_daemon.rs
@@ -211,7 +211,10 @@ fn test_server_get_credential_multiple_attempts_with_daemon() {
     assert!(result2.is_err(), "second get_credential should return Err");
 
     // Third attempt — with multiple info directives.
-    let cred_info2 = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
+    let cred_info2 = vec![
+        InfoBuilder::new().build().expect("build info"),
+        InfoBuilder::new().build().expect("build info"),
+    ];
     let result3 = server_get_credential(&handle, &cred_info2);
     assert!(result3.is_err(), "third get_credential should return Err");
 

--- a/tests/server_security_via_daemon.rs
+++ b/tests/server_security_via_daemon.rs
@@ -113,7 +113,7 @@ fn test_server_get_credential_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Get credential — returns error without auth setup.
@@ -134,11 +134,11 @@ fn test_server_get_credential_with_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Get credential with info directives — still returns error without auth.
-    let cred_info = vec![InfoBuilder::new().build()];
+    let cred_info = vec![InfoBuilder::new().build().expect("build info")];
     let result = server_get_credential(&handle, &cred_info);
     assert!(
         result.is_err(),
@@ -156,7 +156,7 @@ fn test_server_get_credential_returns_credential_type_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let result: Result<pmix::security::PmixCredential, PmixStatus> =
@@ -178,7 +178,7 @@ fn test_server_get_credential_with_callbacks_module_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let result = server_get_credential(&handle, &[]);
@@ -198,7 +198,7 @@ fn test_server_get_credential_multiple_attempts_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // First attempt — empty info.
@@ -206,12 +206,12 @@ fn test_server_get_credential_multiple_attempts_with_daemon() {
     assert!(result1.is_err(), "first get_credential should return Err");
 
     // Second attempt — with info directives.
-    let cred_info = vec![InfoBuilder::new().build()];
+    let cred_info = vec![InfoBuilder::new().build().expect("build info")];
     let result2 = server_get_credential(&handle, &cred_info);
     assert!(result2.is_err(), "second get_credential should return Err");
 
     // Third attempt — with multiple info directives.
-    let cred_info2 = vec![InfoBuilder::new().build(), InfoBuilder::new().build()];
+    let cred_info2 = vec![InfoBuilder::new().build().expect("build info"), InfoBuilder::new().build().expect("build info")];
     let result3 = server_get_credential(&handle, &cred_info2);
     assert!(result3.is_err(), "third get_credential should return Err");
 

--- a/tests/server_server_collect_inventory.rs
+++ b/tests/server_server_collect_inventory.rs
@@ -187,7 +187,7 @@ fn collect_inventory_without_init_returns_err_init() {
         fn on_complete(&self, _status: PmixStatus, _inventory: CollectInventoryResults) {}
     }
 
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_collect_inventory(&directives, Box::new(NopCallback));
 
     // Should return Err(PMIX_ERR_INIT) because PMIx_server_init was not called.
@@ -208,8 +208,8 @@ fn collect_inventory_empty_directives() {
         fn on_complete(&self, _status: PmixStatus, _inventory: CollectInventoryResults) {}
     }
 
-    let directives = InfoBuilder::new().build();
-    // InfoBuilder::new().build() creates an empty info list (len == 0).
+    let directives = InfoBuilder::new().build().expect("build info");
+    // InfoBuilder::new().build().expect("build info") creates an empty info list (len == 0).
     let result = server_collect_inventory(&directives, Box::new(NopCallback));
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrInit));
@@ -309,10 +309,10 @@ fn collect_inventory_with_server_init() {
 
     // Initialize the PMIx server.
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _handle = server_init(Some(&module), &info).expect("PMIx_server_init failed");
 
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_collect_inventory(&directives, Box::new(TestCallback));
     assert!(
         result.is_ok(),
@@ -338,13 +338,13 @@ fn collect_inventory_with_directives() {
     }
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _handle = server_init(Some(&module), &info).expect("PMIx_server_init failed");
 
     // We cannot easily construct non-empty Info from test code because
     // Info's internal handle is a raw pointer. The C API accepts null
     // for directives, which is equivalent to an empty slice.
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let result = server_collect_inventory(&directives, Box::new(TestCallback));
     assert!(result.is_ok());
 }
@@ -363,10 +363,10 @@ fn collect_inventory_concurrent_requests() {
     }
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _handle = server_init(Some(&module), &info).expect("PMIx_server_init failed");
 
-    let directives = InfoBuilder::new().build();
+    let directives = InfoBuilder::new().build().expect("build info");
     let results: Vec<_> = (0..3)
         .map(|_| server_collect_inventory(&directives, Box::new(TestCallback)))
         .collect();
@@ -415,8 +415,8 @@ fn collect_inventory_status_error_variants() {
 /// Info type is usable as the directives parameter.
 #[test]
 fn collect_inventory_info_directives_type() {
-    let directives = InfoBuilder::new().build();
-    // InfoBuilder::new().build() creates an empty info list.
+    let directives = InfoBuilder::new().build().expect("build info");
+    // InfoBuilder::new().build().expect("build info") creates an empty info list.
 
     // The function accepts &Info.
     struct Nop;

--- a/tests/server_server_deliver_inventory.rs
+++ b/tests/server_server_deliver_inventory.rs
@@ -127,7 +127,7 @@ fn test_callback_receives_error_status() {
 
 /// Helper to create an empty Info via InfoBuilder.
 fn empty_info() -> pmix::Info {
-    InfoBuilder::new().build()
+    InfoBuilder::new().build().expect("build info")
 }
 
 /// server_deliver_inventory accepts valid inventory and directives with callback.
@@ -395,7 +395,7 @@ fn test_deliver_inventory_with_builder_info() {
     }
 
     // Build inventory using InfoBuilder.
-    let inventory = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
     let directives = empty_info();
 
     let _result = server_deliver_inventory(&inventory, &directives, Some(Box::new(BuilderCb)));
@@ -597,8 +597,8 @@ fn test_deliver_inventory_with_directives() {
     let module = PmixServerModule::default();
     let handle = server_init_minimal(Some(&module)).expect("server_init failed");
 
-    let inventory = InfoBuilder::new().build();
-    let directives = InfoBuilder::new().build();
+    let inventory = InfoBuilder::new().build().expect("build info");
+    let directives = InfoBuilder::new().build().expect("build info");
 
     let _result = server_deliver_inventory(&inventory, &directives, Some(Box::new(DirCb)));
 

--- a/tests/server_server_deregister_nspace.rs
+++ b/tests/server_server_deregister_nspace.rs
@@ -372,7 +372,7 @@ fn test_deregister_nspace_full_cycle() {
     impl pmix::server::RegisterNspaceCallback for RegCb {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     server_register_nspace("foobar", 0, &info, Box::new(RegCb));
 
     // Deregister it.

--- a/tests/server_server_deregister_resources.rs
+++ b/tests/server_server_deregister_resources.rs
@@ -193,7 +193,7 @@ fn test_server_deregister_resources_signature() {
 /// InfoBuilder produces an Info that can be passed to server_deregister_resources.
 #[test]
 fn test_info_builder_produces_compatible_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // Verify the info has the expected structure (handle + len).
     // We can't call the function without a server, but we can verify
@@ -205,7 +205,7 @@ fn test_info_builder_produces_compatible_info() {
 /// Empty info (no keys) is valid for deregister_resources.
 #[test]
 fn test_empty_info_for_deregister_resources() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Empty info is valid — it means "deregister all previously registered
     // non-namespace resources".
     fn accepts_info(_: &pmix::Info) {}
@@ -396,7 +396,7 @@ fn test_request_id_distinct_pointers() {
 fn test_deregister_all_resources_empty_info() {
     // Empty info is the standard way to deregister all non-namespace
     // resources. Verify the Info type supports this.
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // The Info struct is accepted by the function — that's the important part.
     fn accepts_info(_: &pmix::Info) {}
     accepts_info(&info);
@@ -514,7 +514,7 @@ fn test_server_deregister_resources_empty_info() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, cb);
 
     // Without a running server, this will fail with an error status.
@@ -543,7 +543,7 @@ fn test_server_deregister_resources_with_info() {
     });
 
     // Build info with keys (if InfoBuilder supports it).
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, cb);
 
     assert!(result.is_ok() || result.is_err(), "should return a result");
@@ -569,7 +569,7 @@ fn test_server_deregister_resources_callback_invoked() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, cb);
 
     if result.is_ok() {
@@ -591,7 +591,7 @@ fn test_server_deregister_resources_not_initialized() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, Box::new(TestCb));
 
     // Without PMIx_server_init, this should return an error.
@@ -621,7 +621,7 @@ fn test_server_deregister_resources_immediate_error_no_callback() {
         invoked: Arc::clone(&invoked),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, cb);
 
     // If the FFI call returns an error immediately, the callback should
@@ -654,7 +654,7 @@ fn test_server_deregister_resources_callback_success_status() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_deregister_resources(&info, cb);
 
     if result.is_ok() {
@@ -691,7 +691,7 @@ fn test_server_deregister_resources_multiple_calls() {
         status: Arc::clone(&status2),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result1 = server_deregister_resources(&info, cb1);
     let _result2 = server_deregister_resources(&info, cb2);
 
@@ -724,7 +724,7 @@ fn test_register_then_deregister_resources() {
     let reg_status = Arc::new(Mutex::new(None));
     let dereg_status = Arc::new(Mutex::new(None));
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _reg_result = server_register_resources(
         &info,
         Box::new(TestCb {

--- a/tests/server_server_init.rs
+++ b/tests/server_server_init.rs
@@ -203,7 +203,7 @@ fn test_server_init_minimal_with_daemon() {
 #[ignore = "requires PMIx daemon"]
 fn test_server_init_with_empty_info() {
     let module = PmixServerModule::default();
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -227,7 +227,7 @@ fn test_server_finalize_idempotent() {
 fn test_server_init_with_tool_support() {
     let module = PmixServerModule::default();
     // PMIX_SERVER_TOOL_SUPPORT is a boolean key
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed");
     server_finalize(handle).expect("server_finalize should succeed");
 }
@@ -252,7 +252,7 @@ fn test_api_signatures_compile() {
     // without a PMIx daemon).
     fn _check_server_init() {
         let module = PmixServerModule::default();
-        let info = pmix::InfoBuilder::new().build();
+        let info = pmix::InfoBuilder::new().build().expect("build info");
         let _result: Result<PmixServerHandle, PmixStatus> = server_init(Some(&module), &info);
     }
     fn _check_server_init_minimal() {

--- a/tests/server_server_iof_deliver.rs
+++ b/tests/server_server_iof_deliver.rs
@@ -100,7 +100,7 @@ fn iof_deliver_before_init_no_panic() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"hello".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDOUT,
@@ -124,7 +124,7 @@ fn iof_deliver_with_stdout_channel() {
 
     let source = Proc::new("test.nspace", 1).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"stdout data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDOUT,
@@ -147,7 +147,7 @@ fn iof_deliver_with_stderr_channel() {
 
     let source = Proc::new("test.nspace", 2).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"stderr data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDERR,
@@ -169,7 +169,7 @@ fn iof_deliver_with_stdin_channel() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"stdin data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDIN,
@@ -191,7 +191,7 @@ fn iof_deliver_with_empty_byte_object() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(Vec::new());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDOUT,
@@ -214,7 +214,7 @@ fn iof_deliver_with_large_byte_object() {
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let large_data: Vec<u8> = (0..65536).map(|i| (i % 256) as u8).collect();
     let bo = PmixByteObject::from(large_data);
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDOUT,
@@ -237,7 +237,7 @@ fn iof_deliver_different_source_procs() {
     let source1 = Proc::new("job1.12345", 0).expect("Proc::new should succeed");
     let source2 = Proc::new("job2.67890", 42).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     let result1 = server_iof_deliver(
         &source1,
@@ -269,7 +269,7 @@ fn iof_deliver_consistent_result_type() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     // Call multiple times — all should return the same result type.
     let first = server_iof_deliver(
@@ -317,7 +317,7 @@ fn iof_deliver_callback_with_state() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result = server_iof_deliver(
         &source,
         IOFChannelFlags::STDOUT,
@@ -340,7 +340,7 @@ fn iof_deliver_combined_channel_flags() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"data".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     // Combine STDOUT | STDERR using BitOr
     let combined = IOFChannelFlags::STDOUT | IOFChannelFlags::STDERR;
@@ -369,7 +369,7 @@ fn iof_deliver_various_nspace_formats() {
         let source =
             Proc::new(nspace, 0).expect(&format!("Proc::new should succeed for {}", nspace));
         let bo = PmixByteObject::from(b"data".to_vec());
-        let info = pmix::InfoBuilder::new().build();
+        let info = pmix::InfoBuilder::new().build().expect("build info");
         let _result = server_iof_deliver(
             &source,
             IOFChannelFlags::STDOUT,
@@ -393,7 +393,7 @@ fn iof_deliver_various_ranks() {
         let source = Proc::new("test.nspace", *rank)
             .expect(&format!("Proc::new should succeed for rank {}", rank));
         let bo = PmixByteObject::from(b"data".to_vec());
-        let info = pmix::InfoBuilder::new().build();
+        let info = pmix::InfoBuilder::new().build().expect("build info");
         let _result = server_iof_deliver(
             &source,
             IOFChannelFlags::STDOUT,
@@ -440,7 +440,7 @@ fn iof_deliver_after_server_init() {
     use pmix::server::{PmixServerModule, server_finalize, server_init};
 
     let module = PmixServerModule::default();
-    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build()) {
+    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build().expect("build info")) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("Skipping: server_init failed: {:?}", e);
@@ -455,7 +455,7 @@ fn iof_deliver_after_server_init() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"test output".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     let result = server_iof_deliver(
         &source,
@@ -495,7 +495,7 @@ fn iof_deliver_callback_fires_on_success() {
     use std::time::Duration;
 
     let module = PmixServerModule::default();
-    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build()) {
+    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build().expect("build info")) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("Skipping: server_init failed: {:?}", e);
@@ -517,7 +517,7 @@ fn iof_deliver_callback_fires_on_success() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"integration test".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     let result = server_iof_deliver(
         &source,
@@ -549,7 +549,7 @@ fn iof_deliver_with_complete_flag() {
     use pmix::server::{PmixServerModule, server_finalize, server_init};
 
     let module = PmixServerModule::default();
-    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build()) {
+    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build().expect("build info")) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("Skipping: server_init failed: {:?}", e);
@@ -564,7 +564,7 @@ fn iof_deliver_with_complete_flag() {
 
     let source = Proc::new("test.nspace", 0).expect("Proc::new should succeed");
     let bo = PmixByteObject::from(b"final output".to_vec());
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     let result = server_iof_deliver(
         &source,
@@ -593,7 +593,7 @@ fn iof_deliver_concurrent_calls() {
     use pmix::server::{PmixServerModule, server_finalize, server_init};
 
     let module = PmixServerModule::default();
-    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build()) {
+    let handle = match server_init(Some(&module), &pmix::InfoBuilder::new().build().expect("build info")) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("Skipping: server_init failed: {:?}", e);
@@ -610,7 +610,7 @@ fn iof_deliver_concurrent_calls() {
     for i in 0..10 {
         let source = Proc::new(&format!("test.{}", i), 0).expect("Proc::new should succeed");
         let bo = PmixByteObject::from(format!("data {}", i).into_bytes());
-        let info = pmix::InfoBuilder::new().build();
+        let info = pmix::InfoBuilder::new().build().expect("build info");
 
         let result = server_iof_deliver(
             &source,

--- a/tests/server_server_register_nspace.rs
+++ b/tests/server_server_register_nspace.rs
@@ -148,7 +148,7 @@ fn test_server_register_nspace_signature() {
         impl RegisterNspaceCallback for DummyCb {
             fn on_complete(self: Box<Self>, _status: PmixStatus) {}
         }
-        let info = pmix::InfoBuilder::new().build();
+        let info = pmix::InfoBuilder::new().build().expect("build info");
         let _f: fn(
             &str,
             i32,
@@ -167,7 +167,7 @@ fn test_register_nspace_nul_in_nspace() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace(
         "job\0name", // Contains NUL byte
         4,
@@ -195,7 +195,7 @@ fn test_register_nspace_valid_nspace_signature() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_register_nspace("myjob.12345", 4, &info, Box::new(DummyCb));
     // We don't assert the result because it depends on PMIx server state.
@@ -209,7 +209,7 @@ fn test_register_nspace_zero_local_procs() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_register_nspace("myjob.67890", 0, &info, Box::new(DummyCb));
 }
@@ -222,7 +222,7 @@ fn test_register_nspace_large_nlocalprocs() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_register_nspace("bigjob.99999", 1024, &info, Box::new(DummyCb));
 }
@@ -235,7 +235,7 @@ fn test_register_nspace_empty_info() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let _result: Result<(), PmixStatus> =
         server_register_nspace("test_nspace", 2, &info, Box::new(DummyCb));
 }
@@ -269,7 +269,7 @@ fn test_register_nspace_with_server() {
         status: Arc::clone(&status),
     });
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace("test_nspace", 4, &info, cb);
 
     // The initial call should succeed (request accepted).
@@ -297,7 +297,7 @@ fn test_register_nspace_multiple_nspaces() {
     }
 
     let count = Arc::new(Mutex::new(0usize));
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
 
     for i in 0..3 {
         let cb = Box::new(CountCb {
@@ -322,7 +322,7 @@ fn test_register_nspace_empty_nspace() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     let result = server_register_nspace("", 4, &info, Box::new(DummyCb));
 
     // Empty nspace should be rejected by the PMIx library.
@@ -348,7 +348,7 @@ fn test_callback_registry_unique_ids() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = pmix::InfoBuilder::new().build();
+    let info = pmix::InfoBuilder::new().build().expect("build info");
     // Create multiple callbacks — each should get a unique ID internally.
     for _ in 0..10 {
         let _result = server_register_nspace("test", 1, &info, Box::new(DummyCb));

--- a/tests/server_server_register_resources.rs
+++ b/tests/server_server_register_resources.rs
@@ -166,7 +166,7 @@ fn test_server_register_resources_signature() {
 /// InfoBuilder produces an Info that can be passed to server_register_resources.
 #[test]
 fn test_info_builder_produces_compatible_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // Verify the info has the expected structure (handle + len).
     // We can't call the function without a server, but we can verify
@@ -178,7 +178,7 @@ fn test_info_builder_produces_compatible_info() {
 /// Empty info (no keys) is valid for register_resources.
 #[test]
 fn test_empty_info_for_register_resources() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Empty info is valid — it means "no resource info to register".
     fn accepts_info(_: &pmix::Info) {}
     accepts_info(&info);
@@ -383,7 +383,7 @@ fn test_server_register_resources_empty_info() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, cb);
 
     // Without a running server, this will fail with an error status.
@@ -412,7 +412,7 @@ fn test_server_register_resources_with_info() {
     });
 
     // Build info with keys (if InfoBuilder supports it).
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, cb);
 
     assert!(result.is_ok() || result.is_err(), "should return a result");
@@ -438,7 +438,7 @@ fn test_server_register_resources_callback_invoked() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, cb);
 
     if result.is_ok() {
@@ -460,7 +460,7 @@ fn test_server_register_resources_not_initialized() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, Box::new(TestCb));
 
     // Without PMIx_server_init, this should return an error.
@@ -490,7 +490,7 @@ fn test_server_register_resources_immediate_error_no_callback() {
         invoked: Arc::clone(&invoked),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, cb);
 
     // If the FFI call returns an error immediately, the callback should
@@ -523,7 +523,7 @@ fn test_server_register_resources_callback_success_status() {
         status: Arc::clone(&status),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_register_resources(&info, cb);
 
     if result.is_ok() {
@@ -560,7 +560,7 @@ fn test_server_register_resources_multiple_calls() {
         status: Arc::clone(&status2),
     });
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result1 = server_register_resources(&info, cb1);
     let _result2 = server_register_resources(&info, cb2);
 

--- a/tests/server_server_setup_application.rs
+++ b/tests/server_server_setup_application.rs
@@ -70,7 +70,7 @@ fn setup_application_before_init_returns_err_init() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("test.nspace", &info, Box::new(TestCallback));
 
     assert!(
@@ -99,7 +99,7 @@ fn setup_application_valid_params_err_init_not_bad_param() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("another.job.99999", &info, Box::new(TestCallback));
 
     assert!(result.is_err());
@@ -126,7 +126,7 @@ fn setup_application_multiple_namespaces_consistent_error() {
 
     let namespaces = ["job.12345", "myapp", "a", "test.nspace"];
     for ns in namespaces {
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let result = server_setup_application(ns, &info, Box::new(TestCallback));
         assert!(
             result.is_err(),
@@ -150,7 +150,7 @@ fn setup_application_empty_info_before_init() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("test.nspace", &info, Box::new(TestCallback));
 
     assert!(result.is_err());
@@ -168,7 +168,7 @@ fn setup_application_returns_result_not_panic() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
 
     // This should not panic — it should return Err(PmixStatus).
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -187,7 +187,7 @@ fn setup_application_single_char_namespace() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("x", &info, Box::new(TestCallback));
 
     assert!(result.is_err());
@@ -203,7 +203,7 @@ fn setup_application_long_namespace() {
     }
 
     let long_ns = "a".repeat(200);
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application(&long_ns, &info, Box::new(TestCallback));
 
     assert!(result.is_err());
@@ -310,7 +310,7 @@ fn setup_application_accepts_empty_info() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Info created from empty builder has length 0.
 
     let result = server_setup_application("test.nspace", &info, Box::new(TestCallback));
@@ -331,7 +331,7 @@ fn setup_application_error_is_pmix_err_init() {
         fn on_complete(self: Box<Self>, _status: PmixStatus, _info: Vec<(String, String)>) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_application("test.nspace", &info, Box::new(TestCallback));
 
     let err = result.unwrap_err();
@@ -380,7 +380,7 @@ fn setup_application_multiple_calls_consistent() {
 
     let mut last_err: Option<i32> = None;
     for i in 0..5 {
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let result = server_setup_application(&format!("job.{}", i), &info, Box::new(TestCallback));
         let err = result.unwrap_err().to_raw();
         assert_eq!(err, -31, "call {} should return PMIX_ERR_INIT", i);

--- a/tests/server_server_setup_local_support.rs
+++ b/tests/server_server_setup_local_support.rs
@@ -120,7 +120,7 @@ fn test_setup_local_support_without_server() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = server_setup_local_support("valid_nspace", &info, Box::new(TestCb));
 
     // Without a PMIx server initialized, this should return an error.
@@ -138,8 +138,8 @@ fn test_setup_local_support_empty_info() {
         fn on_complete(self: Box<Self>, _status: PmixStatus) {}
     }
 
-    let info = InfoBuilder::new().build();
-    // Info.len is private; we trust InfoBuilder::new().build() produces an empty array.
+    let info = InfoBuilder::new().build().expect("build info");
+    // Info.len is private; we trust InfoBuilder::new().build().expect("build info") produces an empty array.
 
     let result = server_setup_local_support("test_nspace", &info, Box::new(TestCb));
 

--- a/tests/server_spawn_via_daemon.rs
+++ b/tests/server_spawn_via_daemon.rs
@@ -126,7 +126,7 @@ fn test_server_spawn_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -135,7 +135,7 @@ fn test_server_spawn_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     // Spawn — returns ErrUnreach from server context.
     let result = server_spawn(&handle, &job_info, &apps);
@@ -155,7 +155,7 @@ fn test_server_spawn_with_job_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -165,7 +165,7 @@ fn test_server_spawn_with_job_info_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result = server_spawn(&handle, &job_info, &apps);
     assert!(
@@ -184,7 +184,7 @@ fn test_server_spawn_multiple_apps_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app1 = PmixApp::builder()
@@ -198,7 +198,7 @@ fn test_server_spawn_multiple_apps_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app1, app2];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result = server_spawn(&handle, &job_info, &apps);
     assert!(
@@ -217,7 +217,7 @@ fn test_server_spawn_err_unreach_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -226,7 +226,7 @@ fn test_server_spawn_err_unreach_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result = server_spawn(&handle, &job_info, &apps);
     assert!(result.is_err(), "server_spawn should return Err");
@@ -248,7 +248,7 @@ fn test_server_spawn_returns_result_string_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -257,7 +257,7 @@ fn test_server_spawn_returns_result_string_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result: Result<String, PmixStatus> = server_spawn(&handle, &job_info, &apps);
     assert!(
@@ -279,7 +279,7 @@ fn test_server_spawn_nb_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -288,7 +288,7 @@ fn test_server_spawn_nb_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let wrapper = SpawnCallbackWrapper::new(move |status: PmixStatus, nspace: Option<String>| {
         CALLBACK_INVOKED.store(true, Ordering::SeqCst);
@@ -310,7 +310,7 @@ fn test_server_spawn_nb_with_job_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -320,7 +320,7 @@ fn test_server_spawn_nb_with_job_info_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let wrapper = SpawnCallbackWrapper::new(move |_status: PmixStatus, _nspace: Option<String>| {
         // callback invoked on spawn completion
@@ -341,7 +341,7 @@ fn test_server_spawn_with_callbacks_module_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -350,7 +350,7 @@ fn test_server_spawn_with_callbacks_module_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result = server_spawn(&handle, &job_info, &apps);
     assert!(
@@ -369,7 +369,7 @@ fn test_server_spawn_with_full_app_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let app = PmixApp::builder()
@@ -381,7 +381,7 @@ fn test_server_spawn_with_full_app_with_daemon() {
         .build()
         .expect("valid app");
     let apps = vec![app];
-    let job_info = vec![InfoBuilder::new().build()];
+    let job_info = vec![InfoBuilder::new().build().expect("build info")];
 
     let result = server_spawn(&handle, &job_info, &apps);
     assert!(

--- a/tests/server_sync_via_daemon.rs
+++ b/tests/server_sync_via_daemon.rs
@@ -76,7 +76,7 @@ fn test_server_fence_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_fence(&handle, &[], 0);
@@ -96,7 +96,7 @@ fn test_server_fence_with_timeout_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_fence(&handle, &[], 30);
@@ -116,7 +116,7 @@ fn test_server_fence_returns_pmix_status_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result: Result<PmixStatus, PmixStatus> = server_fence(&handle, &[], 0);
@@ -136,10 +136,10 @@ fn test_server_fence_with_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
-    let fence_info = vec![InfoBuilder::new().build()];
+    let fence_info = vec![InfoBuilder::new().build().expect("build info")];
     let result = server_fence(&handle, &fence_info, 0);
     assert!(result.is_err(), "server_fence with info should return Err");
 
@@ -157,7 +157,7 @@ fn test_server_fence_nb_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let wrapper = FenceNbCallbackWrapper::new(move |status: PmixStatus| {
@@ -179,10 +179,10 @@ fn test_server_fence_nb_with_info_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
-    let fence_info = vec![InfoBuilder::new().build()];
+    let fence_info = vec![InfoBuilder::new().build().expect("build info")];
     let wrapper = FenceNbCallbackWrapper::new(move |_status: PmixStatus| {});
 
     let result = server_fence_nb(&handle, &fence_info, wrapper);
@@ -200,7 +200,7 @@ fn test_server_fence_with_callbacks_module_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_fence(&handle, &[], 0);
@@ -217,7 +217,7 @@ fn test_server_fence_err_unreach_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init");
 
     let result = server_fence(&handle, &[], 0);

--- a/tests/server_tool_via_daemon.rs
+++ b/tests/server_tool_via_daemon.rs
@@ -73,7 +73,7 @@ fn test_proc_constructible_for_tool_attach() {
 /// InfoBuilder produces Info usable with tool_attach.
 #[test]
 fn test_info_builder_for_tool_attach() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _: &pmix::Info = &info;
 }
 
@@ -96,11 +96,11 @@ fn test_server_tool_attach_to_server_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // Tool attach from server context — returns error (no tool connection).
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, None, false, &attach_info);
     assert!(
         result.is_err(),
@@ -118,11 +118,11 @@ fn test_server_tool_attach_with_myproc_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let myproc = Proc::new("test_nspace", 0).expect("invalid nspace");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, Some(&myproc), false, &attach_info);
     assert!(
         result.is_err(),
@@ -140,10 +140,10 @@ fn test_server_tool_attach_want_server_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, None, true, &attach_info);
     assert!(
         result.is_err(),
@@ -161,11 +161,11 @@ fn test_server_tool_attach_full_params_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     let myproc = Proc::new("full_params_nspace", 0).expect("invalid nspace");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, Some(&myproc), true, &attach_info);
     assert!(
         result.is_err(),
@@ -183,10 +183,10 @@ fn test_server_tool_attach_err_unreach_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, None, false, &attach_info);
     assert!(
         result.is_err(),
@@ -210,10 +210,10 @@ fn test_server_tool_attach_returns_tuple_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result: Result<
         (
             Option<pmix::tool::PmixToolHandle>,
@@ -238,10 +238,10 @@ fn test_server_tool_attach_with_callbacks_module_with_daemon() {
 
     let mut module = PmixServerModule::default();
 
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = server_tool_attach_to_server(&handle, None, false, &attach_info);
     assert!(
         result.is_err(),
@@ -259,11 +259,11 @@ fn test_server_tool_attach_multiple_attempts_with_daemon() {
     let _guard = daemon_helper::connect_to_daemon().expect("daemon available");
 
     let module = PmixServerModule::default();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = server_init(Some(&module), &info).expect("server_init should succeed with daemon");
 
     // First attempt — no myproc, no want_server.
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result1 = server_tool_attach_to_server(&handle, None, false, &attach_info);
     assert!(result1.is_err(), "first tool_attach should return Err");
 

--- a/tests/threading_mt_via_prterun.rs
+++ b/tests/threading_mt_via_prterun.rs
@@ -91,7 +91,7 @@ fn client_clone_is_send_across_threads() {
 fn init_options_external_progress_builds() {
     let mut opts = InitOptions::new();
     opts.external_progress(true);
-    let info = opts.build();
+    let info = opts.build().expect("build info");
     assert_eq!(info.len(), 1, "external_progress must emit one Info entry");
     unsafe {
         let ent = &*info.as_ptr();
@@ -247,7 +247,7 @@ fn mt_external_progress_host_thread() {
 
     let mut opts = InitOptions::new();
     opts.external_progress(true);
-    let info = opts.build();
+    let info = opts.build().expect("build info");
 
     let client = PmixClient::connect_new(Some(info))
         .expect("connect_new with external_progress must succeed under prterun");

--- a/tests/tool_Tool_set_server.rs
+++ b/tests/tool_Tool_set_server.rs
@@ -9,7 +9,7 @@ use pmix::{Info, InfoBuilder, Proc, tool::tool_set_server};
 #[test]
 fn tool_set_server_without_init_returns_error() {
     let server = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&server, &info);
     assert!(
         result.is_err(),

--- a/tests/tool_basic_lifecycle.rs
+++ b/tests/tool_basic_lifecycle.rs
@@ -156,7 +156,7 @@ fn test_tool_init_minimal_same_return_type_as_tool_init() {
     }
 
     fn _check_full() -> InitReturn {
-        tool_init(None, &InfoBuilder::new().build())
+        tool_init(None, &InfoBuilder::new().build().expect("build info"))
     }
 
     let _ = (_check_minimal, _check_full);
@@ -169,7 +169,7 @@ fn test_tool_init_minimal_same_return_type_as_tool_init() {
 /// tool_init(None, &empty_info) does not panic.
 #[test]
 fn test_tool_init_none_no_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _result = tool_init(None, &info);
 }
 
@@ -182,21 +182,21 @@ fn test_tool_init_signature() {
 /// tool_init takes Option<&Proc> as first argument.
 #[test]
 fn test_tool_init_accepts_option_proc() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _: Result<PmixTool, PmixStatus> = tool_init(None, &info);
 }
 
 /// tool_init takes &Info as second argument.
 #[test]
 fn test_tool_init_accepts_info_ref() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _: Result<PmixTool, PmixStatus> = tool_init(None, &info);
 }
 
 /// tool_init with empty InfoBuilder returns consistent result across calls.
 #[test]
 fn test_tool_init_consistent_result() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let results: Vec<Result<PmixTool, PmixStatus>> =
         (0..5).map(|_| tool_init(None, &info)).collect();
 
@@ -216,7 +216,7 @@ fn test_tool_init_consistent_result() {
 /// tool_init error status is not PMIX_SUCCESS when daemon unavailable.
 #[test]
 fn test_tool_init_error_not_success() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Err(status) = result {
         assert!(
@@ -236,7 +236,7 @@ fn test_tool_init_error_not_success() {
 /// tool_init with non-empty InfoBuilder also returns consistent result.
 #[test]
 fn test_tool_init_with_info_builder_consistent() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let r1 = tool_init(None, &info);
     let r2 = tool_init(None, &info);
     assert_eq!(
@@ -408,7 +408,7 @@ fn test_pmix_status_unknown_returns_none() {
 /// Lifecycle: init result and is_tool_initialized are consistent.
 #[test]
 fn test_lifecycle_init_and_flag_consistency() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     let flag = is_tool_initialized();
 
@@ -436,7 +436,7 @@ fn test_lifecycle_init_and_flag_consistency() {
 /// Lifecycle: multiple inits return consistent results.
 #[test]
 fn test_lifecycle_multiple_inits_consistent() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let results: Vec<Result<PmixTool, PmixStatus>> =
         (0..5).map(|_| tool_init(None, &info)).collect();
 
@@ -463,7 +463,7 @@ fn test_lifecycle_multiple_inits_consistent() {
 /// Lifecycle: tool_init and tool_init_minimal return the same result type.
 #[test]
 fn test_lifecycle_minimal_and_full_same_result_type() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let full = tool_init(None, &info);
     let minimal = tool_init_minimal();
 
@@ -485,7 +485,7 @@ fn test_lifecycle_minimal_and_full_same_result_type() {
 /// Lifecycle: init -> finalize cycle works when daemon is available.
 #[test]
 fn test_lifecycle_init_finalize_cycle() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         let finalize_result = tool_finalize(handle);
@@ -515,7 +515,7 @@ fn test_lifecycle_init_minimal_finalize_cycle() {
 /// Lifecycle: two inits need two finalizes (reference counting).
 #[test]
 fn test_lifecycle_reference_counting() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let h1 = tool_init(None, &info);
     let h2 = tool_init(None, &info);
 
@@ -534,7 +534,7 @@ fn test_lifecycle_reference_counting() {
 /// Lifecycle: handle can be cloned before finalize.
 #[test]
 fn test_lifecycle_handle_clone_before_finalize() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         let cloned = handle.clone();
@@ -554,7 +554,7 @@ fn test_lifecycle_handle_clone_before_finalize() {
 /// Lifecycle: is_tool_initialized flag tracks init/finalize state.
 #[test]
 fn test_lifecycle_flag_tracks_state() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         assert!(
@@ -642,7 +642,7 @@ fn test_thread_safe_concurrent_init() {
 
     for _ in 0..NUM_THREADS {
         handles.push(std::thread::spawn(|| {
-            let info = InfoBuilder::new().build();
+            let info = InfoBuilder::new().build().expect("build info");
             for _ in 0..CALLS_PER_THREAD {
                 let _result = tool_init(None, &info);
                 // No panic regardless of Ok/Err.
@@ -716,7 +716,7 @@ fn test_error_path_tool_init_minimal_without_daemon() {
 /// When daemon is NOT available, tool_init returns an error.
 #[test]
 fn test_error_path_tool_init_without_daemon() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     match result {
         Err(status) => {
@@ -744,7 +744,7 @@ fn test_error_path_tool_init_without_daemon() {
 /// When daemon IS available, tool_init returns a valid handle.
 #[test]
 fn test_success_path_tool_init_with_daemon() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         // Handle should have valid proc info.
@@ -762,7 +762,7 @@ fn test_success_path_tool_init_with_daemon() {
 /// When daemon IS available, handle Debug output is non-empty.
 #[test]
 fn test_success_path_handle_debug_output() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         let debug = format!("{:?}", handle);
@@ -780,7 +780,7 @@ fn test_success_path_handle_debug_output() {
 /// When daemon IS available, handle Clone produces identical proc info.
 #[test]
 fn test_success_path_handle_clone_identical() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         let cloned = handle.clone();
@@ -803,7 +803,7 @@ fn test_success_path_handle_clone_identical() {
 /// When daemon IS available, init -> finalize -> init cycle works.
 #[test]
 fn test_success_path_init_finalize_reinit() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result1 = tool_init(None, &info);
     if let Ok(handle1) = result1 {
         tool_finalize(handle1).expect("first finalize should succeed");
@@ -818,7 +818,7 @@ fn test_success_path_init_finalize_reinit() {
 /// When daemon IS available, is_tool_initialized tracks state correctly.
 #[test]
 fn test_success_path_flag_state_tracking() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     if let Ok(handle) = result {
         assert!(is_tool_initialized(), "flag should be true after init");
@@ -837,7 +837,7 @@ fn test_success_path_flag_state_tracking() {
 /// InfoBuilder produces an Info that can be passed to tool_init.
 #[test]
 fn test_info_builder_produces_valid_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Just verify it compiles and can be used.
     let _: Result<PmixTool, PmixStatus> = tool_init(None, &info);
 }
@@ -845,7 +845,7 @@ fn test_info_builder_produces_valid_info() {
 /// Empty InfoBuilder produces an Info with zero entries.
 #[test]
 fn test_info_builder_empty() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Verify tool_init accepts it without panic.
     let _result = tool_init(None, &info);
 }

--- a/tests/tool_server_interaction.rs
+++ b/tests/tool_server_interaction.rs
@@ -25,7 +25,7 @@ use pmix::{Info, InfoBuilder, PmixStatus, Proc};
 /// tool_attach_to_server returns Err when called without tool_init.
 #[test]
 fn test_attach_to_server_without_init_returns_err() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     assert!(
         result.is_err(),
@@ -36,7 +36,7 @@ fn test_attach_to_server_without_init_returns_err() {
 /// tool_attach_to_server error is not PMIX_SUCCESS.
 #[test]
 fn test_attach_to_server_without_init_error_not_success() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Err(status) => {
@@ -53,7 +53,7 @@ fn test_attach_to_server_without_init_error_not_success() {
 /// tool_attach_to_server without init does not panic.
 #[test]
 fn test_attach_to_server_without_init_no_panic() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // If we reach here, no panic occurred.
     let _result = tool_attach_to_server(None, true, &info);
 }
@@ -61,7 +61,7 @@ fn test_attach_to_server_without_init_no_panic() {
 /// tool_attach_to_server with want_server=false also errors without init.
 #[test]
 fn test_attach_to_server_without_init_no_server_flag() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, false, &info);
     assert!(
         result.is_err(),
@@ -72,7 +72,7 @@ fn test_attach_to_server_without_init_no_server_flag() {
 /// tool_attach_to_server with myproc=Some also errors without init.
 #[test]
 fn test_attach_to_server_without_init_with_myproc() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let proc = Proc::new("test-nspace", 0).unwrap();
     let result = tool_attach_to_server(Some(&proc), true, &info);
     assert!(
@@ -84,7 +84,7 @@ fn test_attach_to_server_without_init_with_myproc() {
 /// tool_attach_to_server with empty info errors without init.
 #[test]
 fn test_attach_to_server_without_init_empty_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     assert!(
         result.is_err(),
@@ -137,7 +137,7 @@ fn test_server_handle_traits_for_attach() {
 fn test_attach_to_server_with_init_no_panic() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     // This may succeed or fail depending on server config, but must not panic.
     let _result = tool_attach_to_server(handle.proc().as_ref(), true, &attach_info);
 }
@@ -149,7 +149,7 @@ fn test_attach_to_server_with_init_no_panic() {
 fn test_attach_to_server_want_server_returns_option() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(handle.proc().as_ref(), true, &attach_info);
     match result {
         Ok((tool_handle, server_handle)) => {
@@ -176,7 +176,7 @@ fn test_attach_to_server_want_server_returns_option() {
 fn test_attach_to_server_no_server_flag_returns_none() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(handle.proc().as_ref(), false, &attach_info);
     match result {
         Ok((_, server_handle)) => {
@@ -198,7 +198,7 @@ fn test_attach_to_server_no_server_flag_returns_none() {
 fn test_attach_to_server_no_myproc_returns_none_tool() {
     let _lock = daemon_helper::daemon_lock().expect("daemon lock");
     let _handle = daemon_helper::get_tool_handle().expect("daemon not available");
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &attach_info);
     match result {
         Ok((tool_handle, _)) => {
@@ -376,7 +376,7 @@ fn test_get_servers_result_is_send() {
 #[test]
 fn test_set_server_without_init_returns_err() {
     let proc = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&proc, &info);
     assert!(
         result.is_err(),
@@ -388,7 +388,7 @@ fn test_set_server_without_init_returns_err() {
 #[test]
 fn test_set_server_without_init_error_not_success() {
     let proc = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&proc, &info);
     match result {
         Err(status) => {
@@ -406,7 +406,7 @@ fn test_set_server_without_init_error_not_success() {
 #[test]
 fn test_set_server_without_init_no_panic() {
     let proc = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // If we reach here, no panic occurred.
     let _result = tool_set_server(&proc, &info);
 }
@@ -415,7 +415,7 @@ fn test_set_server_without_init_no_panic() {
 #[test]
 fn test_set_server_without_init_empty_info() {
     let proc = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&proc, &info);
     assert!(
         result.is_err(),
@@ -430,7 +430,7 @@ fn test_set_server_without_init_various_procs() {
         Proc::new("other-nspace", 1).unwrap(),
         Proc::new("prte-beast-1519", 0).unwrap(),
     ];
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for proc in procs {
         let result = tool_set_server(&proc, &info);
         assert!(
@@ -522,7 +522,7 @@ fn test_set_server_with_init_no_panic() {
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
 
     // Use the tool's own proc as the server proc — may or may not work
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&handle.require_proc(), &info);
     // We accept either success or error — the key is no panic
     let _ = result;
@@ -539,7 +539,7 @@ fn test_set_server_with_server_from_get_servers() {
     let servers = tool_get_servers().expect("tool_get_servers failed");
     if let Some(server) = servers.first() {
         // Try to set the first server as primary
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let result = tool_set_server(server, &info);
         // May succeed or fail depending on server config
         let _ = result;
@@ -560,7 +560,7 @@ fn test_lifecycle_init_attach_disconnect_finalize() {
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
 
     // Step 1: attach (may succeed or fail)
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
         Ok((_, Some(server))) => {
             // Step 2: disconnect from the server we attached to
@@ -609,7 +609,7 @@ fn test_lifecycle_init_set_server_finalize() {
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
 
     // Step 1: set_server (using tool's own proc as target)
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _set_result = tool_set_server(&handle.require_proc(), &info);
 
     // Step 2: finalize — singleton handle, Drop handles it at process exit
@@ -628,12 +628,12 @@ fn test_lifecycle_full_combined() {
 
     // Step 2: set_server (if we have servers)
     if let Some(server) = servers.first() {
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let _ = tool_set_server(server, &info);
     }
 
     // Step 3: attach (may succeed or fail)
-    let attach_info = InfoBuilder::new().build();
+    let attach_info = InfoBuilder::new().build().expect("build info");
     match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
         Ok((_, Some(server))) => {
             // Step 4: disconnect
@@ -685,7 +685,7 @@ fn test_finalize_after_failed_attach() {
     let handle = daemon_helper::get_tool_handle().expect("daemon not available");
 
     // Try attach with empty info (likely to fail)
-    let empty_info = InfoBuilder::new().build();
+    let empty_info = InfoBuilder::new().build().expect("build info");
     let _ = tool_attach_to_server(handle.proc().as_ref(), true, &empty_info);
 
     // Finalize should still work — this test specifically tests finalize behavior
@@ -728,7 +728,7 @@ fn test_finalize_after_failed_set_server() {
 
     // Try set_server with a fake server proc
     let fake_server = Proc::new("nonexistent-server", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _ = tool_set_server(&fake_server, &info);
 
     // Finalize should still work
@@ -778,7 +778,7 @@ fn test_concurrent_get_servers_safe() {
 /// Error from tool_attach_to_server without init is a known PMIx error.
 #[test]
 fn test_attach_without_init_error_code() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Err(status) => {
@@ -810,7 +810,7 @@ fn test_get_servers_without_init_error_code() {
 #[test]
 fn test_set_server_without_init_error_code() {
     let proc = Proc::new("test-nspace", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&proc, &info);
     match result {
         Err(status) => {
@@ -883,7 +883,7 @@ fn test_proc_new_various() {
 /// InfoBuilder produces Info compatible with all server interaction functions.
 #[test]
 fn test_info_compatible_with_all_server_funcs() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let proc = Proc::new("test", 0).unwrap();
 
     // All these compile — proving Info is compatible
@@ -911,7 +911,7 @@ fn test_get_servers_then_set_each_as_primary() {
     let servers = tool_get_servers().expect("tool_get_servers failed");
     for server in &servers {
         // Try to set each server as primary
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let result = tool_set_server(server, &info);
         // May succeed or fail — the key is no panic
         let _ = result;

--- a/tests/tool_tool_attach_to_server.rs
+++ b/tests/tool_tool_attach_to_server.rs
@@ -111,7 +111,7 @@ fn test_tool_attach_to_server_both_requested() {
 fn test_tool_attach_to_server_empty_info() {
     fn _check_empty_info() -> Result<(Option<PmixToolHandle>, Option<PmixServerHandle>), PmixStatus>
     {
-        let empty = InfoBuilder::new().build();
+        let empty = InfoBuilder::new().build().expect("build info");
         tool_attach_to_server(None, true, &empty)
     }
     let _ = _check_empty_info;
@@ -193,10 +193,10 @@ fn test_attach_result_is_send() {
 // Info interaction
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// InfoBuilder::new().build() produces a valid Info for tool_attach_to_server.
+/// InfoBuilder::new().build().expect("build info") produces a valid Info for tool_attach_to_server.
 #[test]
 fn test_info_builder_produces_attach_compatible_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // Compile-time check that Info can be passed to tool_attach_to_server.
     let _: fn(
         Option<&pmix::Proc>,
@@ -216,7 +216,7 @@ fn test_info_builder_produces_attach_compatible_info() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_tool_attach_to_server_with_server() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Ok((tool, server)) => {
@@ -248,7 +248,7 @@ fn test_tool_attach_to_server_with_server() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_tool_attach_to_server_no_server_identity() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, false, &info);
     match result {
         Ok((tool, server)) => {
@@ -270,7 +270,7 @@ fn test_tool_attach_to_server_no_server_identity() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_tool_attach_to_server_no_tool_identity() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Ok((tool, server)) => {
@@ -294,12 +294,12 @@ fn test_tool_attach_to_server_no_tool_identity() {
 fn test_tool_attach_after_init() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     let init_result = tool_init(None, &init_info);
     match init_result {
         Ok(handle) => {
             // Now try to attach to a server
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             let attach_result = tool_attach_to_server(handle.proc().as_ref(), true, &attach_info);
             match attach_result {
                 Ok((tool, server)) => {
@@ -337,11 +337,11 @@ fn test_tool_attach_after_init() {
 fn test_tool_attach_both_handles() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     let init_result = tool_init(None, &init_info);
     match init_result {
         Ok(handle) => {
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             let attach_result = tool_attach_to_server(handle.proc().as_ref(), true, &attach_info);
             match attach_result {
                 Ok((tool, server)) => {

--- a/tests/tool_tool_disconnect.rs
+++ b/tests/tool_tool_disconnect.rs
@@ -212,10 +212,10 @@ fn test_proc_ref_lifetime() {
 // InfoBuilder compatibility
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// InfoBuilder::new().build() produces a valid Info.
+/// InfoBuilder::new().build().expect("build info") produces a valid Info.
 #[test]
 fn test_info_builder_builds() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let _: &Info = &info;
 }
 
@@ -248,12 +248,12 @@ fn test_disconnect_result_is_sync() {
 fn test_attach_then_disconnect() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     let init_result = tool_init(None, &init_info);
     match init_result {
         Ok(handle) => {
             // Attach to a server
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             let attach_result = tool_attach_to_server(handle.proc().as_ref(), true, &attach_info);
             match attach_result {
                 Ok((_, Some(server))) => {
@@ -291,7 +291,7 @@ fn test_attach_then_disconnect() {
 fn test_disconnect_not_connected() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     match tool_init(None, &init_info) {
         Ok(handle) => {
             // Try to disconnect from a server we never connected to.
@@ -325,10 +325,10 @@ fn test_disconnect_not_connected() {
 fn test_disconnect_with_server_handle() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     match tool_init(None, &init_info) {
         Ok(handle) => {
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
                 Ok((_, Some(server))) => {
                     // Clone the server handle before disconnecting
@@ -361,10 +361,10 @@ fn test_disconnect_with_server_handle() {
 fn test_attach_disconnect_cycle() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     match tool_init(None, &init_info) {
         Ok(handle) => {
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             // First attach
             match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
                 Ok((_, Some(server1))) => {
@@ -401,7 +401,7 @@ fn test_attach_disconnect_cycle() {
 fn test_disconnect_leaves_tool_initialized() {
     use pmix::tool::{is_tool_initialized, tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     match tool_init(None, &init_info) {
         Ok(handle) => {
             assert!(
@@ -409,7 +409,7 @@ fn test_disconnect_leaves_tool_initialized() {
                 "Tool should be initialized after init"
             );
 
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
                 Ok((_, Some(server))) => {
                     // Disconnect from server
@@ -438,7 +438,7 @@ fn test_disconnect_leaves_tool_initialized() {
 fn test_finalize_after_failed_disconnect() {
     use pmix::tool::{tool_finalize, tool_init};
 
-    let init_info = InfoBuilder::new().build();
+    let init_info = InfoBuilder::new().build().expect("build info");
     match tool_init(None, &init_info) {
         Ok(handle) => {
             // Try to disconnect from a non-connected server
@@ -465,7 +465,7 @@ fn test_disconnect_with_minimal_init() {
 
     match tool_init_minimal() {
         Ok(handle) => {
-            let attach_info = InfoBuilder::new().build();
+            let attach_info = InfoBuilder::new().build().expect("build info");
             match tool_attach_to_server(handle.proc().as_ref(), true, &attach_info) {
                 Ok((_, Some(server))) => {
                     let result = tool_disconnect(server.proc());

--- a/tests/tool_tool_finalize.rs
+++ b/tests/tool_tool_finalize.rs
@@ -125,7 +125,7 @@ fn test_init_finalize_type_pair() {
 fn test_init_minimal_compatible_with_finalize() {
     type InitReturn = Result<PmixTool, PmixStatus>;
     fn _check_full() -> InitReturn {
-        tool_init(None, &InfoBuilder::new().build())
+        tool_init(None, &InfoBuilder::new().build().expect("build info"))
     }
     fn _check_minimal() -> InitReturn {
         tool_init_minimal()
@@ -184,7 +184,7 @@ fn test_reference_counting_documented() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_tool_init_then_finalize() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = match tool_init(None, &info) {
         Ok(h) => h,
         Err(_) => {
@@ -218,7 +218,7 @@ fn test_tool_init_minimal_then_finalize() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_reference_counted_finalize() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let h1 = match tool_init(None, &info) {
         Ok(h) => h,
         Err(_) => return,
@@ -254,7 +254,7 @@ fn test_finalize_without_init() {
 fn test_finalize_with_custom_proc() {
     // Tool init with a specific proc identity, then finalize.
     // This tests that finalize works regardless of how the handle was obtained.
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = match tool_init(None, &info) {
         Ok(h) => h,
         Err(_) => return,
@@ -274,7 +274,7 @@ fn test_finalize_with_custom_proc() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_clone_then_finalize_original() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = match tool_init(None, &info) {
         Ok(h) => h,
         Err(_) => return,
@@ -294,7 +294,7 @@ fn test_clone_then_finalize_original() {
 #[test]
 #[ignore = "requires PMIx server"]
 fn test_finalize_error_status() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let handle = match tool_init(None, &info) {
         Ok(h) => h,
         Err(_) => return,

--- a/tests/tool_unit.rs
+++ b/tests/tool_unit.rs
@@ -13,7 +13,7 @@ use pmix::tool::PmixTool;
 
 #[test]
 fn test_tool_init_with_empty_info_and_none_proc() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     match result {
         Ok(_) => {}
@@ -26,7 +26,7 @@ fn test_tool_init_with_empty_info_and_none_proc() {
 #[test]
 fn test_tool_init_with_empty_info_and_some_proc() {
     let proc = pmix::Proc::new("test_ns", 42).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(Some(&proc), &info);
     match result {
         Ok(_) => {}
@@ -38,7 +38,7 @@ fn test_tool_init_with_empty_info_and_some_proc() {
 
 #[test]
 fn test_tool_init_with_infobuilder_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(None, &info);
     match result {
         Ok(_) => {}
@@ -52,7 +52,7 @@ fn test_tool_init_with_infobuilder_info() {
 fn test_tool_init_with_collect_data_info() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let result = tool_init(None, &info);
     match result {
         Ok(_) => {}
@@ -64,7 +64,7 @@ fn test_tool_init_with_collect_data_info() {
 
 #[test]
 fn test_tool_init_multiple_calls_consistent() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     // tool_init behavior depends on PMIx state — just verify it doesn't crash
     for i in 0..5 {
         let result = tool_init(None, &info);
@@ -81,7 +81,7 @@ fn test_tool_init_multiple_calls_consistent() {
 
 #[test]
 fn test_tool_init_with_various_proc_ranks() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for rank in [0u32, 1, 100, u32::MAX] {
         let proc = pmix::Proc::new("test_ns", rank).unwrap();
         let result = tool_init(Some(&proc), &info);
@@ -156,7 +156,7 @@ fn test_tool_finalize_after_tool_init() {
 #[ignore] // SIGSEGV on process cleanup when PMIx is initialized then finalized
 fn test_tool_finalize_after_tool_init_with_proc() {
     let proc = pmix::Proc::new("test", 999).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_init(Some(&proc), &info);
     match result {
         Ok(handle) => {
@@ -175,7 +175,7 @@ fn test_tool_finalize_after_tool_init_with_proc() {
 #[test]
 fn test_attach_with_both_myproc_and_server() {
     let proc = pmix::Proc::new("my_tool", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(Some(&proc), true, &info);
     match result {
         Ok((tool, server)) => {
@@ -193,7 +193,7 @@ fn test_attach_with_both_myproc_and_server() {
 
 #[test]
 fn test_attach_with_neither_myproc_nor_server() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, false, &info);
     match result {
         Ok((tool, server)) => {
@@ -212,7 +212,7 @@ fn test_attach_with_neither_myproc_nor_server() {
 #[test]
 fn test_attach_with_myproc_only() {
     let proc = pmix::Proc::new("my_tool", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(Some(&proc), false, &info);
     match result {
         Ok((tool, server)) => {
@@ -227,7 +227,7 @@ fn test_attach_with_myproc_only() {
 
 #[test]
 fn test_attach_with_server_only() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Ok((tool, server)) => {
@@ -242,7 +242,7 @@ fn test_attach_with_server_only() {
 
 #[test]
 fn test_attach_with_empty_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_attach_to_server(None, true, &info);
     match result {
         Ok(_) => {}
@@ -278,7 +278,7 @@ fn test_get_servers_consecutive_calls() {
 #[test]
 fn test_set_server_with_empty_info() {
     let server = pmix::Proc::new("server_ns", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&server, &info);
     match result {
         Ok(_) => {}
@@ -291,7 +291,7 @@ fn test_set_server_with_empty_info() {
 #[test]
 fn test_set_server_with_wildcard_server() {
     let server = pmix::Proc::new("", u32::MAX).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_set_server(&server, &info);
     match result {
         Ok(_) => {}
@@ -303,7 +303,7 @@ fn test_set_server_with_wildcard_server() {
 
 #[test]
 fn test_set_server_various_ranks() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     for rank in [0u32, 1, 42, 1000, u32::MAX] {
         let server = pmix::Proc::new("server_ns", rank).unwrap();
         let result = tool_set_server(&server, &info);
@@ -348,7 +348,7 @@ fn test_disconnect_consecutive_calls() {
 
 #[test]
 fn test_connect_to_server_with_none_proc() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_connect_to_server(None, &info);
     match result {
         Ok(_) => {}
@@ -361,7 +361,7 @@ fn test_connect_to_server_with_none_proc() {
 #[test]
 fn test_connect_to_server_with_some_proc() {
     let proc = pmix::Proc::new("my_tool", 0).unwrap();
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_connect_to_server(Some(&proc), &info);
     match result {
         Ok(handle) => {
@@ -375,7 +375,7 @@ fn test_connect_to_server_with_some_proc() {
 
 #[test]
 fn test_connect_to_server_with_empty_info() {
-    let info = InfoBuilder::new().build();
+    let info = InfoBuilder::new().build().expect("build info");
     let result = tool_connect_to_server(None, &info);
     match result {
         Ok(_) => {}
@@ -488,7 +488,7 @@ fn test_tool_error_to_raw_values() {
 #[test]
 fn test_tool_init_with_multiple_info_builders() {
     for _ in 0..5 {
-        let info = InfoBuilder::new().build();
+        let info = InfoBuilder::new().build().expect("build info");
         let result = tool_init(None, &info);
         match result {
             Ok(_) => {}
@@ -503,7 +503,7 @@ fn test_tool_init_with_multiple_info_builders() {
 fn test_tool_connect_with_info_builder_collect_data() {
     let mut builder = InfoBuilder::new();
     builder.collect_data();
-    let info = builder.build();
+    let info = builder.build().expect("build info");
     let result = tool_connect_to_server(None, &info);
     match result {
         Ok(_) => {}


### PR DESCRIPTION
Closes #399

## Summary
InfoBuilder::build() now returns Result<Info, PmixStatus> instead of panicking on PMIx_Info_create/PMIx_Info_load failure.

## Error handling sites
- PMIx_Info_create null allocation returns PMIX_ERR_NOMEM.
- Fixed-key, string-key, and boolean-key PMIx_Info_load failures free the allocated info array and return the PMIx status.
- Successful builds return Ok(Info { ... }).

## Caller migration
Migrated callers of InfoBuilder::build() and InitOptions::build() across library tests, documentation examples, examples, and integration tests. Non-InfoBuilder builders were not changed. info_with_string_key remains unchanged and is tracked in #400.

## Test plan
- cargo build (OpenPMIx 6.1.0 via PMIX_PREFIX): passed
- cargo test --lib --no-run: passed
- cargo test: passed; daemon-dependent tests remain ignored where applicable
- cargo clippy --lib -- -D warnings: blocked by missing safety docs in generated OUT_DIR bindings, unrelated to this diff
- git diff --check: passed
