### PR TITLE
fix(lib): get_version returns Result<&str, Utf8Error> instead of panicking on non-UTF-8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3972,12 +3972,11 @@ pub fn fence(proc: &Proc, info: Option<Info>) -> Result<(), pmix_status_t> {
     }
 }
 
-pub fn get_version() -> &'static str {
-    let version: &CStr;
-    unsafe {
-        version = CStr::from_ptr(PMIx_Get_version());
-    }
-    version.to_str().unwrap()
+pub fn get_version() -> Result<&'static str, std::str::Utf8Error> {
+    // SAFETY: PMIx_Get_version() returns a pointer to a NUL-terminated,
+    // process-lifetime static string.
+    let version = unsafe { CStr::from_ptr(PMIx_Get_version()) };
+    version.to_str()
 }
 /// Manually drive the PMIx event progress loop.
 ///
@@ -4166,7 +4165,7 @@ mod tests {
 
     #[test]
     fn test_get_version() {
-        let ver = super::get_version();
+        let ver = super::get_version().unwrap();
         assert!(!ver.is_empty(), "PMIx version string should not be empty");
     }
 

--- a/tests/lib_core_api.rs
+++ b/tests/lib_core_api.rs
@@ -18,13 +18,13 @@ use std::ffi::CString;
 
 #[test]
 fn test_get_version_not_empty() {
-    let version = pmix::get_version();
+    let version = pmix::get_version().expect("version");
     assert!(!version.is_empty(), "version should not be empty");
 }
 
 #[test]
 fn test_get_version_has_digits() {
-    let version = pmix::get_version();
+    let version = pmix::get_version().expect("version");
     assert!(
         version.chars().any(|c| c.is_ascii_digit()),
         "version should contain digits: {}",

--- a/tests/lib_core_lifecycle.rs
+++ b/tests/lib_core_lifecycle.rs
@@ -20,7 +20,7 @@ use pmix::{InfoBuilder, PmixClient, PmixError, PmixStatus, finalize, get_version
 #[test]
 fn get_version_returns_non_empty() {
     assert!(
-        !get_version().is_empty(),
+        !get_version().unwrap().is_empty(),
         "get_version should return non-empty string"
     );
 }
@@ -28,7 +28,7 @@ fn get_version_returns_non_empty() {
 /// `get_version` returns a string containing digits (version numbers).
 #[test]
 fn get_version_contains_digits() {
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(
         version.chars().any(|c| c.is_ascii_digit()),
         "get_version should contain digits"
@@ -38,15 +38,15 @@ fn get_version_contains_digits() {
 /// `get_version` returns `&'static str` (compile-time type check).
 #[test]
 fn get_version_returns_static_str() {
-    let _v: &'static str = get_version();
+    let _v: &'static str = get_version().expect("version");
 }
 
 /// `get_version` is deterministic — repeated calls return the same value.
 #[test]
 fn get_version_is_deterministic() {
     assert_eq!(
-        get_version(),
-        get_version(),
+        get_version().unwrap(),
+        get_version().unwrap(),
         "get_version must be deterministic"
     );
 }
@@ -54,7 +54,7 @@ fn get_version_is_deterministic() {
 /// `get_version` returns printable ASCII and spaces only.
 #[test]
 fn get_version_is_printable_ascii() {
-    let version = get_version();
+    let version = get_version().unwrap();
     for (i, c) in version.chars().enumerate() {
         assert!(
             c.is_ascii_graphic() || c == ' ' || c == '\t',
@@ -70,7 +70,7 @@ fn get_version_is_printable_ascii() {
 #[test]
 fn get_version_starts_with_openpmix() {
     assert!(
-        get_version().starts_with("OpenPMIx"),
+        get_version().unwrap().starts_with("OpenPMIx"),
         "get_version should start with 'OpenPMIx'"
     );
 }
@@ -79,7 +79,7 @@ fn get_version_starts_with_openpmix() {
 #[test]
 fn get_version_has_space_separator() {
     assert!(
-        get_version().contains(' '),
+        get_version().unwrap().contains(' '),
         "get_version should contain a space between name and version"
     );
 }
@@ -88,7 +88,7 @@ fn get_version_has_space_separator() {
 /// The format is "OpenPMIx 5.0.7a1 ..." — split on space, then find the first numeric segment.
 #[test]
 fn get_version_can_extract_major_version() {
-    let version = get_version();
+    let version = get_version().unwrap();
     let version_part = version.split(' ').nth(1).unwrap_or("");
     let major = version_part
         .split(|c: char| !c.is_ascii_digit())
@@ -106,7 +106,7 @@ fn get_version_can_extract_major_version() {
 /// Can extract a full "major.minor" version from `get_version` output.
 #[test]
 fn get_version_can_extract_major_minor_version() {
-    let version = get_version();
+    let version = get_version().unwrap();
     let version_part = version.split(' ').nth(1).unwrap_or("");
     let mut dot_count = 0;
     let mut segment = String::new();
@@ -141,7 +141,7 @@ fn get_version_can_extract_major_minor_version() {
 /// `get_version` string length is reasonable (not absurdly long).
 #[test]
 fn get_version_reasonable_length() {
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(
         version.len() > 5 && version.len() < 256,
         "get_version has suspicious length {}",
@@ -152,7 +152,7 @@ fn get_version_reasonable_length() {
 /// `get_version` contains version metadata like "PMIx Standard" or "ABI".
 #[test]
 fn get_version_contains_metadata() {
-    let version = get_version();
+    let version = get_version().unwrap();
     // The version string from OpenPMIx includes metadata like
     // "OpenPMIx 5.0.7a1 (PMIx Standard: 5.1, Stable ABI: 5.0, ...)"
     assert!(
@@ -592,7 +592,7 @@ fn concurrent_get_version_safe() {
         handles.push(std::thread::spawn(|| {
             let mut results = Vec::new();
             for _ in 0..CALLS_PER_THREAD {
-                results.push(get_version().to_string());
+                results.push(get_version().unwrap().to_string());
             }
             results
         }));
@@ -633,7 +633,7 @@ fn mixed_concurrent_safe_calls() {
                 if id % 2 == 0 {
                     let _ = initialized();
                 } else {
-                    let _ = get_version();
+                    let _ = get_version().unwrap();
                 }
             }
         }));
@@ -648,7 +648,7 @@ fn mixed_concurrent_safe_calls() {
 #[test]
 fn safe_functions_work_before_any_lifecycle() {
     // These should work even at the very start, before any init/finalize
-    let version = get_version();
+    let version = get_version().unwrap();
     let _is_init = initialized();
 
     assert!(!version.is_empty(), "version should be non-empty");
@@ -659,7 +659,7 @@ fn safe_functions_work_before_any_lifecycle() {
 fn get_version_works_after_failed_init() {
     let _ = PmixClient::connect_new(None);
     assert!(
-        !get_version().is_empty(),
+        !get_version().unwrap().is_empty(),
         "get_version should work after failed init"
     );
 }
@@ -694,7 +694,7 @@ fn get_version_thread_consistent_under_contention() {
         let v = versions.clone();
         handles.push(std::thread::spawn(move || {
             b.wait(); // synchronize all threads
-            let ver = get_version().to_string();
+            let ver = get_version().unwrap().to_string();
             v.lock().unwrap().push(ver);
         }));
     }

--- a/tests/utility_Get_version.rs
+++ b/tests/utility_Get_version.rs
@@ -8,7 +8,7 @@ use pmix::get_version;
 /// `get_version` returns a non-empty version string.
 #[test]
 fn get_version_returns_non_empty() {
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(
         !version.is_empty(),
         "get_version should return non-empty string"
@@ -18,7 +18,7 @@ fn get_version_returns_non_empty() {
 /// `get_version` returns a string matching typical version format (e.g. "4.1.1").
 #[test]
 fn get_version_has_version_format() {
-    let version = get_version();
+    let version = get_version().unwrap();
     // Version strings typically contain digits and dots
     assert!(
         version.chars().any(|c| c.is_ascii_digit()),
@@ -30,13 +30,13 @@ fn get_version_has_version_format() {
 /// `get_version` returns `&'static str`, not `String`.
 #[test]
 fn get_version_return_type() {
-    let _v: &str = get_version();
+    let _v: &str = get_version().unwrap();
 }
 
 /// `get_version` is deterministic — same call returns same value.
 #[test]
 fn get_version_deterministic() {
-    let v1 = get_version();
-    let v2 = get_version();
+    let v1 = get_version().unwrap();
+    let v2 = get_version().unwrap();
     assert_eq!(v1, v2, "get_version must be deterministic");
 }

--- a/tests/utility_attribute_helpers.rs
+++ b/tests/utility_attribute_helpers.rs
@@ -25,7 +25,7 @@ use pmix::{PmixError, PmixStatus, get_version};
 /// `get_version` returns a non-empty version string.
 #[test]
 fn test_get_version_non_empty() {
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(
         !version.is_empty(),
         "get_version should return a non-empty string"
@@ -35,7 +35,7 @@ fn test_get_version_non_empty() {
 /// `get_version` returns a string containing digits (typical semver format).
 #[test]
 fn test_get_version_contains_digits() {
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(
         version.chars().any(|c| c.is_ascii_digit()),
         "get_version('{}') should contain at least one digit",
@@ -49,21 +49,21 @@ fn test_get_version_contains_digits() {
 /// an owned `String`.
 #[test]
 fn test_get_version_returns_static_str() {
-    let _v: &str = get_version();
+    let _v: &str = get_version().unwrap();
 }
 
 /// `get_version` is deterministic — multiple calls return the same value.
 #[test]
 fn test_get_version_deterministic() {
-    let v1 = get_version();
-    let v2 = get_version();
+    let v1 = get_version().unwrap();
+    let v2 = get_version().unwrap();
     assert_eq!(v1, v2, "get_version must be deterministic");
 }
 
 /// `get_version` follows a version-like format (digits and dots/hyphens).
 #[test]
 fn test_get_version_format() {
-    let version = get_version();
+    let version = get_version().unwrap();
     // Typical PMIx version: "4.1.1" or "5.0.0" — contains at least one dot
     // or hyphen separating version components, or is purely numeric.
     let has_separator = version.contains('.') || version.contains('-');
@@ -78,7 +78,7 @@ fn test_get_version_format() {
 /// `get_version` output is printable ASCII.
 #[test]
 fn test_get_version_printable() {
-    let version = get_version();
+    let version = get_version().unwrap();
     for c in version.chars() {
         assert!(
             c.is_ascii_graphic() || c.is_ascii_whitespace(),
@@ -91,7 +91,7 @@ fn test_get_version_printable() {
 /// `get_version` contains a parseable version number.
 #[test]
 fn test_get_version_major_version() {
-    let version = get_version();
+    let version = get_version().unwrap();
     // Version is e.g. "OpenPMIx 5.0.7a1..." — find first digit sequence
     let major = version
         .split(|c: char| c.is_whitespace() || c == '.' || c == '-')
@@ -1185,7 +1185,7 @@ fn test_register_attributes_tool_functions() {
 #[test]
 fn test_all_utility_functions_coexist() {
     // get_version — always works, safe to call
-    let version = get_version();
+    let version = get_version().unwrap();
     assert!(!version.is_empty());
 
     // Compile-time type checks for all utility functions — they coexist


### PR DESCRIPTION
Closes #404

## Summary
`get_version()` now propagates invalid UTF-8 from the PMIx library instead of panicking.

## Change
Changed the public signature from `&'static str` to `Result<&'static str, std::str::Utf8Error>`, retaining the static lifetime and documenting the FFI safety invariant for the PMIx-owned string.

## Callers migrated
Updated the unit test and all repository callers in `tests/lib_core_api.rs`, `tests/lib_core_lifecycle.rs`, `tests/utility_Get_version.rs`, and `tests/utility_attribute_helpers.rs` to explicitly unwrap or expect the known-valid PMIx version string.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` — passed
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib test_get_version` — passed
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --no-run` — passed; daemon-based tests compile but require CI runtime infrastructure to execute
- `git diff --check` — passed
- No `cargo fmt` or `cargo clippy` run, per issue instructions
