### PR TITLE
fix(info): return Result from add_string_key/bind_progress_thread/info_with_string_key instead of panicking on NUL

### DIFF
--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2075,7 +2075,9 @@ use super::*;
         let _guard = MockGuard::with_config(config);
         let proc = Proc::new("mock.ns", 0).unwrap();
         let mut builder = InfoBuilder::new();
-        builder.add_string_key("pmix.qual.val", "true", PMIX_STRING as _);
+        builder
+            .add_string_key("pmix.qual.val", "true", PMIX_STRING as _)
+            .expect("string info");
         let info = builder.build().expect("build info");
 
         let result = get_nb(&proc, "qualified.key", Some(&info), Box::new(DummyGet));

--- a/src/info.rs
+++ b/src/info.rs
@@ -17,7 +17,7 @@ pub fn with_collect_data() -> Info {
 }
 
 /// Single string key/value info entry (no 13-byte key limit).
-pub fn string_kv(key: &str, value: &str) -> Info {
+pub fn string_kv(key: &str, value: &str) -> Result<Info, PmixStatus> {
     info_with_string_key(key, value)
 }
 
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_string_kv() {
-        let info = string_kv("pmix.srvr.uri", "tcp://127.0.0.1:1");
+        let info = string_kv("pmix.srvr.uri", "tcp://127.0.0.1:1").expect("string info");
         assert_eq!(info.len(), 1);
     }
 
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_info_is_empty_false_for_string_kv() {
-        assert!(!string_kv("k", "v").is_empty());
+        assert!(!string_kv("k", "v").expect("string info").is_empty());
     }
 
     #[test]
@@ -308,8 +308,8 @@ mod tests {
     #[test]
     fn mock_info_helpers_cover_success_paths() {
         let _guard = crate::mock_ffi::MockGuard::new();
-        let mut dest = string_kv("k", "v");
-        let src = string_kv("k2", "v2");
+        let mut dest = string_kv("k", "v").expect("string info");
+        let src = string_kv("k2", "v2").expect("string info");
         assert!(dest.xfer_from(&src).is_ok());
         assert_eq!(dest.get_size().unwrap(), 0);
         assert_eq!(dest.info_string().unwrap(), "mock info");
@@ -328,7 +328,7 @@ mod tests {
     fn mock_info_status_override_is_returned_as_error() {
         let config = crate::mock_ffi::MockConfig::new().with_function_status("PMIx_Info_get_size", crate::mock_ffi::PMIX_ERR_BAD_PARAM);
         let _guard = crate::mock_ffi::MockGuard::with_config(config);
-        let info = string_kv("k", "v");
+        let info = string_kv("k", "v").expect("string info");
         assert!(info.get_size().is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3158,14 +3158,15 @@ impl InfoBuilder {
         key: &str,
         value: &str,
         data_type: pmix_data_type_t,
-    ) {
-        let key_cstr = CString::new(key).expect("key must not contain null bytes");
-        let value_cstr = CString::new(value).expect("value must not contain null bytes");
+    ) -> Result<&mut Self, std::ffi::NulError> {
+        let key_cstr = CString::new(key)?;
+        let value_cstr = CString::new(value)?;
         self.string_infos.push(InfoEntryString {
             key: key_cstr,
             value: value_cstr,
             data_type,
         });
+        Ok(self)
     }
 
     /// Append a string-key `PMIX_BOOL` attribute with correct scalar encoding.
@@ -3203,14 +3204,14 @@ impl InfoBuilder {
     ///
     /// # C API
     /// `PMIX_BIND_PROGRESS_THREAD` (`pmix.bind.pt`) — `PMIX_STRING`
-    pub fn bind_progress_thread(&mut self, cpus: &str) -> &mut Self {
-        let cpus_cstr = CString::new(cpus).expect("cpu set must not contain null bytes");
+    pub fn bind_progress_thread(&mut self, cpus: &str) -> Result<&mut Self, std::ffi::NulError> {
+        let cpus_cstr = CString::new(cpus)?;
         self.string_infos.push(InfoEntryString {
             key: CString::new("pmix.bind.pt").unwrap(),
             value: cpus_cstr,
             data_type: PMIX_STRING as pmix_data_type_t,
         });
-        self
+        Ok(self)
     }
 
     /// Set `PMIX_BIND_REQUIRED` attribute.
@@ -3244,9 +3245,8 @@ impl InfoBuilder {
     ///
     /// # C API
     /// `PMIX_PROGRESS_THREAD_NAME` (`pmix.evname`) — `PMIX_STRING`
-    pub fn progress_thread_name(&mut self, name: &str) -> &mut Self {
-        self.add_string_key("pmix.evname", name, PMIX_STRING as pmix_data_type_t);
-        self
+    pub fn progress_thread_name(&mut self, name: &str) -> Result<&mut Self, std::ffi::NulError> {
+        self.add_string_key("pmix.evname", name, PMIX_STRING as pmix_data_type_t)
     }
 
     pub fn collect_data(&mut self) -> &mut InfoBuilder {
@@ -3454,7 +3454,9 @@ impl InitOptions {
         }
 
         if let Some(ref cpus) = self.bind_progress_thread {
-            builder.bind_progress_thread(cpus);
+            builder
+                .bind_progress_thread(cpus)
+                .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
         }
 
         if let Some(required) = self.bind_required {
@@ -3466,7 +3468,9 @@ impl InitOptions {
         }
 
         if let Some(ref name) = self.progress_thread_name {
-            builder.progress_thread_name(name);
+            builder
+                .progress_thread_name(name)
+                .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
         }
 
         builder.build()
@@ -3478,13 +3482,15 @@ impl InitOptions {
 ///
 /// This is useful for keys like `"pmix.srvr.uri"` (14 bytes) which don't
 /// fit in `InfoBuilder::add(key: &'static [u8; 13])`.
-pub fn info_with_string_key(key: &str, value: &str) -> Info {
+pub fn info_with_string_key(key: &str, value: &str) -> Result<Info, PmixStatus> {
+    let key_cstr = CString::new(key)
+        .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
+    let value_cstr = CString::new(value)
+        .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
     let info_ptr = unsafe { PMIx_Info_create(1) };
     if info_ptr.is_null() {
-        panic!("PMIx_Info_create(1) returned null");
+        return Err(PmixStatus::from_raw(ffi::PMIX_ERR_NOMEM));
     }
-    let key_cstr = CString::new(key).expect("key must not contain null bytes");
-    let value_cstr = CString::new(value).expect("value must not contain null bytes");
     // PMIx_Info_load copies key/value into the info array (PMIx 4+/5+/6+).
     // Keep CStrings alive only for the duration of the load call, then drop.
     let status = unsafe {
@@ -3499,17 +3505,17 @@ pub fn info_with_string_key(key: &str, value: &str) -> Info {
     drop(key_cstr);
     drop(value_cstr);
     if status != PMIX_SUCCESS as i32 {
-        // Free the half-built array before panicking.
+        // Free the half-built array before returning the PMIx error.
         unsafe {
             PMIx_Info_free(info_ptr, 1);
         }
-        panic!("PMIx_Info_load failed for key {}: {}", key, status);
+        return Err(PmixStatus::from_raw(status));
     }
-    Info {
+    Ok(Info {
         handle: info_ptr,
         len: 1,
-    _not_thread_safe: std::marker::PhantomData,
-    }
+        _not_thread_safe: std::marker::PhantomData,
+    })
 }
 
 
@@ -4085,7 +4091,7 @@ mod tests {
         let info = InfoBuilder::new().build().expect("build info");
         assert_eq!(info.len(), 0);
         drop(info);
-        let info2 = info_with_string_key("pmix.srvr.uri", "tcp://127.0.0.1:1");
+        let info2 = info_with_string_key("pmix.srvr.uri", "tcp://127.0.0.1:1").expect("string info");
         assert_eq!(info2.len(), 1);
         assert!(!info2.as_ptr().is_null());
         drop(info2);
@@ -5428,9 +5434,27 @@ mod tests {
     #[test]
     fn test_infobuilder_bind_progress_thread() {
         let mut builder = InfoBuilder::new();
-        builder.bind_progress_thread("0-3");
+        builder.bind_progress_thread("0-3").expect("bind progress thread");
         let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
+    }
+
+    #[test]
+    fn test_string_info_helpers_reject_nul() {
+        let mut builder = InfoBuilder::new();
+        assert!(builder.add_string_key("bad\0key", "v", PMIX_STRING as _).is_err());
+        assert!(builder.add_string_key("k", "bad\0value", PMIX_STRING as _).is_err());
+        assert!(builder.bind_progress_thread("0\0-3").is_err());
+        assert!(builder.progress_thread_name("bad\0name").is_err());
+        assert!(info_with_string_key("bad\0key", "v").is_err());
+        assert!(info_with_string_key("k", "bad\0value").is_err());
+    }
+
+    #[test]
+    fn test_initoptions_rejects_nul_bind_progress_thread() {
+        let mut options = InitOptions::new();
+        options.bind_progress_thread("0\0-3");
+        assert!(options.build().is_err());
     }
 
     #[test]
@@ -5445,7 +5469,7 @@ mod tests {
     fn test_infobuilder_combined_string_keys() {
         let mut builder = InfoBuilder::new();
         builder.external_progress(true);
-        builder.bind_progress_thread("4,5,6,7");
+        builder.bind_progress_thread("4,5,6,7").expect("bind progress thread");
         builder.bind_required(false);
         let info = builder.build().expect("build info");
         assert_eq!(info.len(), 3);
@@ -5529,7 +5553,7 @@ mod tests {
     #[test]
     fn test_infobuilder_progress_thread_name() {
         let mut builder = InfoBuilder::new();
-        builder.progress_thread_name("my-progress-thread");
+        builder.progress_thread_name("my-progress-thread").expect("progress thread name");
         let info = builder.build().expect("build info");
         assert_eq!(info.len(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3153,6 +3153,7 @@ impl InfoBuilder {
     ///
     /// Use this for keys like `PMIX_BIND_REQUIRED` (`pmix.bind.reqd`, 15 bytes)
     /// which don't fit in [`InfoBuilder::add`].
+    /// Returns `Err(NulError)` if the key or value contains a NUL byte.
     pub fn add_string_key(
         &mut self,
         key: &str,
@@ -3202,6 +3203,8 @@ impl InfoBuilder {
     /// thread that calls `PMIx_Get` or other APIs — work is threadshifted
     /// onto the progress/`evbase` internally.
     ///
+    /// Returns `Err(NulError)` if `cpus` contains a NUL byte.
+    ///
     /// # C API
     /// `PMIX_BIND_PROGRESS_THREAD` (`pmix.bind.pt`) — `PMIX_STRING`
     pub fn bind_progress_thread(&mut self, cpus: &str) -> Result<&mut Self, std::ffi::NulError> {
@@ -3242,6 +3245,8 @@ impl InfoBuilder {
     /// Gives the internal PMIx progress thread a custom name for debugging
     /// and profiling. The name is visible in thread listings (e.g.,
     /// `pthread_getname_np`, debuggers, `ps`).
+    ///
+    /// Returns `Err(NulError)` if `name` contains a NUL byte.
     ///
     /// # C API
     /// `PMIX_PROGRESS_THREAD_NAME` (`pmix.evname`) — `PMIX_STRING`
@@ -3483,16 +3488,18 @@ impl InitOptions {
 /// This is useful for keys like `"pmix.srvr.uri"` (14 bytes) which don't
 /// fit in `InfoBuilder::add(key: &'static [u8; 13])`.
 pub fn info_with_string_key(key: &str, value: &str) -> Result<Info, PmixStatus> {
-    let key_cstr = CString::new(key)
-        .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
-    let value_cstr = CString::new(value)
-        .map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
+    let key_cstr = CString::new(key).map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
+    let value_cstr = CString::new(value).map_err(|_| PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;
+    // SAFETY: PMIx allocates one initialized info record and returns a null
+    // pointer on allocation failure.
     let info_ptr = unsafe { PMIx_Info_create(1) };
     if info_ptr.is_null() {
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_NOMEM));
     }
     // PMIx_Info_load copies key/value into the info array (PMIx 4+/5+/6+).
     // Keep CStrings alive only for the duration of the load call, then drop.
+    // SAFETY: `info_ptr` is a valid PMIx info array, and the CString pointers
+    // remain valid for the duration of the call.
     let status = unsafe {
         PMIx_Info_load(
             info_ptr,
@@ -3506,6 +3513,8 @@ pub fn info_with_string_key(key: &str, value: &str) -> Result<Info, PmixStatus> 
     drop(value_cstr);
     if status != PMIX_SUCCESS as i32 {
         // Free the half-built array before returning the PMIx error.
+        // SAFETY: `info_ptr` was allocated by PMIx_Info_create(1) above and
+        // remains valid until it is freed here.
         unsafe {
             PMIx_Info_free(info_ptr, 1);
         }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -1123,7 +1123,7 @@ mod tests {
 
     #[test]
     fn test_log_data_with_string_info() {
-        let info = crate::info_with_string_key("test.key", "test.value");
+        let info = crate::info_with_string_key("test.key", "test.value").expect("string info");
         let data = vec![info];
         let directives = vec![];
         let result = log_data(&data, &directives);
@@ -1134,8 +1134,8 @@ mod tests {
 
     #[test]
     fn test_log_data_with_directives() {
-        let data_info = crate::info_with_string_key("log.data", "hello");
-        let dir_info = crate::info_with_string_key("PMIX_LOG_STDOUT", "1");
+        let data_info = crate::info_with_string_key("log.data", "hello").expect("string info");
+        let dir_info = crate::info_with_string_key("PMIX_LOG_STDOUT", "1").expect("string info");
         let result = log_data(&[data_info], &[dir_info]);
         assert!(result.is_ok() || result.is_err());
     }
@@ -1208,7 +1208,7 @@ mod tests {
             let registry = LOG_REGISTRY.lock();
             registry.len()
         };
-        let info = crate::info_with_string_key("test.key", "test.value");
+        let info = crate::info_with_string_key("test.key", "test.value").expect("string info");
         let cb = Box::new(LogNbCounting {
             _called: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         });
@@ -1245,7 +1245,7 @@ mod tests {
             registry.len()
         };
         for _ in 0..5 {
-            let info = crate::info_with_string_key("test", "val");
+            let info = crate::info_with_string_key("test", "val").expect("string info");
             let _ = log_data_nb(&[info], &[], Box::new(LogDummy));
         }
         let size_after = {
@@ -1515,7 +1515,7 @@ mod tests {
 
     #[test]
     fn test_info_with_string_key_for_log() {
-        let info = crate::info_with_string_key("PMIX_LOG_STDOUT", "test message");
+        let info = crate::info_with_string_key("PMIX_LOG_STDOUT", "test message").expect("string info");
         assert!(!info.is_empty());
         assert_eq!(info.len(), 1);
     }
@@ -1598,7 +1598,7 @@ mod tests {
     #[test]
     fn test_log_data_success_with_mock() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
         let result = log_data(&data, &directives);
         assert!(result.is_ok());
@@ -1610,7 +1610,7 @@ mod tests {
             mock_ffi::MockConfig::new()
                 .with_function_status("PMIx_Log", mock_ffi::PMIX_ERR_NOT_SUPPORTED)
         );
-        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
         let result = log_data(&data, &directives);
         assert!(result.is_err());
@@ -1620,7 +1620,7 @@ mod tests {
     #[test]
     fn test_log_data_nb_success_with_mock() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
 
         struct TestLogCallback {
@@ -1646,7 +1646,7 @@ mod tests {
             mock_ffi::MockConfig::new()
                 .with_function_status("PMIx_Log_nb", mock_ffi::PMIX_ERR_INIT)
         );
-        let data = vec![crate::info_with_string_key("test.key", "test.value")];
+        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
 
         struct TestLogCallback {
@@ -1745,8 +1745,8 @@ mod tests {
     #[test]
     fn test_log_data_with_both_data_and_directives() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("log.message", "Hello, world!")];
-        let directives = vec![crate::info_with_string_key("pmix.log.stdout", "true")];
+        let data = vec![crate::info_with_string_key("log.message", "Hello, world!").expect("string info")];
+        let directives = vec![crate::info_with_string_key("pmix.log.stdout", "true").expect("string info")];
         let result = log_data(&data, &directives);
         assert!(result.is_ok());
     }

--- a/tests/daemon_helper.rs
+++ b/tests/daemon_helper.rs
@@ -139,7 +139,7 @@ pub fn get_tool_init_info() -> Info {
     let uri = read_uri().unwrap_or_else(|e| {
         panic!("Cannot read PRTE URI for tool_init: {}", e);
     });
-    info_with_string_key("pmix.srvr.uri", &uri)
+    info_with_string_key("pmix.srvr.uri", &uri).expect("string info")
 }
 
 /// Singleton tool handle, initialized once for the entire test binary.
@@ -172,7 +172,7 @@ fn tool_init_with_timeout(uri: &str) -> Result<PmixTool, String> {
 
     let handle = thread::spawn(move || {
         // Construct the Info inside the thread to avoid cross-thread pointer issues
-        let info = info_with_string_key("pmix.srvr.uri", &uri);
+        let info = info_with_string_key("pmix.srvr.uri", &uri).expect("string info");
         match tool_init(None, &info) {
             Ok(h) => tx.send(Ok(h)),
             Err(e) => tx.send(Err(format!("tool_init returned error: {:?}", e))),


### PR DESCRIPTION
Closes #400

## Summary
Return errors instead of panicking when caller-provided info keys, values, CPU sets, or progress-thread names contain interior NUL bytes. PMIx allocation and load failures now propagate as PmixStatus with cleanup on load failure.

## Signature changes
- `InfoBuilder::add_string_key(...) -> Result<&mut Self, std::ffi::NulError>`
- `InfoBuilder::bind_progress_thread(...) -> Result<&mut Self, std::ffi::NulError>`
- `InfoBuilder::progress_thread_name(...) -> Result<&mut Self, std::ffi::NulError>`
- `info_with_string_key(...) -> Result<Info, PmixStatus>`
- `info::string_kv(...) -> Result<Info, PmixStatus>`

## Callers migrated
Updated InitOptions error propagation, unit tests, data-ops tests, query-log tests, daemon helper callers, and the existing lib test call sites.

## Test plan
Local OpenPMIx 6.1.0 build and full cargo test passed, including mock-based NUL regression tests and doctests. Daemon/DVM tests are compiled and ignored locally where required; daemon execution remains for CI.

Quality gates: cargo clippy --lib -- -D warnings is blocked only by six pre-existing generated bindgen missing-safety-doc errors; cargo fmt --check reports pre-existing repository-wide formatting differences.