### PR TITLE
fix(process-mgmt): return Err(PMIX_ERR_BAD_PARAM) on NUL in abort/resolve_peers/resolve_nodes instead of panicking

### DIFF
--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -83,6 +83,8 @@ use std::sync::{LazyLock, Mutex};
 /// # Returns
 /// * `Ok(())` — the abort request was accepted. If the caller's own
 ///   process was included, the function will not return with success.
+/// * `Err(PmixStatus::Known(PmixError::ErrBadParam))` — `msg` contains an
+///   interior NUL byte.
 /// * `Err(PmixStatus::Known(PmixError::ErrParamValueNotSupported))` — the
 ///   host environment cannot abort the requested processes (e.g., subsets
 ///   from another namespace).
@@ -1151,6 +1153,8 @@ pub fn disconnect_nb(
 ///   initialized via `PMIx_Init`.
 /// * `Err(PmixStatus::Known(PmixError::ErrNotFound))` — `nspace` was
 ///   provided but no such namespace is known.
+/// * `Err(PmixStatus::Known(PmixError::ErrBadParam))` — `nodename` or
+///   `nspace` contains an interior NUL byte.
 /// * `Err(PmixStatus)` — another error in the request.
 ///
 /// # Thread Safety
@@ -1255,6 +1259,8 @@ pub fn resolve_peers(
 ///   initialized via `PMIx_Init`.
 /// * `Err(PmixStatus::Known(PmixError::ErrNotFound))` — the specified
 ///   namespace is not known.
+/// * `Err(PmixStatus::Known(PmixError::ErrBadParam))` — `nspace` contains an
+///   interior NUL byte.
 /// * `Err(PmixStatus)` — another error in the request.
 ///
 /// # Thread Safety

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -105,7 +105,10 @@ pub fn abort(
     // Convert the optional message to a C string pointer.
     let (msg_ptr, _msg_cstring) = match msg {
         Some(m) => {
-            let cs = CString::new(m).expect("abort message must not contain interior NUL bytes");
+            let cs = match CString::new(m) {
+                Ok(c) => c,
+                Err(_) => return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM)),
+            };
             (cs.as_ptr(), Some(cs))
         }
         None => (ptr::null(), None),
@@ -1167,7 +1170,10 @@ pub fn resolve_peers(
     // Convert nodename to C string if provided.
     let (nodename_ptr, _nodename_cstring) = match nodename {
         Some(n) => {
-            let cs = CString::new(n).expect("nodename must not contain interior NUL bytes");
+            let cs = match CString::new(n) {
+                Ok(c) => c,
+                Err(_) => return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM)),
+            };
             (cs.as_ptr(), Some(cs))
         }
         None => (ptr::null::<c_char>(), None),
@@ -1176,7 +1182,10 @@ pub fn resolve_peers(
     // Convert nspace to C string if provided.
     let (nspace_ptr, _nspace_cstring) = match nspace {
         Some(ns) => {
-            let cs = CString::new(ns).expect("nspace must not contain interior NUL bytes");
+            let cs = match CString::new(ns) {
+                Ok(c) => c,
+                Err(_) => return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM)),
+            };
             (cs.as_ptr(), Some(cs))
         }
         None => (ptr::null::<c_char>(), None),
@@ -1259,7 +1268,10 @@ pub fn resolve_peers(
 /// ```
 pub fn resolve_nodes(nspace: &str) -> Result<String, PmixStatus> {
     // Convert namespace to C string.
-    let nspace_cs = CString::new(nspace).expect("nspace must not contain interior NUL bytes");
+    let nspace_cs = match CString::new(nspace) {
+        Ok(c) => c,
+        Err(_) => return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM)),
+    };
 
     let mut nodelist: *mut c_char = ptr::null_mut();
 
@@ -2203,6 +2215,38 @@ mod tests {
     // error code varies by PMIx version and state — PMIx 5.0.7 returns
     // ErrNotFound rather than ErrInit. We assert only that an error is
     // returned, not the specific error, to avoid version-dependent failures.
+
+    #[test]
+    fn test_abort_with_nul_message_returns_bad_param() {
+        let result = abort(PmixStatus::from_raw(1), Some("boom\0"), None);
+        assert_eq!(result.unwrap_err().to_raw(), ffi::PMIX_ERR_BAD_PARAM);
+    }
+
+    #[test]
+    fn test_resolve_peers_with_nul_nodename_returns_bad_param() {
+        let result = resolve_peers(Some("node\0"), None);
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("resolve_peers() should reject NUL in nodename"),
+        };
+        assert_eq!(error.to_raw(), ffi::PMIX_ERR_BAD_PARAM);
+    }
+
+    #[test]
+    fn test_resolve_peers_with_nul_nspace_returns_bad_param() {
+        let result = resolve_peers(None, Some("ns\0"));
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("resolve_peers() should reject NUL in nspace"),
+        };
+        assert_eq!(error.to_raw(), ffi::PMIX_ERR_BAD_PARAM);
+    }
+
+    #[test]
+    fn test_resolve_nodes_with_nul_nspace_returns_bad_param() {
+        let result = resolve_nodes("ns\0withnul");
+        assert_eq!(result.unwrap_err().to_raw(), ffi::PMIX_ERR_BAD_PARAM);
+    }
 
     #[test]
     fn test_resolve_peers_no_dvm() {


### PR DESCRIPTION
Closes #402

## Summary
abort, resolve_peers, and resolve_nodes now return Err(PmixStatus::from_raw(PMIX_ERR_BAD_PARAM)) when caller-supplied msg/nodename/nspace contains an interior NUL byte, instead of panicking.

## Sites changed
- abort message conversion
- resolve_peers nodename conversion
- resolve_peers nspace conversion
- resolve_nodes namespace conversion

## Tests
Added regression tests covering interior NUL bytes in all four conversion sites. Existing no-DVM sanity tests remain in place for resolve_peers(None, None) and resolve_nodes("test_ns").

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build`
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib nul`
- `git diff --check`

The local tests exercise input validation before FFI; daemon-dependent behavior remains for CI only.