### PR TITLE
feat(examples): add sos_runtime_bootstrap example (Closes #411)

### DIFF
--- a/examples/sos_runtime_bootstrap.rs
+++ b/examples/sos_runtime_bootstrap.rs
@@ -1,0 +1,157 @@
+//! Minimal PMIx bootstrap used by Sandia OpenSHMEM's symmetric-heap exchange.
+//!
+//! This demonstrates the connect, wildcard discovery, per-rank byte-object
+//! publish, commit, collect-data fence, peer exchange, and disconnect sequence
+//! from SOS `src/runtime-pmix.c`.
+//!
+//! ```text
+//! cargo run --example sos_runtime_bootstrap
+//! prterun -n 2 ./target/debug/examples/sos_runtime_bootstrap
+//! ```
+//!
+//! Without a DVM, `connect_new` may fail; the example prints a message and
+//! exits successfully in that case.
+
+use std::ffi::CString;
+
+const LOCAL_SIZE: &[u8] = b"PMIX_LOCAL_SIZE\0";
+const LOCAL_PEERS: &[u8] = b"PMIX_LOCAL_PEERS\0";
+const UNIV_SIZE: &[u8] = b"PMIX_UNIV_SIZE\0";
+
+fn main() {
+    println!("pmix-rs sos_runtime_bootstrap");
+
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("PmixClient::connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+
+    let rank = client.require_proc().get_rank();
+    println!("rank {rank}");
+    let wildcard = match client.proc_with_nspace(pmix::RANK_WILDCARD) {
+        Ok(proc) => proc,
+        Err(error) => {
+            eprintln!("could not create wildcard process: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+
+    let job_size = match pmix::get_value(&wildcard, pmix::JOB_SIZE, None) {
+        Ok(value) => {
+            let size = value.uint64();
+            println!("job size: {size}");
+            size as u32
+        }
+        Err(error) => {
+            eprintln!("PMIX_JOB_SIZE get failed: {error:?}; using rank-local exchange");
+            1
+        }
+    };
+
+    match pmix::get_value(&wildcard, LOCAL_SIZE, None) {
+        Ok(value) => println!("local size: {}", value.size()),
+        Err(error) => eprintln!("PMIX_LOCAL_SIZE get failed: {error:?}"),
+    }
+
+    match pmix::get_value(&wildcard, LOCAL_PEERS, None) {
+        Ok(value) => match value.string_copy() {
+            Ok(peers) => {
+                let ranks: Vec<u32> = peers
+                    .split(',')
+                    .filter_map(|peer| peer.trim().parse().ok())
+                    .collect();
+                println!("local peers: {ranks:?}");
+            }
+            Err(error) => eprintln!("PMIX_LOCAL_PEERS is not valid UTF-8: {error}"),
+        },
+        Err(error) => eprintln!("PMIX_LOCAL_PEERS get failed: {error:?}"),
+    }
+
+    match pmix::get_value(&wildcard, UNIV_SIZE, None) {
+        Ok(value) => println!("universe size: {}", value.size()),
+        Err(error) => eprintln!("PMIX_UNIV_SIZE get failed: {error:?}"),
+    }
+
+    let key = format!("sos:{rank}");
+    let key_c = match CString::new(key.as_str()) {
+        Ok(key) => key,
+        Err(error) => {
+            eprintln!("could not create publish key: {error}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    let payload = format!("hello-from-{rank}").into_bytes();
+    let builder = match pmix::PmixValueBuilder::new().byte_object(&payload) {
+        Ok(builder) => builder,
+        Err(error) => {
+            eprintln!("could not build rank payload: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    let mut value = match builder.build() {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("could not finalize rank payload: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+
+    if let Err(error) = pmix::put_value(pmix::PmixScope::Global.to_raw(), &key_c, &mut value) {
+        eprintln!("put_value failed: {error:?}");
+        let _ = client.disconnect(None);
+        return;
+    }
+    if let Err(error) = pmix::commit() {
+        eprintln!("commit failed: {error:?}");
+        let _ = client.disconnect(None);
+        return;
+    }
+
+    let mut info_builder = pmix::InfoBuilder::new();
+    info_builder.collect_data();
+    let info = match info_builder.build() {
+        Ok(info) => info,
+        Err(error) => {
+            eprintln!("could not build collect-data info: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    if let Err(error) = pmix::fence(&wildcard, Some(info)) {
+        eprintln!("fence failed: {error:?}");
+        let _ = client.disconnect(None);
+        return;
+    }
+
+    for peer_rank in 0..job_size {
+        let peer = match client.proc_with_nspace(peer_rank) {
+            Ok(peer) => peer,
+            Err(error) => {
+                eprintln!("could not create process for rank {peer_rank}: {error:?}");
+                continue;
+            }
+        };
+        let peer_key = format!("sos:{peer_rank}");
+        let peer_key = match CString::new(peer_key) {
+            Ok(key) => key,
+            Err(error) => {
+                eprintln!("could not create key for rank {peer_rank}: {error}");
+                continue;
+            }
+        };
+        match pmix::get_value(&peer, peer_key.as_bytes_with_nul(), None) {
+            Ok(peer_value) => println!("rank {peer_rank} payload: {:?}", peer_value.bytes_copy()),
+            Err(error) => eprintln!("get for rank {peer_rank} failed: {error:?}"),
+        }
+    }
+
+    let _ = client.disconnect(None);
+    println!("sos_runtime_bootstrap done");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3025,6 +3025,14 @@ impl PmixOwnedValue {
         }
         unsafe { std::slice::from_raw_parts(ptr as *const u8, len).to_vec() }
     }
+
+    /// Read the value as an owned UTF-8 string.
+    pub fn string_copy(&self) -> Result<String, std::str::Utf8Error> {
+        // SAFETY: PMIX_STRING values contain a valid NUL-terminated pointer
+        // owned by this value for its lifetime.
+        let string = unsafe { CStr::from_ptr(self.inner.data.string) };
+        string.to_str().map(str::to_owned)
+    }
 }
 
 impl Drop for PmixOwnedValue {
@@ -4156,7 +4164,7 @@ mod tests {
         crate::mock_ffi::mock_store_value("pmix.host", b"host", PMIX_STRING);
         let result = get_value(&proc, b"pmix.host\0", None);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().uint32(), 1);
+        assert_eq!(result.unwrap().string_copy().unwrap(), "host");
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3028,9 +3028,16 @@ impl PmixOwnedValue {
 
     /// Read the value as an owned UTF-8 string.
     pub fn string_copy(&self) -> Result<String, std::str::Utf8Error> {
+        // SAFETY: this accessor is only valid for a PMIX_STRING value, whose
+        // active union arm is the string pointer.
+        let ptr = unsafe { self.inner.data.string };
+        if ptr.is_null() {
+            // SAFETY: an empty C string is valid and never null.
+            return Ok(String::new());
+        }
         // SAFETY: PMIX_STRING values contain a valid NUL-terminated pointer
         // owned by this value for its lifetime.
-        let string = unsafe { CStr::from_ptr(self.inner.data.string) };
+        let string = unsafe { CStr::from_ptr(ptr) };
         string.to_str().map(str::to_owned)
     }
 }

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -259,12 +259,18 @@ pub fn mock_get(
     };
     let mut boxed = Box::new(unsafe { std::mem::MaybeUninit::<crate::ffi::pmix_value_t>::zeroed().assume_init() });
     if let Some((bytes, dtype)) = KEY_VALUE_STORE.with(|cell| cell.borrow().get(&key_str).cloned()) {
-        boxed.type_ = dtype as u16;
-        // PMIX_INT = 1, PMIX_STRING = 2 (numeric to avoid order deps)
-        boxed.type_ = 1u16; // PMIX_INT
-        let n = if dtype == 2 { bytes.len() as i32 } else { 1 };
-        unsafe {
-            *(&mut boxed.data as *mut _ as *mut i32) = n;
+        // PMIX_INT = 1, PMIX_STRING = 3 (numeric to avoid order deps).
+        if dtype == 3 {
+            boxed.type_ = 3u16;
+            let string = std::ffi::CString::new(bytes).expect("mock string");
+            boxed.data.string = string.into_raw();
+        } else {
+            boxed.type_ = 1u16; // PMIX_INT
+            // SAFETY: the mock value union is initialized and the int arm is
+            // the active arm for this PMIX_INT value.
+            unsafe {
+                *(&mut boxed.data as *mut _ as *mut i32) = 1;
+            }
         }
     } else {
         boxed.type_ = 1u16; // PMIX_INT

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -259,9 +259,9 @@ pub fn mock_get(
     };
     let mut boxed = Box::new(unsafe { std::mem::MaybeUninit::<crate::ffi::pmix_value_t>::zeroed().assume_init() });
     if let Some((bytes, dtype)) = KEY_VALUE_STORE.with(|cell| cell.borrow().get(&key_str).cloned()) {
-        // PMIX_INT = 1, PMIX_STRING = 3 (numeric to avoid order deps).
-        if dtype == 3 {
-            boxed.type_ = 3u16;
+        // PMIX_INT = 1, PMIX_STRING = 3 (OpenPMIx >= 6.1 numbering).
+        if dtype == crate::ffi::PMIX_STRING as u32 {
+            boxed.type_ = crate::ffi::PMIX_STRING as u16;
             let string = std::ffi::CString::new(bytes).expect("mock string");
             boxed.data.string = string.into_raw();
         } else {


### PR DESCRIPTION
Closes #411

## Summary
Ports Sandia OpenSHMEM's PMIx client bootstrap (`src/runtime-pmix.c`) into a self-contained Rust example: connect, wildcard discovery (JOB_SIZE/LOCAL_SIZE/LOCAL_PEERS/UNIV_SIZE), per-rank byte-object publish, commit, collect-data fence, peer blob exchange, disconnect. Adds the reusable `PmixOwnedValue::string_copy()` accessor and mock string round-trip coverage needed for LOCAL_PEERS.

## Module placement rationale
The runnable artifact belongs in `examples/sos_runtime_bootstrap.rs` because it demonstrates the public client API end to end without daemon-only test machinery. The small string accessor belongs on `PmixOwnedValue` because sibling PMIx consumers can reuse it safely.

## Rust mapping
- `PmixClient::connect_new` / `require_proc` / `proc_with_nspace` / `disconnect`
- wildcard `get_value` with `RANK_WILDCARD` proc
- `InfoBuilder::collect_data()` for the fence qualifier
- `PmixOwnedValue::bytes_copy()` and `string_copy()` for value reads

## Test plan
- `cargo build --examples` passes locally
- targeted mock string test and `cargo test --lib` pass locally (1839 passed, 29 ignored)
- full `cargo test` reaches the suite but exits with SIGSEGV in an existing daemon-related/mock test; no failure was attributed to this change
- `cargo fmt --check` is blocked by pre-existing repository-wide formatting diffs; the added example is rustfmt-clean
- `cargo clippy --all-targets -- -D warnings` is blocked by pre-existing repository-wide warnings/errors
- bare run exits gracefully without a DVM (client_minimal convention)
- `prterun -n 2` acceptance run passes under the PRRTE scratch install
- daemon tests are CI-only (no local DVM guarantees)