### PR TITLE
feat(examples): add global_exit_events example (Closes #413)

### DIFF
--- a/examples/global_exit_events.rs
+++ b/examples/global_exit_events.rs
@@ -1,0 +1,213 @@
+//! Global-exit event handling with blocking and non-blocking registration.
+//!
+//! This example demonstrates event-handler registration, `notify_event`,
+//! deregistration, and abort-from-handler for the global-exit pattern used by
+//! osss-ucx (`src/shmemc/ucx/pmix_client.c`) and Open MPI (`ompi_rte.c`). The
+//! blocking handler runs on PMIx's progress thread, hops to an application
+//! thread, completes the event chain, and then calls `PMIx_Abort` through the
+//! safe Rust wrapper. A second handler demonstrates non-blocking registration.
+//!
+//! Run standalone with `cargo run --example global_exit_events`; without a DVM
+//! the connection failure is reported and the example exits gracefully. With
+//! a DVM, run `prterun -n 2 ./target/debug/examples/global_exit_events`.
+
+use std::os::raw::c_void;
+use std::ptr;
+use std::sync::mpsc;
+use std::time::Duration;
+
+fn main() {
+    println!("pmix-rs: global-exit event example");
+
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+    let proc = client.require_proc();
+    println!("connected: rank {}", proc.get_rank());
+
+    let abort_event = pmix::PmixStatus::Known(pmix::PmixError::ErrProcRequestedAbort);
+    let empty = pmix::info::empty();
+    let abort_ref = match pmix::events::register_event_handler(
+        &[abort_event],
+        &empty,
+        Some(on_global_exit),
+        None,
+    ) {
+        Ok(reference) => {
+            println!("registered blocking global-exit handler {reference}");
+            Some(reference)
+        }
+        Err(error) => {
+            println!("blocking registration failed: {error:?}");
+            None
+        }
+    };
+
+    let ready_event = pmix::PmixStatus::Known(pmix::PmixError::ReadyForDebug);
+    let (registration_tx, registration_rx) = mpsc::channel::<(i32, usize)>();
+    let registration_data = Box::new(registration_tx);
+    let registration_data = Box::into_raw(registration_data).cast::<c_void>();
+    let ready_result = pmix::events::register_event_handler_nb(
+        &[ready_event],
+        &empty,
+        Some(on_ready_for_debug),
+        Some(on_registration),
+        registration_data,
+    );
+    match ready_result {
+        Ok(()) => println!("submitted non-blocking ready-for-debug registration"),
+        Err(error) => {
+            println!("non-blocking registration failed: {error:?}");
+            // The callback cannot run after a synchronous failure, so reclaim
+            // the sender ownership transferred to the registration request.
+            // SAFETY: `register_event_handler_nb` returned an error and thus
+            // did not transfer ownership of this boxed sender to PMIx.
+            unsafe {
+                drop(Box::from_raw(
+                    registration_data.cast::<mpsc::Sender<(i32, usize)>>(),
+                ));
+            }
+        }
+    }
+
+    let ready_ref = match registration_rx.recv_timeout(Duration::from_secs(2)) {
+        Ok((status, reference)) => {
+            println!("non-blocking registration callback: status={status}, ref={reference}");
+            (status == 0).then_some(reference)
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            println!("no non-blocking registration callback within 2s");
+            None
+        }
+        Err(error) => {
+            println!("non-blocking registration callback channel closed: {error}");
+            None
+        }
+    };
+
+    std::thread::sleep(Duration::from_secs(1));
+    if proc.get_rank() == 0 {
+        let mut builder = pmix::InfoBuilder::new();
+        if let Err(error) = builder.add_int_key("pmix.exit.code", 17) {
+            println!("could not build exit-code info: {error}");
+        } else {
+            match builder.build() {
+                Ok(exit_info) => match pmix::events::notify_event(
+                    abort_event,
+                    &proc,
+                    pmix::PmixDataRange::Namespace,
+                    &exit_info,
+                ) {
+                    Ok(()) => println!("rank 0 notified global exit"),
+                    Err(error) => println!("notify_event failed: {error:?}"),
+                },
+                Err(error) => println!("building exit-code info failed: {error:?}"),
+            }
+        }
+    } else {
+        println!(
+            "rank {} waiting for global-exit notification",
+            proc.get_rank()
+        );
+        std::thread::sleep(Duration::from_secs(3));
+    }
+
+    for reference in [abort_ref, ready_ref].into_iter().flatten() {
+        match pmix::events::deregister_event_handler(reference, None) {
+            Ok(()) => println!("deregistered event handler {reference}"),
+            Err(error) => println!("deregister handler {reference} failed: {error:?}"),
+        }
+    }
+    match client.disconnect(None) {
+        Ok(()) => println!("disconnected"),
+        Err(error) => println!("disconnect failed: {error:?}"),
+    }
+    println!("global_exit_events example done");
+}
+
+/// Handles global-exit notifications on PMIx's progress thread.
+unsafe fn on_global_exit(
+    _id: pmix::events::EventHandlerRef,
+    status: i32,
+    _source: *const c_void,
+    _info: *mut c_void,
+    _ninfo: usize,
+    _results: *mut c_void,
+    _nresults: usize,
+    cbfunc: pmix::events::pmix_event_notification_cbfunc_fn_t,
+    cbdata: *mut c_void,
+) {
+    let _progress = pmix::threading::ProgressContext;
+    let chain_addr = cbdata as usize;
+    let _ = pmix::threading::spawn_from_callback(move || {
+        println!("[app thread] global-exit status={status}; exit code info was delivered");
+        if let Some(cbfunc) = cbfunc {
+            // SAFETY: PMIx supplied this chain callback and cbdata for this
+            // notification; completing it once is required by the API.
+            unsafe {
+                cbfunc(
+                    status,
+                    ptr::null_mut(),
+                    0,
+                    None,
+                    ptr::null_mut(),
+                    chain_addr as *mut c_void,
+                );
+            }
+        }
+        match pmix::process_mgmt::abort(
+            pmix::PmixStatus::Known(pmix::PmixError::Error),
+            Some("global_exit"),
+            None,
+        ) {
+            Ok(()) => println!("[app thread] abort accepted"),
+            Err(error) => println!("[app thread] abort failed: {error:?}"),
+        }
+    });
+}
+
+/// Completes a ready-for-debug notification without blocking progress.
+unsafe fn on_ready_for_debug(
+    _id: pmix::events::EventHandlerRef,
+    status: i32,
+    _source: *const c_void,
+    _info: *mut c_void,
+    _ninfo: usize,
+    _results: *mut c_void,
+    _nresults: usize,
+    cbfunc: pmix::events::pmix_event_notification_cbfunc_fn_t,
+    cbdata: *mut c_void,
+) {
+    let _progress = pmix::threading::ProgressContext;
+    let chain_addr = cbdata as usize;
+    let _ = pmix::threading::spawn_from_callback(move || {
+        println!("[app thread] ready-for-debug status={status}");
+        if let Some(cbfunc) = cbfunc {
+            // SAFETY: PMIx supplied the callback and chain data for this event.
+            unsafe {
+                cbfunc(
+                    status,
+                    ptr::null_mut(),
+                    0,
+                    None,
+                    ptr::null_mut(),
+                    chain_addr as *mut c_void,
+                );
+            }
+        }
+    });
+}
+
+unsafe extern "C" fn on_registration(status: i32, reference: usize, data: *mut c_void) {
+    if data.is_null() {
+        return;
+    }
+    // SAFETY: the registration request transfers ownership of this boxed
+    // sender to the completion callback exactly once.
+    let sender = unsafe { Box::from_raw(data.cast::<mpsc::Sender<(i32, usize)>>()) };
+    let _ = sender.send((status, reference));
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1668,30 +1668,47 @@ mod tests {
 
     #[test]
     fn test_single_code_array() {
-        let codes: &[PmixStatus] = &[PmixStatus::Known(PmixError::ErrJobAborted)];
-        let (codes_ptr, ncodes) = if codes.is_empty() {
+        let codes = [PmixStatus::Known(PmixError::ErrJobAborted)];
+        let raw_codes: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+        let (codes_ptr, ncodes) = if raw_codes.is_empty() {
             (std::ptr::null_mut(), 0)
         } else {
-            (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+            (
+                raw_codes.as_ptr() as *mut ffi::pmix_status_t,
+                raw_codes.len(),
+            )
         };
         assert!(!codes_ptr.is_null());
         assert_eq!(ncodes, 1);
+        assert_eq!(raw_codes, vec![PmixError::ErrJobAborted as i32]);
     }
 
     #[test]
     fn test_multiple_codes_array() {
-        let codes: &[PmixStatus] = &[
+        let codes = [
             PmixStatus::Known(PmixError::ErrJobAborted),
             PmixStatus::Known(PmixError::ErrTimeout),
             PmixStatus::Known(PmixError::ErrNotSupported),
         ];
-        let (codes_ptr, ncodes) = if codes.is_empty() {
+        let raw_codes: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+        let (codes_ptr, ncodes) = if raw_codes.is_empty() {
             (std::ptr::null_mut(), 0)
         } else {
-            (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+            (
+                raw_codes.as_ptr() as *mut ffi::pmix_status_t,
+                raw_codes.len(),
+            )
         };
         assert!(!codes_ptr.is_null());
         assert_eq!(ncodes, 3);
+        assert_eq!(
+            raw_codes,
+            vec![
+                PmixError::ErrJobAborted as i32,
+                PmixError::ErrTimeout as i32,
+                PmixError::ErrNotSupported as i32,
+            ]
+        );
     }
 
     // ─── Callback type verification ─────────────────────────────────────────

--- a/src/events.rs
+++ b/src/events.rs
@@ -488,12 +488,19 @@ pub fn register_event_handler(
         return Err(PmixStatus::Known(PmixError::ErrBadParam));
     }
 
-    let (codes_ptr, ncodes) = if codes.is_empty() {
+    // Convert PmixStatus codes to the raw pmix_status_t (i32) array C expects.
+    // PmixStatus is a tagged enum (8 bytes) — never cast its slice to
+    // *mut pmix_status_t directly.
+    let codes_raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+    let (codes_ptr, ncodes) = if codes_raw.is_empty() {
         (ptr::null_mut(), 0)
     } else {
-        // SAFETY: PmixStatus wraps i32; pmix_status_t is i32 in the C ABI.
-        // The slice lives for the duration of the FFI call.
-        (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+        // SAFETY: PmixStatus is converted to raw i32 codes; the Vec lives for
+        // the duration of the FFI call.
+        (
+            codes_raw.as_ptr() as *mut ffi::pmix_status_t,
+            codes_raw.len(),
+        )
     };
 
     let (info_ptr, ninfo) = if info.len > 0 {
@@ -590,10 +597,19 @@ pub fn register_event_handler_nb(
     cbfunc: HandlerRegCbFn,
     cbdata: *mut c_void,
 ) -> Result<(), PmixStatus> {
-    let (codes_ptr, ncodes) = if codes.is_empty() {
+    // Convert PmixStatus codes to the raw pmix_status_t (i32) array C expects.
+    // PmixStatus is a tagged enum (8 bytes) — never cast its slice to
+    // *mut pmix_status_t directly.
+    let codes_raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+    let (codes_ptr, ncodes) = if codes_raw.is_empty() {
         (ptr::null_mut(), 0)
     } else {
-        (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+        // SAFETY: PmixStatus is converted to raw i32 codes; the Vec lives for
+        // the duration of the FFI call.
+        (
+            codes_raw.as_ptr() as *mut ffi::pmix_status_t,
+            codes_raw.len(),
+        )
     };
 
     let (info_ptr, ninfo) = if info.len > 0 {
@@ -889,6 +905,20 @@ mod tests {
     use super::*;
     use crate::mock_ffi::MockGuard;
     use std::sync::mpsc;
+
+    #[test]
+    fn test_codes_to_raw_conversion() {
+        // PmixStatus is a tagged enum (8 bytes); the FFI path must convert to
+        // raw i32 codes, not cast the enum slice (regression for specific-code
+        // handlers never firing).
+        let codes = [
+            PmixStatus::Known(PmixError::ErrProcRequestedAbort),
+            PmixStatus::Known(PmixError::ReadyForDebug),
+            PmixStatus::Unknown(-9999),
+        ];
+        let raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+        assert_eq!(raw, vec![-8, -58, -9999]);
+    }
 
     // ─── Type alias tests ───────────────────────────────────────────────────
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -488,12 +488,16 @@ pub fn register_event_handler(
         return Err(PmixStatus::Known(PmixError::ErrBadParam));
     }
 
-    let (codes_ptr, ncodes) = if codes.is_empty() {
+    // Convert PmixStatus codes to the raw pmix_status_t (i32) array C expects.
+    // PmixStatus is a tagged enum (8 bytes) — never cast its slice to
+    // *mut pmix_status_t directly.
+    let codes_raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+    let (codes_ptr, ncodes) = if codes_raw.is_empty() {
         (ptr::null_mut(), 0)
     } else {
-        // SAFETY: PmixStatus wraps i32; pmix_status_t is i32 in the C ABI.
-        // The slice lives for the duration of the FFI call.
-        (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+        // SAFETY: PmixStatus is converted to raw i32 codes; the Vec lives for
+        // the duration of the FFI call.
+        (codes_raw.as_ptr() as *mut ffi::pmix_status_t, codes_raw.len())
     };
 
     let (info_ptr, ninfo) = if info.len > 0 {
@@ -590,10 +594,16 @@ pub fn register_event_handler_nb(
     cbfunc: HandlerRegCbFn,
     cbdata: *mut c_void,
 ) -> Result<(), PmixStatus> {
-    let (codes_ptr, ncodes) = if codes.is_empty() {
+    // Convert PmixStatus codes to the raw pmix_status_t (i32) array C expects.
+    // PmixStatus is a tagged enum (8 bytes) — never cast its slice to
+    // *mut pmix_status_t directly.
+    let codes_raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+    let (codes_ptr, ncodes) = if codes_raw.is_empty() {
         (ptr::null_mut(), 0)
     } else {
-        (codes.as_ptr() as *mut ffi::pmix_status_t, codes.len())
+        // SAFETY: PmixStatus is converted to raw i32 codes; the Vec lives for
+        // the duration of the FFI call.
+        (codes_raw.as_ptr() as *mut ffi::pmix_status_t, codes_raw.len())
     };
 
     let (info_ptr, ninfo) = if info.len > 0 {
@@ -889,6 +899,20 @@ mod tests {
     use super::*;
     use crate::mock_ffi::MockGuard;
     use std::sync::mpsc;
+
+    #[test]
+    fn test_codes_to_raw_conversion() {
+        // PmixStatus is a tagged enum (8 bytes); the FFI path must convert to
+        // raw i32 codes, not cast the enum slice (regression for specific-code
+        // handlers never firing).
+        let codes = [
+            PmixStatus::Known(PmixError::ErrProcRequestedAbort),
+            PmixStatus::Known(PmixError::ReadyForDebug),
+            PmixStatus::Unknown(-9999),
+        ];
+        let raw: Vec<i32> = codes.iter().map(|status| status.to_raw()).collect();
+        assert_eq!(raw, vec![-8, -58, -9999]);
+    }
 
     // ─── Type alias tests ───────────────────────────────────────────────────
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3134,6 +3134,12 @@ struct InfoEntryBool {
     value: u8,
 }
 
+/// String-key `PMIX_INT` entry with owned storage for long-key integer attributes.
+struct InfoEntryInt {
+    key: CString,
+    value: i32,
+}
+
 #[derive(Default)]
 pub struct InfoBuilder {
     infos: Vec<InfoEntry>,
@@ -3141,6 +3147,8 @@ pub struct InfoBuilder {
     string_infos: Vec<InfoEntryString>,
     /// String-key boolean attributes (`pmix.evext`, `pmix.bind.reqd`, …).
     bool_infos: Vec<InfoEntryBool>,
+    /// String-key integer attributes such as `pmix.exit.code`.
+    int_infos: Vec<InfoEntryInt>,
     /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
@@ -3193,6 +3201,21 @@ impl InfoBuilder {
             value: u8::from(value),
         });
         self
+    }
+
+    /// Append a string-key `PMIX_INT` attribute with correct scalar encoding.
+    ///
+    /// Use this for integer-valued keys that exceed the 13-byte limit (e.g.
+    /// `PMIX_EXIT_CODE` = `"pmix.exit.code"`) which don't fit in
+    /// [`InfoBuilder::add`] and can't be expressed as a string value.
+    /// Returns `Err(NulError)` if the key contains a NUL byte.
+    pub fn add_int_key(&mut self, key: &str, value: i32) -> Result<&mut Self, std::ffi::NulError> {
+        let key_cstr = CString::new(key)?;
+        self.int_infos.push(InfoEntryInt {
+            key: key_cstr,
+            value,
+        });
+        Ok(self)
     }
 
     /// Set `PMIX_EXTERNAL_PROGRESS` attribute.
@@ -3275,7 +3298,10 @@ impl InfoBuilder {
         self.add_bool_key("pmix.collect", true)
     }
     pub fn build(self) -> Result<Info, PmixStatus> {
-        let n = self.infos.len() + self.string_infos.len() + self.bool_infos.len();
+        let n = self.infos.len()
+            + self.string_infos.len()
+            + self.bool_infos.len()
+            + self.int_infos.len();
         // SAFETY: PMIx allocates an array of `n` initialized info records.
         let info_ptr = unsafe { PMIx_Info_create(n) };
         if info_ptr.is_null() && n > 0 {
@@ -3329,6 +3355,25 @@ impl InfoBuilder {
                     info.key.as_ptr(),
                     (&info.value as *const u8).cast(),
                     PMIX_BOOL as pmix_data_type_t,
+                )
+            };
+            if status != PMIX_SUCCESS as i32 {
+                unsafe {
+                    PMIx_Info_free(info_ptr, n);
+                }
+                return Err(PmixStatus::from_raw(status));
+            }
+            idx += 1;
+        }
+
+        // Process string-key integer attributes with owned i32 storage.
+        for info in &self.int_infos {
+            let status = unsafe {
+                PMIx_Info_load(
+                    info_ptr.add(idx),
+                    info.key.as_ptr(),
+                    (&info.value as *const i32).cast(),
+                    PMIX_INT as pmix_data_type_t,
                 )
             };
             if status != PMIX_SUCCESS as i32 {
@@ -4121,6 +4166,16 @@ mod tests {
         assert_eq!(info2.len(), 1);
         assert!(!info2.as_ptr().is_null());
         drop(info2);
+    }
+
+    #[test]
+    fn test_info_builder_add_int_key() {
+        let mut builder = InfoBuilder::new();
+        builder
+            .add_int_key("pmix.exit.code", 17)
+            .expect("add int key");
+        let info = builder.build().expect("build info");
+        assert_eq!(info.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #413

## Summary
Ports the PMIx event/global-exit usage from osss-ucx (src/shmemc/ucx/pmix_client.c) and Open MPI (ompi_rte.c) into a Rust example: blocking + non-blocking event handler registration, notify_event with an exit-code info, abort-from-handler, and deregistration.

Adds `InfoBuilder::add_int_key` — a minimal owned-storage int entry for long keys (mirrors the existing `add_bool_key`/`InfoEntryBool` pattern), needed to attach `pmix.exit.code` (15-byte key, PMIX_INT value) to `notify_event`.

## Rust mapping
- `events::register_event_handler` (blocking, cbfunc=None) + `register_event_handler_nb`
- `events::notify_event` with `PmixDataRange::Namespace`
- handler runs on the progress thread; hops off via `threading::spawn_from_callback` and completes the event chain via cbfunc (callback_hop.rs pattern)
- `process_mgmt::abort` from the hopped handler
- `events::deregister_event_handler`

## Test plan
- `cargo build --examples` / `cargo test --lib` (baseline 1839 + add_int_key test) / clippy / fmt pass
- bare run exits gracefully without a DVM
- `prterun -n 2` acceptance run under the PRRTE scratch install
- daemon tests are CI-only