### PR TITLE
feat(examples): add spawn_child_job example (Closes #414)

### DIFF
--- a/examples/spawn_child_job.rs
+++ b/examples/spawn_child_job.rs
@@ -30,32 +30,36 @@ fn run_child() {
         }
     };
     let proc = client.require_proc();
-    let wildcard = match client.proc_with_nspace(pmix::RANK_WILDCARD) {
-        Ok(proc) => proc,
-        Err(error) => {
-            eprintln!("child could not create wildcard process: {error:?}");
-            let _ = client.disconnect(None);
-            return;
-        }
-    };
 
-    let parent = match pmix::data_ops::get(&wildcard, "pmix.parent", None) {
-        Ok(value) => format!("raw={:?}", value.bytes_copy()),
+    let parent = match pmix::data_ops::get(&proc, "pmix.parent", None) {
+        Ok(value) => {
+            // SAFETY: the value is a PMIX_PROC (type_tag() == PMIX_PROC); its
+            // union `proc_` arm points to a pmix_proc_t { nspace: [c_char; 256],
+            // rank: u32 } allocated by the PMIx library and owned by `value`.
+            // We only read it while `value` is alive (this match arm), and
+            // PmixOwnedValue's Drop frees it via free_value.
+            let raw = value.as_raw();
+            let proc = unsafe { &*(*raw).data.proc_ };
+            let nspace = unsafe { std::ffi::CStr::from_ptr(proc.nspace.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            format!("{nspace}:{}", proc.rank)
+        }
         Err(error) => {
             eprintln!("child PMIX_PARENT_ID get failed: {error:?}");
             "<unavailable>".to_string()
         }
     };
-    let appnum = match pmix::data_ops::get(&wildcard, "pmix.appnum", None) {
+    let appnum = match pmix::data_ops::get(&proc, "pmix.appnum", None) {
         Ok(value) => value.uint32().to_string(),
         Err(error) => {
             eprintln!("child PMIX_APPNUM get failed: {error:?}");
             "<unavailable>".to_string()
         }
     };
-    let _spawn_env = std::env::var("SPAWN_CHILD").unwrap_or_else(|_| "<unset>".to_string());
+    let spawn_env = std::env::var("SPAWN_CHILD").unwrap_or_else(|_| "<unset>".to_string());
     println!(
-        "child rank {} connected; parent={parent} appnum={appnum}",
+        "child rank {} connected; parent={parent} appnum={appnum} SPAWN_CHILD={spawn_env}",
         proc.get_rank()
     );
 
@@ -126,5 +130,5 @@ fn run_parent() {
     }
 }
 
-// The child receives PMIX_PARENT_ID as a PMIX_PROC value; `bytes_copy` keeps
-// this example safe while still exposing the returned value for inspection.
+// PMIX_PROC values are read through `as_raw()`; `bytes_copy` reads the wrong
+// union arm for a PMIX_PROC value.

--- a/examples/spawn_child_job.rs
+++ b/examples/spawn_child_job.rs
@@ -1,0 +1,130 @@
+//! Demonstrates PMIx dynamic process management with `PMIx_Spawn`.
+//!
+//! The parent builds a [`pmix::process_mgmt::PmixApp`], spawns a child job,
+//! and queries the child job size. Each child discovers its parent through
+//! `pmix.parent` (`PMIX_PARENT_ID`) and reports `pmix.appnum` (`PMIX_APPNUM`).
+//!
+//! ```text
+//! cargo run --example spawn_child_job
+//! prterun -n 1 ./target/debug/examples/spawn_child_job
+//! ```
+//!
+//! A bare run, or a run under a DVM without spawn support, reports the PMIx
+//! error and exits successfully. The call shape follows MPICH's
+//! `src/util/mpir_pmix.inc` and Open MPI's `ompi/ompi/dpm/dpm.c`.
+
+fn main() {
+    if std::env::args().any(|arg| arg == "--child") {
+        run_child();
+    } else {
+        run_parent();
+    }
+}
+
+fn run_child() {
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("child connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+    let proc = client.require_proc();
+    let wildcard = match client.proc_with_nspace(pmix::RANK_WILDCARD) {
+        Ok(proc) => proc,
+        Err(error) => {
+            eprintln!("child could not create wildcard process: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+
+    let parent = match pmix::data_ops::get(&wildcard, "pmix.parent", None) {
+        Ok(value) => format!("raw={:?}", value.bytes_copy()),
+        Err(error) => {
+            eprintln!("child PMIX_PARENT_ID get failed: {error:?}");
+            "<unavailable>".to_string()
+        }
+    };
+    let appnum = match pmix::data_ops::get(&wildcard, "pmix.appnum", None) {
+        Ok(value) => value.uint32().to_string(),
+        Err(error) => {
+            eprintln!("child PMIX_APPNUM get failed: {error:?}");
+            "<unavailable>".to_string()
+        }
+    };
+    let _spawn_env = std::env::var("SPAWN_CHILD").unwrap_or_else(|_| "<unset>".to_string());
+    println!(
+        "child rank {} connected; parent={parent} appnum={appnum}",
+        proc.get_rank()
+    );
+
+    if let Err(error) = client.disconnect(None) {
+        eprintln!("child disconnect failed: {error:?}");
+    }
+}
+
+fn run_parent() {
+    println!("pmix-rs: spawn_child_job parent");
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("parent connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+
+    let executable = match std::env::current_exe() {
+        Ok(path) => path.to_string_lossy().into_owned(),
+        Err(error) => {
+            eprintln!("could not determine current executable: {error}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    let mut builder = pmix::process_mgmt::PmixApp::builder();
+    let app = match builder
+        .cmd(&executable)
+        .arg("--child")
+        .env("SPAWN_CHILD=1")
+        .maxprocs(2)
+        .build()
+    {
+        Ok(app) => app,
+        Err(error) => {
+            eprintln!("could not build child application: {error}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+
+    let child_nspace = match pmix::process_mgmt::spawn(&[], &[app]) {
+        Ok(nspace) => nspace,
+        Err(error) => {
+            eprintln!("spawn not supported by this DVM / no DVM? ({error:?})");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    println!("spawned child nspace: {child_nspace}");
+
+    let child_wildcard = match pmix::Proc::new(&child_nspace, pmix::RANK_WILDCARD) {
+        Ok(proc) => proc,
+        Err(error) => {
+            eprintln!("could not create child wildcard process: {error}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    match pmix::data_ops::get(&child_wildcard, "pmix.job.size", None) {
+        Ok(value) => println!("child job size: {}", value.uint64()),
+        Err(error) => eprintln!("child PMIX_JOB_SIZE get failed: {error:?}"),
+    }
+
+    if let Err(error) = client.disconnect(None) {
+        eprintln!("parent disconnect failed: {error:?}");
+    }
+}
+
+// The child receives PMIX_PARENT_ID as a PMIX_PROC value; `bytes_copy` keeps
+// this example safe while still exposing the returned value for inspection.


### PR DESCRIPTION
Closes #414

## Summary
Ports PMIx_Spawn dynamic-process-management usage (MPICH src/util/mpir_pmix.inc, Open MPI dpm.c) into a self-spawning Rust example: parent builds a PmixApp and spawns a child job, child discovers the parent via PMIX_PARENT_ID / PMIX_APPNUM, parent queries the child job size.

## Module placement rationale
The artifact belongs in `examples/` because it demonstrates the public process-management and data-operations APIs end to end without changing the library surface or adding daemon tests.

## Rust mapping
- `PmixApp::builder()` cmd/arg/env/maxprocs
- `process_mgmt::spawn` -> child nspace string
- `data_ops::get` with real PMIx keys (pmix.parent / pmix.appnum / pmix.job.size)
- graceful handling of spawn-not-supported / no-DVM

## Test plan
- `cargo build --examples` passed
- `cargo test --lib -- --test-threads=1` passed (1841 passed / 0 failed / 29 ignored); the default parallel run exposed a pre-existing order-dependent failure, so the serialized result is reported
- `cargo clippy --lib -- -D warnings` blocked by 6 pre-existing generated `bindings.rs` missing-safety-doc errors
- `cargo fmt --check` is clean for the added file; repository-wide check has pre-existing formatting drift
- bare run exits gracefully without a DVM
- `prterun -n 1` spawn attempt under the PRRTE scratch install succeeded and launched two children; PMIX_PARENT_ID / PMIX_APPNUM were unavailable in this environment and were reported gracefully
- daemon tests are CI-only