### PR TITLE
fix(process_mgmt,server): build contiguous proc/info arrays for connect/disconnect

### DIFF
--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -488,6 +488,29 @@ static SPAWN_REGISTRY: LazyLock<Registry<SpawnCallbackWrapper>> = LazyLock::new(
 static CONNECT_REGISTRY: LazyLock<Registry<ConnectCallbackWrapper>> = LazyLock::new(Registry::new);
 static DISCONNECT_REGISTRY: LazyLock<Registry<DisconnectCallbackWrapper>> = LazyLock::new(Registry::new);
 
+fn flat_procs(procs: &[Proc]) -> Vec<ffi::pmix_proc_t> {
+    procs
+        .iter()
+        .map(|proc| unsafe { std::ptr::read(&proc.handle) })
+        .collect()
+}
+
+fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
+    infos
+        .iter()
+        .flat_map(|info| {
+            if info.handle.is_null() || info.len == 0 {
+                Vec::new()
+            } else {
+                unsafe { std::slice::from_raw_parts(info.handle, info.len) }
+                    .iter()
+                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect()
+}
+
 /// Non-blocking spawn callback wrapper.
 ///
 /// Wraps a Rust closure so it can be called from the C FFI callback.
@@ -737,23 +760,13 @@ pub fn connect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     // containing a `pmix_proc_t` handle as its first field. We take
     // the address of the first element's handle and cast it to the
     // FFI type. The slice remains valid for the duration of this call.
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    // Convert info slice to a raw pointer.
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        // SAFETY: `info` is a non-empty slice of `Info` values, each
-        // containing a pointer to a `pmix_info_t`. We take the address
-        // of the first element's handle field.
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     // SAFETY: FFI call into PMIx library.
@@ -765,7 +778,7 @@ pub fn connect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     // - `nprocs` and `ninfo` are the correct lengths of their arrays.
     // - This is a blocking call: it does not return until all
     //   participating processes have completed the connect operation.
-    let raw_status = unsafe { ffi::PMIx_Connect(procs_ptr, procs.len(), info_ptr, ninfo) };
+    let raw_status = unsafe { ffi::PMIx_Connect(procs_ptr, flat_procs.len(), info_ptr, ninfo) };
 
     let pmix_status = PmixStatus::from_raw(raw_status);
     if pmix_status.is_success() {
@@ -858,20 +871,13 @@ pub fn connect_nb(
 
     // Convert proc slice to a raw pointer.
     // SAFETY: `procs` is a non-empty slice of `Proc` values.
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    // Convert info slice to a raw pointer.
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     // SAFETY: FFI call into PMIx library.
@@ -885,7 +891,7 @@ pub fn connect_nb(
     let raw_status = unsafe {
         ffi::PMIx_Connect_nb(
             procs_ptr,
-            procs.len(),
+            flat_procs.len(),
             info_ptr,
             ninfo,
             Some(connect_callback_bridge),
@@ -965,20 +971,13 @@ pub fn disconnect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     // containing a `pmix_proc_t` handle as its first field. We take
     // the address of the first element's handle and cast it to the
     // FFI type. The slice remains valid for the duration of this call.
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    // Convert info slice to a raw pointer.
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     // SAFETY: FFI call into PMIx library.
@@ -990,7 +989,7 @@ pub fn disconnect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     // - `nprocs` and `ninfo` are the correct lengths of their arrays.
     // - This is a blocking call: it does not return until all
     //   participating processes have completed the disconnect operation.
-    let raw_status = unsafe { ffi::PMIx_Disconnect(procs_ptr, procs.len(), info_ptr, ninfo) };
+    let raw_status = unsafe { ffi::PMIx_Disconnect(procs_ptr, flat_procs.len(), info_ptr, ninfo) };
 
     let pmix_status = PmixStatus::from_raw(raw_status);
     if pmix_status.is_success() {
@@ -1083,20 +1082,13 @@ pub fn disconnect_nb(
 
     // Convert proc slice to a raw pointer.
     // SAFETY: `procs` is a non-empty slice of `Proc` values.
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    // Convert info slice to a raw pointer.
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     // SAFETY: FFI call into PMIx library.
@@ -1110,7 +1102,7 @@ pub fn disconnect_nb(
     let raw_status = unsafe {
         ffi::PMIx_Disconnect_nb(
             procs_ptr,
-            procs.len(),
+            flat_procs.len(),
             info_ptr,
             ninfo,
             Some(disconnect_callback_bridge),
@@ -1956,6 +1948,20 @@ mod tests {
         if let Err(status) = result {
             assert_ne!(status, PmixStatus::Known(crate::PmixError::ErrBadParam));
         }
+    }
+
+    #[test]
+    fn test_connect_arrays_are_flattened_for_multiple_entries() {
+        let p1 = crate::Proc::new("ns_a", 7).unwrap();
+        let p2 = crate::Proc::new("ns_b", 9).unwrap();
+        let i1 = crate::info_with_string_key("test.key.one", "one").unwrap();
+        let i2 = crate::info_with_string_key("test.key.two", "two").unwrap();
+        let procs = super::flat_procs(&[p1, p2]);
+        let infos = super::flat_infos(&[i1, i2]);
+        assert_eq!(procs.len(), 2);
+        assert_eq!(infos.len(), 2);
+        assert_eq!(procs[0].rank, 7);
+        assert_eq!(procs[1].rank, 9);
     }
 
     #[test]

--- a/src/process_mgmt.rs
+++ b/src/process_mgmt.rs
@@ -491,7 +491,10 @@ static DISCONNECT_REGISTRY: LazyLock<Registry<DisconnectCallbackWrapper>> = Lazy
 fn flat_procs(procs: &[Proc]) -> Vec<ffi::pmix_proc_t> {
     procs
         .iter()
-        .map(|proc| unsafe { std::ptr::read(&proc.handle) })
+        .map(|proc| {
+            // SAFETY: Proc contains an initialized pmix_proc_t for this borrow.
+            unsafe { std::ptr::read(&proc.handle) }
+        })
         .collect()
 }
 
@@ -502,9 +505,13 @@ fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
             if info.handle.is_null() || info.len == 0 {
                 Vec::new()
             } else {
+                // SAFETY: handle points to len initialized entries owned by the borrow.
                 unsafe { std::slice::from_raw_parts(info.handle, info.len) }
                     .iter()
-                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .map(|entry| {
+                        // SAFETY: entry is initialized and copied by value into local storage.
+                        unsafe { std::ptr::read(entry) }
+                    })
                     .collect::<Vec<_>>()
             }
         })
@@ -755,11 +762,10 @@ pub fn connect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    // Convert proc slice to a raw pointer.
-    // SAFETY: `procs` is a non-empty slice of `Proc` values, each
-    // containing a `pmix_proc_t` handle as its first field. We take
-    // the address of the first element's handle and cast it to the
-    // FFI type. The slice remains valid for the duration of this call.
+    // Build owned contiguous arrays for the FFI call.
+    // SAFETY: `procs_ptr` points into an owned contiguous Vec of
+    // `ffi::pmix_proc_t` values, and `info_ptr` points into an owned
+    // contiguous Vec of `ffi::pmix_info_t` values; both Vecs outlive the FFI call.
     let flat_procs = flat_procs(procs);
     let procs_ptr = flat_procs.as_ptr();
     let flat_infos = flat_infos(info);
@@ -770,11 +776,10 @@ pub fn connect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     };
 
     // SAFETY: FFI call into PMIx library.
-    // - `procs_ptr` points to a valid slice of `pmix_proc_t` handles
-    //   that remain valid for the duration of this call. PMIx does
-    //   not retain these pointers after return.
-    // - `info_ptr` is either null or points to a valid slice of
-    //   `pmix_info_t` pointers. PMIx reads but does not retain.
+    // - `procs_ptr` points into the owned contiguous `flat_procs` Vec,
+    //   which outlives this call. PMIx does not retain the pointer after return.
+    // - `info_ptr` is either null or points into the owned contiguous `flat_infos`
+    //   Vec, which outlives this call. PMIx reads but does not retain the pointer.
     // - `nprocs` and `ninfo` are the correct lengths of their arrays.
     // - This is a blocking call: it does not return until all
     //   participating processes have completed the connect operation.
@@ -869,8 +874,10 @@ pub fn connect_nb(
     let req_id = CONNECT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
-    // Convert proc slice to a raw pointer.
-    // SAFETY: `procs` is a non-empty slice of `Proc` values.
+    // Build owned contiguous arrays for the FFI call.
+    // SAFETY: `procs_ptr` points into an owned contiguous Vec of
+    // `ffi::pmix_proc_t` values, and `info_ptr` points into an owned
+    // contiguous Vec of `ffi::pmix_info_t` values; both Vecs outlive the FFI call.
     let flat_procs = flat_procs(procs);
     let procs_ptr = flat_procs.as_ptr();
     let flat_infos = flat_infos(info);
@@ -881,9 +888,10 @@ pub fn connect_nb(
     };
 
     // SAFETY: FFI call into PMIx library.
-    // - `procs_ptr` points to a valid slice of `pmix_proc_t` handles.
-    // - `info_ptr` is either null or points to a valid slice of
-    //   `pmix_info_t` pointers.
+    // - `procs_ptr` points into the owned contiguous `flat_procs` Vec,
+    //   which outlives this call.
+    // - `info_ptr` is either null or points into the owned contiguous `flat_infos`
+    //   Vec, which outlives this call.
     // - `connect_callback_bridge` is a valid extern "C" callback.
     // - `cbdata` is an opaque request ID for CONNECT_REGISTRY.
     // - PMIx_Connect_nb returns immediately; the callback is invoked
@@ -966,11 +974,10 @@ pub fn disconnect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    // Convert proc slice to a raw pointer.
-    // SAFETY: `procs` is a non-empty slice of `Proc` values, each
-    // containing a `pmix_proc_t` handle as its first field. We take
-    // the address of the first element's handle and cast it to the
-    // FFI type. The slice remains valid for the duration of this call.
+    // Build owned contiguous arrays for the FFI call.
+    // SAFETY: `procs_ptr` points into an owned contiguous Vec of
+    // `ffi::pmix_proc_t` values, and `info_ptr` points into an owned
+    // contiguous Vec of `ffi::pmix_info_t` values; both Vecs outlive the FFI call.
     let flat_procs = flat_procs(procs);
     let procs_ptr = flat_procs.as_ptr();
     let flat_infos = flat_infos(info);
@@ -981,11 +988,10 @@ pub fn disconnect(procs: &[Proc], info: &[Info]) -> Result<(), PmixStatus> {
     };
 
     // SAFETY: FFI call into PMIx library.
-    // - `procs_ptr` points to a valid slice of `pmix_proc_t` handles
-    //   that remain valid for the duration of this call. PMIx does
-    //   not retain these pointers after return.
-    // - `info_ptr` is either null or points to a valid slice of
-    //   `pmix_info_t` pointers. PMIx reads but does not retain.
+    // - `procs_ptr` points into the owned contiguous `flat_procs` Vec,
+    //   which outlives this call. PMIx does not retain the pointer after return.
+    // - `info_ptr` is either null or points into the owned contiguous `flat_infos`
+    //   Vec, which outlives this call. PMIx reads but does not retain the pointer.
     // - `nprocs` and `ninfo` are the correct lengths of their arrays.
     // - This is a blocking call: it does not return until all
     //   participating processes have completed the disconnect operation.
@@ -1080,8 +1086,10 @@ pub fn disconnect_nb(
     let req_id = DISCONNECT_REGISTRY.insert_next(callback);
     let cbdata = encode_req_id(req_id);
 
-    // Convert proc slice to a raw pointer.
-    // SAFETY: `procs` is a non-empty slice of `Proc` values.
+    // Build owned contiguous arrays for the FFI call.
+    // SAFETY: `procs_ptr` points into an owned contiguous Vec of
+    // `ffi::pmix_proc_t` values, and `info_ptr` points into an owned
+    // contiguous Vec of `ffi::pmix_info_t` values; both Vecs outlive the FFI call.
     let flat_procs = flat_procs(procs);
     let procs_ptr = flat_procs.as_ptr();
     let flat_infos = flat_infos(info);
@@ -1092,9 +1100,10 @@ pub fn disconnect_nb(
     };
 
     // SAFETY: FFI call into PMIx library.
-    // - `procs_ptr` points to a valid slice of `pmix_proc_t` handles.
-    // - `info_ptr` is either null or points to a valid slice of
-    //   `pmix_info_t` pointers.
+    // - `procs_ptr` points into the owned contiguous `flat_procs` Vec,
+    //   which outlives this call.
+    // - `info_ptr` is either null or points into the owned contiguous `flat_infos`
+    //   Vec, which outlives this call.
     // - `disconnect_callback_bridge` is a valid extern "C" callback.
     // - `cbdata` is an opaque request ID for DISCONNECT_REGISTRY.
     // - PMIx_Disconnect_nb returns immediately; the callback is invoked

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -11,7 +11,10 @@ use crate::mock_ffi;
 fn flat_procs(procs: &[Proc]) -> Vec<ffi::pmix_proc_t> {
     procs
         .iter()
-        .map(|proc| unsafe { std::ptr::read(&proc.handle) })
+        .map(|proc| {
+            // SAFETY: Proc contains an initialized pmix_proc_t for this borrow.
+            unsafe { std::ptr::read(&proc.handle) }
+        })
         .collect()
 }
 
@@ -22,9 +25,13 @@ fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
             if info.handle.is_null() || info.len == 0 {
                 Vec::new()
             } else {
+                // SAFETY: handle points to len initialized entries owned by the borrow.
                 unsafe { std::slice::from_raw_parts(info.handle, info.len) }
                     .iter()
-                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .map(|entry| {
+                        // SAFETY: entry is initialized and copied by value into local storage.
+                        unsafe { std::ptr::read(entry) }
+                    })
                     .collect::<Vec<_>>()
             }
         })

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -8,6 +8,29 @@ use std::sync::{LazyLock, Mutex};
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
+fn flat_procs(procs: &[Proc]) -> Vec<ffi::pmix_proc_t> {
+    procs
+        .iter()
+        .map(|proc| unsafe { std::ptr::read(&proc.handle) })
+        .collect()
+}
+
+fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
+    infos
+        .iter()
+        .flat_map(|info| {
+            if info.handle.is_null() || info.len == 0 {
+                Vec::new()
+            } else {
+                unsafe { std::slice::from_raw_parts(info.handle, info.len) }
+                    .iter()
+                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_server_publish — publish key-value data through the server
 // ─────────────────────────────────────────────────────────────────────────────
@@ -504,19 +527,13 @@ pub fn server_connect(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
         let status;
@@ -526,7 +543,7 @@ pub fn server_connect(
             unsafe {
             mock_ffi::mock_server_fence(
                 procs_ptr as *const std::ffi::c_void,
-                procs.len(),
+                flat_procs.len(),
                 info_ptr as *mut std::ffi::c_void,
                 ninfo,
                 ptr::null_mut(),
@@ -534,13 +551,13 @@ pub fn server_connect(
             )
         }
         } else {
-            unsafe { ffi::PMIx_Connect(procs_ptr, procs.len(), info_ptr, ninfo) }
+            unsafe { ffi::PMIx_Connect(procs_ptr, flat_procs.len(), info_ptr, ninfo) }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
-            unsafe { ffi::PMIx_Connect(procs_ptr, procs.len(), info_ptr, ninfo) }
+            unsafe { ffi::PMIx_Connect(procs_ptr, flat_procs.len(), info_ptr, ninfo) }
         };
     }
 
@@ -578,25 +595,19 @@ pub fn server_connect_nb(
     let cbdata = encode_req_id(req_id);
 
 
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     let status = unsafe {
         ffi::PMIx_Connect_nb(
             procs_ptr,
-            procs.len(),
+            flat_procs.len(),
             info_ptr,
             ninfo,
             Some(connect_nb_callback_bridge),
@@ -643,19 +654,13 @@ pub fn server_disconnect(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
         let status;
@@ -665,7 +670,7 @@ pub fn server_disconnect(
             unsafe {
             mock_ffi::mock_server_fence(
                 procs_ptr as *const std::ffi::c_void,
-                procs.len(),
+                flat_procs.len(),
                 info_ptr as *mut std::ffi::c_void,
                 ninfo,
                 ptr::null_mut(),
@@ -673,13 +678,13 @@ pub fn server_disconnect(
             )
         }
         } else {
-            unsafe { ffi::PMIx_Disconnect(procs_ptr, procs.len(), info_ptr, ninfo) }
+            unsafe { ffi::PMIx_Disconnect(procs_ptr, flat_procs.len(), info_ptr, ninfo) }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
-            unsafe { ffi::PMIx_Disconnect(procs_ptr, procs.len(), info_ptr, ninfo) }
+            unsafe { ffi::PMIx_Disconnect(procs_ptr, flat_procs.len(), info_ptr, ninfo) }
         };
     }
 
@@ -715,25 +720,19 @@ pub fn server_disconnect_nb(
     let cbdata = encode_req_id(req_id);
 
 
-    let procs_ptr = unsafe {
-        std::ptr::addr_of!((*(&procs[0] as *const Proc)).handle) as *const ffi::pmix_proc_t
-    };
-
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_procs = flat_procs(procs);
+    let procs_ptr = flat_procs.as_ptr();
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *const ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     let status = unsafe {
         ffi::PMIx_Disconnect_nb(
             procs_ptr,
-            procs.len(),
+            flat_procs.len(),
             info_ptr,
             ninfo,
             Some(disconnect_nb_callback_bridge),
@@ -796,6 +795,24 @@ pub fn server_spawn_nb(
     callback: crate::process_mgmt::SpawnCallbackWrapper,
 ) -> Result<(), PmixStatus> {
     crate::process_mgmt::spawn_nb(job_info, apps, callback)
+}
+
+#[cfg(test)]
+mod array_tests {
+    use super::*;
+    #[test]
+    fn server_arrays_are_flattened_for_multiple_entries() {
+        let p1 = Proc::new("ns_a", 7).unwrap();
+        let p2 = Proc::new("ns_b", 9).unwrap();
+        let i1 = crate::info_with_string_key("test.key.one", "one").unwrap();
+        let i2 = crate::info_with_string_key("test.key.two", "two").unwrap();
+        let procs = flat_procs(&[p1, p2]);
+        let infos = flat_infos(&[i1, i2]);
+        assert_eq!(procs.len(), 2);
+        assert_eq!(infos.len(), 2);
+        assert_eq!(procs[0].rank, 7);
+        assert_eq!(procs[1].rank, 9);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #432

## Summary
`Proc` and `Info` are Rust wrapper types, not C arrays. The connect/disconnect wrappers were passing pointers into wrapper fields while reporting wrapper counts, so PMIx read garbage for multiple entries. This change mirrors the existing `groups.rs` flattening approach and builds contiguous C-owned-value vectors before each call.

## Functions fixed
- `process_mgmt`: `connect`, `connect_nb`, `disconnect`, `disconnect_nb`
- `server::data`: `server_connect`, `server_connect_nb`, `server_disconnect`, `server_disconnect_nb`

## Module placement rationale
Each module owns the affected wrappers and keeps a small local flattening helper, matching the established `groups.rs` pattern without adding cross-module coupling. The vectors remain alive through the synchronous FFI submission; PMIx consumes the non-blocking arguments at submission time and callbacks retain only request IDs.

## Test plan
- Local mock-independent unit tests construct multiple `Proc` and `Info` values and verify both module flatteners produce the correct entry counts and proc ranks.
- `cargo build` passed with `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0`.
- Targeted mock-enabled library tests passed.
- Full daemon-based tests require the CI PMIx/PRTE environment and were not run locally.
