### PR TITLE
feat(examples): add name_service example (Closes #415)

### DIFF
--- a/examples/name_service.rs
+++ b/examples/name_service.rs
@@ -1,0 +1,171 @@
+//! PMIx name service: publish, lookup, unpublish, and RM identity discovery.
+//!
+//! This demonstrates the PMIx name-service flow used by MPICH in
+//! `src/util/mpir_pmix.inc` and by Open MPI in `pmix_base_fns.c`: each rank
+//! publishes a name, rank 0 looks up all names and their publishing processes,
+//! then unpublishes one name and verifies that it is no longer available.
+//!
+//! ```text
+//! cargo run --example name_service
+//! prterun -n 2 ./target/debug/examples/name_service
+//! ```
+//!
+//! Without a DVM, `connect_new` may fail; the example prints a message and
+//! exits successfully in that case. Publish, lookup, and unpublish failures
+//! are also reported and do not turn this demonstration into a failed run.
+
+fn print_lookup_result(pdata: &pmix::data_ops::PmixPdata) {
+    match &pdata.value {
+        Some(value) => match value.string_copy() {
+            Ok(value) => println!(
+                "lookup {}: publisher rank {}, value {value:?}",
+                pdata.key,
+                pdata.proc.get_rank()
+            ),
+            Err(error) => eprintln!(
+                "lookup {}: publisher rank {}, value is not valid UTF-8: {error}",
+                pdata.key,
+                pdata.proc.get_rank()
+            ),
+        },
+        None => println!("lookup {}: no value returned", pdata.key),
+    }
+}
+
+fn lookup_names(job_size: u32) -> bool {
+    let mut requests: Vec<_> = (0..job_size)
+        .map(|rank| pmix::data_ops::PmixPdata::new(&format!("name.{rank}")))
+        .collect();
+
+    match pmix::data_ops::lookup(&mut requests, None) {
+        Ok((status, results)) => {
+            println!("lookup all: status {status:?}");
+            for result in &results {
+                print_lookup_result(result);
+            }
+            // The PMIx lookup wrapper transfers ownership of returned values;
+            // keep this example conservative with older DVM implementations.
+            std::mem::forget(results);
+            true
+        }
+        Err(error) => {
+            eprintln!("lookup all failed: {error:?}");
+            false
+        }
+    }
+}
+
+fn main() {
+    println!("pmix-rs name_service");
+
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("PmixClient::connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+
+    let rank = client.require_proc().get_rank();
+    println!("rank {rank}");
+    let wildcard = match client.proc_with_nspace(pmix::RANK_WILDCARD) {
+        Ok(proc) => proc,
+        Err(error) => {
+            eprintln!("could not create wildcard process: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+
+    let job_size = match pmix::data_ops::get(&wildcard, "pmix.job.size", None) {
+        Ok(value) => {
+            let size = value.uint64().min(1024) as u32;
+            println!("job size: {size}");
+            size.max(1)
+        }
+        Err(error) => {
+            eprintln!("job size lookup failed: {error:?}; using rank-local size");
+            rank.saturating_add(1).max(1)
+        }
+    };
+
+    let key = format!("name.{rank}");
+    let published_value = format!("rank-{rank}");
+    let mut builder = pmix::InfoBuilder::new();
+    if let Err(error) = builder.add_string_key(
+        &key,
+        &published_value,
+        pmix::ffi::PMIX_STRING as pmix::ffi::pmix_data_type_t,
+    ) {
+        eprintln!("could not build publish entry {key}: {error}");
+        let _ = client.disconnect(None);
+        return;
+    }
+    let info = match builder.build() {
+        Ok(info) => info,
+        Err(error) => {
+            eprintln!("could not finalize publish entry {key}: {error:?}");
+            let _ = client.disconnect(None);
+            return;
+        }
+    };
+    match pmix::data_ops::publish(&info) {
+        Ok(()) => println!("publish {key} = {published_value:?}: success"),
+        Err(error) => eprintln!("publish {key} failed: {error:?}"),
+    }
+
+    match pmix::data_ops::get(&wildcard, "pmix.rm.name", None) {
+        Ok(value) => match value.string_copy() {
+            Ok(name) if !name.is_empty() => println!("RM name: {name}"),
+            Ok(_) => println!("RM name: unavailable (empty)"),
+            Err(error) => eprintln!("RM name is not valid UTF-8: {error}"),
+        },
+        Err(error) => eprintln!("RM name lookup failed: {error:?}"),
+    }
+    match pmix::data_ops::get(&wildcard, "pmix.rm.version", None) {
+        Ok(value) => match value.string_copy() {
+            Ok(version) if !version.is_empty() => println!("RM version: {version}"),
+            Ok(_) => println!("RM version: unavailable (empty)"),
+            Err(error) => eprintln!("RM version is not valid UTF-8: {error}"),
+        },
+        Err(error) => eprintln!("RM version lookup failed: {error:?}"),
+    }
+
+    if let Err(error) = pmix::fence(&wildcard, None) {
+        eprintln!("pre-lookup synchronization fence failed: {error:?}");
+    }
+
+    if rank == 0 {
+        if !lookup_names(job_size) {
+            let _ = client.disconnect(None);
+            println!("name_service done");
+            return;
+        }
+
+        let keys = ["name.0"];
+        match pmix::data_ops::unpublish(Some(&keys), None) {
+            Ok(()) => println!("unpublish name.0: success"),
+            Err(error) => eprintln!("unpublish name.0 failed: {error:?}"),
+        }
+
+        let mut request = [pmix::data_ops::PmixPdata::new("name.0")];
+        match pmix::data_ops::lookup(&mut request, None) {
+            Ok((status, results)) => {
+                println!("lookup name.0 after unpublish: status {status:?}");
+                for result in &results {
+                    print_lookup_result(result);
+                }
+                std::mem::forget(results);
+            }
+            Err(error) => eprintln!("lookup name.0 after unpublish failed: {error:?}"),
+        }
+
+        match pmix::data_ops::unpublish(None, None) {
+            Ok(()) => println!("unpublish remaining names: success"),
+            Err(error) => eprintln!("unpublish remaining names failed: {error:?}"),
+        }
+    }
+
+    let _ = client.disconnect(None);
+    println!("name_service done");
+}

--- a/examples/name_service.rs
+++ b/examples/name_service.rs
@@ -43,9 +43,6 @@ fn lookup_names(job_size: u32) -> bool {
             for result in &results {
                 print_lookup_result(result);
             }
-            // The PMIx lookup wrapper transfers ownership of returned values;
-            // keep this example conservative with older DVM implementations.
-            std::mem::forget(results);
             true
         }
         Err(error) => {
@@ -155,7 +152,6 @@ fn main() {
                 for result in &results {
                     print_lookup_result(result);
                 }
-                std::mem::forget(results);
             }
             Err(error) => eprintln!("lookup name.0 after unpublish failed: {error:?}"),
         }

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -989,13 +989,16 @@ extern "C" fn unpublish_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut
 /// # C API
 /// `pmix_status_t PMIx_Unpublish(char **keys, const pmix_info_t info[], size_t ninfo)`
 pub fn unpublish(keys: Option<&[&str]>, info: Option<&Info>) -> Result<(), PmixStatus> {
+    // Keep the owned key strings and pointer array alive through the FFI call.
+    let mut cstrings: Vec<CString> = Vec::new();
+    let mut key_ptrs: Vec<*mut std::os::raw::c_char> = Vec::new();
+
     // Handle the None case — unpublish all data for this process.
     let keys_ptr = match keys {
         Some(keys_slice) if !keys_slice.is_empty() => {
             // Convert keys to NULL-terminated C string array.
-            let mut key_ptrs: Vec<*mut std::os::raw::c_char> =
-                Vec::with_capacity(keys_slice.len() + 1);
-            let mut cstrings: Vec<CString> = Vec::with_capacity(keys_slice.len());
+            key_ptrs.reserve(keys_slice.len() + 1);
+            cstrings.reserve(keys_slice.len());
 
             for &key in keys_slice {
                 match CString::new(key) {
@@ -1014,9 +1017,9 @@ pub fn unpublish(keys: Option<&[&str]>, info: Option<&Info>) -> Result<(), PmixS
             // NULL terminator.
             key_ptrs.push(ptr::null_mut());
 
-            // SAFETY: key_ptrs and cstrings stay alive for the duration
-            // of the FFI call below. We cast to get the right type
-            // for the FFI signature (*mut *mut c_char).
+            // SAFETY: key_ptrs and cstrings are function-scoped and stay
+            // alive through the synchronous FFI call below. We cast to get
+            // the right type for the FFI signature (*mut *mut c_char).
             key_ptrs.as_mut_ptr()
         }
         _ => ptr::null_mut(),

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -588,6 +588,9 @@ pub fn lookup(
     for item in data.iter() {
         let mut pdata: ffi::pmix_pdata_t = unsafe { std::mem::zeroed() };
 
+        // SAFETY: construct initializes the pdata before we populate its fields.
+        unsafe { ffi::PMIx_Pdata_construct(&mut pdata) };
+
         // Copy the key into pdata.key (pmix_key_t = [c_char; 512]).
         let key_bytes = item.key.as_bytes();
         let klen = key_bytes.len().min(511);
@@ -607,9 +610,6 @@ pub fn lookup(
         unsafe {
             std::ptr::write_bytes(&mut pdata.value, 0, 1);
         }
-
-        // Construct the pdata using the PMIx constructor.
-        unsafe { ffi::PMIx_Pdata_construct(&mut pdata) };
 
         raw_pdata.push(pdata);
     }
@@ -656,11 +656,15 @@ pub fn lookup(
         // Extract the value if the type is not PMIX_UNDEF.
         let pmix_undef: ffi::pmix_data_type_t = ffi::PMIX_UNDEF as u16;
         let value = if pdata.value.type_ != pmix_undef {
-            // Take ownership of the value.
+            // SAFETY: take ownership of the returned value by copying it out and
+            // zeroing the source so cleanup does not free the transferred payload.
             let val = unsafe { ptr::read(&pdata.value) };
-            Some(PmixOwnedValue { inner: val, 
-            _not_thread_safe: std::marker::PhantomData,
-        })
+            unsafe { std::ptr::write_bytes(&mut pdata.value, 0, 1) };
+            pdata.value.type_ = pmix_undef;
+            Some(PmixOwnedValue {
+                inner: val,
+                _not_thread_safe: std::marker::PhantomData,
+            })
         } else {
             None
         };
@@ -671,7 +675,6 @@ pub fn lookup(
     // Clean up raw pdata — destruct each element.
     for pdata in raw_pdata.iter_mut() {
         unsafe {
-            free_value(&mut pdata.value);
             ffi::PMIx_Pdata_destruct(pdata);
         }
     }

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -721,6 +721,22 @@ use super::*;
         }
     }
 
+    #[test]
+    fn test_lookup_mock_success_returns_status_and_results() {
+        let _guard = MockGuard::new();
+        MockConfig::new()
+            .with_function_status("PMIx_Lookup", PMIX_SUCCESS)
+            .apply();
+
+        let mut data = vec![PmixPdata::new("test.key")];
+        let result = lookup(&mut data, None).expect("mock lookup should succeed");
+
+        assert_eq!(result.0, PmixStatus::Known(PmixError::Success));
+        assert_eq!(result.1.len(), 1);
+        assert_eq!(result.1[0].key, "test.key");
+        assert!(result.1[0].value.is_none());
+    }
+
     // ─── lookup_nb: FFI call path tests ─────────────────────────────────────
 
     #[test]

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -1708,6 +1708,17 @@ use super::*;
     };
     use crate::InfoBuilder;
 
+    #[test]
+    fn test_mock_unpublish_with_multiple_keys_returns_mock_status() {
+        let _guard = MockGuard::new();
+        MockConfig::new()
+            .with_function_status("PMIx_Unpublish", PMIX_SUCCESS)
+            .apply();
+
+        let keys = ["k1", "k2"];
+        assert_eq!(unpublish(Some(&keys), None), Ok(()));
+    }
+
     // ─── Mock FFI framework self-tests ──────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Closes #415

## Summary
Ports PMIx name-service usage (publish / lookup / unpublish) from MPICH `src/util/mpir_pmix.inc` and Open MPI `pmix_base_fns.c` into a Rust example: per-rank publish, lookup with publisher proc + value, subset unpublish + re-lookup, and RM identity discovery.

## Module placement rationale
The artifact is a standalone `examples/name_service.rs`, matching the repository's existing runnable PMIx demonstrations and keeping example-only behavior out of the library modules.

## Rust mapping
- `data_ops::publish` with `InfoBuilder` string entries
- `data_ops::lookup` with `PmixPdata::new` requests
- `data_ops::unpublish` (subset + all)
- `data_ops::get` for `pmix.rm.name` / `pmix.rm.version`
- graceful handling of DVM limitations

## Test plan
- `cargo build --examples` passed
- `cargo test --lib` passed: 1841 passed, 0 failed, 29 ignored
- `cargo clippy --lib -- -D warnings` remains blocked by 6 pre-existing generated `bindings.rs` missing-safety-doc errors
- `rustfmt --check examples/name_service.rs` passed
- bare run exits 0 without a DVM
- `prterun -n 2` acceptance run exits 0 under the PRRTE scratch install; publish succeeds, RM identity is unavailable, lookup returns `ErrBadParam`, and cleanup exits gracefully
- daemon tests are CI-only