### PR TITLE
feat(examples): add load_topology example (Closes #417)

### DIFF
--- a/examples/load_topology.rs
+++ b/examples/load_topology.rs
@@ -1,0 +1,51 @@
+//! Load and report the hardware topology provided by a PMIx server.
+//!
+//! This demonstrates the `PMIx_Load_topology` / hwloc pattern used by MPICH's
+//! `src/util/mpir_pmi.c`: connect to PMIx, load the topology, print its source,
+//! and disconnect. The fabric module is the natural placement because it owns
+//! the safe `PmixTopology` and `load_topology` wrappers.
+//!
+//! ```text
+//! cargo run --example load_topology
+//! prterun -n 2 ./target/debug/examples/load_topology
+//! ```
+//!
+//! Without a DVM, or when the DVM cannot provide a topology, this example
+//! reports the condition and exits successfully. MPICH similarly falls back to
+//! its own hwloc discovery when PMIx cannot provide a topology.
+
+fn main() {
+    println!("pmix-rs load_topology");
+
+    let client = match pmix::PmixClient::connect_new(None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("PmixClient::connect_new failed (need prterun/DVM?): {error:?}");
+            return;
+        }
+    };
+
+    let rank = client.require_proc().get_rank();
+    println!("rank {rank}");
+
+    let mut topology = pmix::fabric::topology_construct();
+    match pmix::fabric::load_topology(&mut topology) {
+        Ok(()) => {
+            println!("topology source: {:?}", topology.source());
+            if topology
+                .source()
+                .is_some_and(|source| source.contains("hwloc"))
+            {
+                println!("topology was provided by hwloc");
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "PMIx could not provide a topology ({error:?}); MPICH falls back to its own hwloc discovery"
+            );
+        }
+    }
+
+    let _ = client.disconnect(None);
+    println!("load_topology done");
+}

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -689,11 +689,28 @@ impl PmixTopology {
         }
     }
 
-    /// Sync the raw struct's topology field back into managed Rust state
-    /// after an FFI call that may have modified it.
+    /// Sync the raw struct's topology and source fields back into managed Rust
+    /// state after an FFI call that may have modified them.
     fn sync_from_raw(&mut self) {
         unsafe {
-            self.topology = (*self.raw.as_ptr()).topology;
+            let raw = self.raw.as_ptr();
+            self.topology = (*raw).topology;
+            let src = (*raw).source;
+            if !src.is_null() {
+                // PMIx may have replaced raw->source with its own C-allocated
+                // string, or kept our hint pointer. If it kept our hint, the
+                // existing Rust CString already owns the right bytes.
+                let aliases_hint = self
+                    .source
+                    .as_ref()
+                    .is_some_and(|s| ptr::eq(s.as_ptr(), src));
+                if !aliases_hint {
+                    let owned = CStr::from_ptr(src).to_string_lossy().into_owned();
+                    if let Ok(cs) = CString::new(owned) {
+                        self.source = Some(cs);
+                    }
+                }
+            }
         }
     }
 
@@ -709,10 +726,30 @@ impl PmixTopology {
 impl Drop for PmixTopology {
     fn drop(&mut self) {
         if self.loaded {
-            let raw_ptr = self.as_mut_ptr();
+            // SAFETY: raw was initialized by as_mut_ptr during load_topology.
+            let raw_ptr = self.raw.as_mut_ptr();
+            unsafe {
+                // PMIx_Load_topology may return the PMIx process-global hwloc
+                // topology. PMIx_Finalize owns destruction of that shared
+                // topology, so leave it null here and let the designated
+                // destructor release only this object's source string.
+                (*raw_ptr).topology = ptr::null_mut();
+                // Do not replace the PMIx-owned source with the Rust hint.
+                // If PMIx kept the hint, duplicate it so its destructor never
+                // attempts to free a Rust allocation.
+                let src = (*raw_ptr).source;
+                if !src.is_null()
+                    && self
+                        .source
+                        .as_ref()
+                        .is_some_and(|s| ptr::eq(s.as_ptr(), src))
+                {
+                    (*raw_ptr).source = libc::strdup(src);
+                }
+            }
             // SAFETY: PMIx_Topology_destruct is the designated destructor
             // for pmix_topology_t objects that have been loaded.
-                        #[cfg(any(test, feature = "mock_ffi"))]
+            #[cfg(any(test, feature = "mock_ffi"))]
             {
                 if mock_ffi::is_mock_enabled() {
                     unsafe { mock_ffi::mock_topology_destruct(raw_ptr) };
@@ -1990,6 +2027,14 @@ mod tests {
         let topo = PmixTopology::new(None).unwrap();
         assert!(!topo.is_loaded());
         assert_eq!(topo.source(), None);
+    }
+
+    #[test]
+    fn test_topology_load_syncs_source_from_raw() {
+        let _guard = mock_ffi::MockGuard::new();
+        let mut topo = PmixTopology::unamed();
+        assert!(load_topology(&mut topo).is_ok());
+        assert_eq!(topo.source(), Some("hwloc:2.11.2"));
     }
 
     /// Test that PmixTopology::new rejects source with interior NUL bytes.

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1610,6 +1610,7 @@ pub fn mock_load_topology(topo: *mut crate::ffi::pmix_topology_t) -> i32 {
         if status == PMIX_SUCCESS && !topo.is_null() {
             unsafe {
                 (*topo).topology = std::ptr::null_mut();
+                (*topo).source = libc::strdup(b"hwloc:2.11.2\0".as_ptr() as *const i8);
             }
             MOCK_TOPOLOGY_LOADED.with(|cell| {
                 *cell.borrow_mut() = true;


### PR DESCRIPTION
Closes #417

## Summary
Ports MPICH's PMIx_Load_topology / hwloc integration (`src/util/mpir_pmi.c`) into a Rust example: connect, load the local topology from the PMIx server, print the topology source, with graceful fallback when the DVM has no topology (mirroring MPICH's fallback philosophy).

## Module placement rationale
The example lives in `examples/load_topology.rs`; it uses the existing `pmix::fabric` safe wrappers because `PmixTopology`, `load_topology`, and topology ownership are defined in the fabric module.

## Rust mapping
- `fabric::topology_construct` / `load_topology` / `.source()`
- graceful handling of no-DVM and no-topology (`ErrNotSupported`/`ErrNotFound`)

## Test plan
- `cargo build --examples`: pass
- `cargo test --lib`: pass, 1843 passed / 0 failed / 29 ignored
- `cargo clippy --lib -- -D warnings`: pre-existing generated `bindings.rs` errors on main; no changed-file warnings
- `cargo fmt --check`: repository has pre-existing formatting differences; the added file passes standalone rustfmt
- bare run exits gracefully without a DVM
- `prterun -n 2` acceptance run under the PRRTE scratch install
- daemon tests are CI-only