### PR TITLE
fix(fabric,query_log,security): flatten info arrays by value instead of array-of-pointers

### DIFF
--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -65,6 +65,26 @@ use crate::{Info, PmixDeviceType, PmixError, PmixStatus};
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
+fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
+    infos
+        .iter()
+        .flat_map(|info| {
+            if info.handle.is_null() || info.len == 0 {
+                Vec::new()
+            } else {
+                // SAFETY: handle points to len initialized entries owned by the borrow.
+                unsafe { std::slice::from_raw_parts(info.handle, info.len) }
+                    .iter()
+                    .map(|entry| {
+                        // SAFETY: entry is initialized and copied by value into local storage.
+                        unsafe { std::ptr::read(entry) }
+                    })
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixFabric — safe wrapper for pmix_fabric_t
 // ─────────────────────────────────────────────────────────────────────────────
@@ -227,6 +247,7 @@ pub trait FabricCallback: Send {
 /// into an `extern "C"` callback compatible with `pmix_op_cbfunc_t`.
 struct FabricCallbackWrapper {
     callback: Box<dyn FabricCallback>,
+    _directives: Option<Vec<ffi::pmix_info_t>>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -254,16 +275,11 @@ struct FabricCallbackWrapper {
 /// `                                   const pmix_info_t directives[],`
 /// `                                   size_t ndirs);`
 pub fn fabric_register(fabric: &mut PmixFabric, directives: &[Info]) -> Result<(), PmixStatus> {
-    let (dirs_ptr, ndirs) = if directives.is_empty() {
+    let flat_infos = flat_infos(directives);
+    let (dirs_ptr, ndirs) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&directives[0] as *const Info)).handle)
-                    as *const ffi::pmix_info_t
-            },
-            directives.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
     let fabric_ptr = fabric.as_mut_ptr();
@@ -319,19 +335,14 @@ pub fn fabric_register_nb(
     directives: &[Info],
     callback: Box<dyn FabricCallback>,
 ) -> Result<(), PmixStatus> {
-    let (dirs_ptr, ndirs) = if directives.is_empty() {
+    let flat_infos = flat_infos(directives);
+    let (dirs_ptr, ndirs) = if flat_infos.is_empty() {
         (ptr::null(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&directives[0] as *const Info)).handle)
-                    as *const ffi::pmix_info_t
-            },
-            directives.len(),
-        )
+        (flat_infos.as_ptr(), flat_infos.len())
     };
 
-    let wrapper = FabricCallbackWrapper { callback };
+    let wrapper = FabricCallbackWrapper { callback, _directives: Some(flat_infos) };
     let wrapper_ptr = Box::into_raw(Box::new(wrapper)) as *mut std::os::raw::c_void;
 
     extern "C" fn fabric_register_cb(
@@ -459,7 +470,7 @@ pub fn fabric_update_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let wrapper = FabricCallbackWrapper { callback };
+    let wrapper = FabricCallbackWrapper { callback, _directives: None };
     let wrapper_ptr = Box::into_raw(Box::new(wrapper)) as *mut std::os::raw::c_void;
 
     extern "C" fn fabric_update_cb(status: ffi::pmix_status_t, cbdata: *mut std::os::raw::c_void) {
@@ -558,7 +569,7 @@ pub fn fabric_deregister_nb(
         return Err(PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM));
     }
 
-    let wrapper = FabricCallbackWrapper { callback };
+    let wrapper = FabricCallbackWrapper { callback, _directives: None };
     let wrapper_ptr = Box::into_raw(Box::new(wrapper)) as *mut std::os::raw::c_void;
 
     extern "C" fn fabric_deregister_cb(
@@ -1274,6 +1285,7 @@ pub trait ComputeDistancesCallback: Send {
 /// Internal wrapper for the compute_distances_nb callback.
 struct ComputeDistancesCallbackWrapper {
     callback: Box<dyn ComputeDistancesCallback>,
+    _info: Vec<ffi::pmix_info_t>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1365,15 +1377,11 @@ pub fn compute_distances(
     cpuset: &mut PmixCpuset,
     info: &[Info],
 ) -> Result<DeviceDistances, PmixStatus> {
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null_mut(), 0)
     } else {
-        (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *mut ffi::pmix_info_t
-            },
-            info.len(),
-        )
+        (flat_infos.as_ptr() as *mut ffi::pmix_info_t, flat_infos.len())
     };
 
     let topo_ptr = topo.as_mut_ptr();
@@ -1479,18 +1487,20 @@ pub fn compute_distances_nb(
     info: &[Info],
     callback: Box<dyn ComputeDistancesCallback>,
 ) -> Result<(), PmixStatus> {
-    let (info_ptr, ninfo) = if info.is_empty() {
+    let flat_infos = flat_infos(info);
+    let (info_ptr, ninfo) = if flat_infos.is_empty() {
         (ptr::null_mut(), 0)
     } else {
         (
-            unsafe {
-                std::ptr::addr_of!((*(&info[0] as *const Info)).handle) as *mut ffi::pmix_info_t
-            },
-            info.len(),
+            flat_infos.as_ptr() as *mut ffi::pmix_info_t,
+            flat_infos.len(),
         )
     };
 
-    let wrapper = ComputeDistancesCallbackWrapper { callback };
+    let wrapper = ComputeDistancesCallbackWrapper {
+        callback,
+        _info: flat_infos,
+    };
     let wrapper_ptr = Box::into_raw(Box::new(wrapper)) as *mut std::os::raw::c_void;
 
     extern "C" fn compute_distances_cb(

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -35,13 +35,14 @@
 //!                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 //! ```
 
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
 use std::sync::{LazyLock, Mutex};
 
-use crate::ffi;
 use crate::cbdata::Registry;
+use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
 
@@ -668,6 +669,15 @@ pub trait LogCallback: Send {
 /// Global registry mapping log request IDs to pending callbacks.
 static LOG_REGISTRY: LazyLock<Registry<Box<dyn LogCallback>>> = LazyLock::new(Registry::new);
 
+/// Flattened info arrays retained until the asynchronous log callback completes.
+struct RetainedLogInfos {
+    _data: Vec<ffi::pmix_info_t>,
+    _directives: Vec<ffi::pmix_info_t>,
+}
+unsafe impl Send for RetainedLogInfos {}
+static LOG_INFO_REGISTRY: LazyLock<Mutex<HashMap<usize, RetainedLogInfos>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// C bridge for `pmix_op_cbfunc_t` (log completion).
 ///
 /// Called by PMIx when the non-blocking log request completes. The `cbdata`
@@ -680,6 +690,10 @@ extern "C" fn log_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_voi
 
     // SAFETY: cbdata is the request ID we passed as a pointer cast.
     let req_id = crate::cbdata::decode_req_id(cbdata);
+    LOG_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
 
     // Look up and remove the callback from the registry.
     let cb = {
@@ -742,6 +756,14 @@ pub fn log_data_nb(
         ptr::null()
     };
 
+    LOG_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(req_id, RetainedLogInfos {
+            _data: data_handles,
+            _directives: dirs_handles,
+        });
+
     let status = unsafe {
         // SAFETY: PMIx_Log_nb is an async PMIx API call.
         // - data_ptr points to a valid pmix_info_t array owned by the
@@ -793,6 +815,10 @@ pub fn log_data_nb(
         // Request rejected — remove the callback from the registry.
         let mut registry = LOG_REGISTRY.lock();
         registry.remove(&req_id);
+        LOG_INFO_REGISTRY
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         Err(pmix_status)
     }
 }

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -48,6 +48,23 @@ use crate::{Info, PmixError, PmixStatus};
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
 
+fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
+    infos
+        .iter()
+        .flat_map(|info| {
+            if info.handle.is_null() || info.len == 0 {
+                Vec::new()
+            } else {
+                // SAFETY: handle points to len initialized entries owned by the borrow.
+                unsafe { std::slice::from_raw_parts(info.handle, info.len) }
+                    .iter()
+                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixQuery — safe Rust wrapper around `pmix_query_t`
 // ─────────────────────────────────────────────────────────────────────────────
@@ -591,13 +608,10 @@ pub fn query_info_nb(
 /// `pmix_status_t PMIx_Log(const pmix_info_t data[], size_t ndata,`
 /// `  const pmix_info_t directives[], size_t ndirs);`
 pub fn log_data(data: &[Info], directives: &[Info]) -> Result<(), PmixStatus> {
-    let ndata = data.len();
-    let ndirs = directives.len();
-
-    // Convert slices to raw C pointers.
-    // Collect raw handles from the Info objects.
-    let data_handles: Vec<*mut ffi::pmix_info_t> = data.iter().map(|i| i.handle).collect();
-    let dirs_handles: Vec<*mut ffi::pmix_info_t> = directives.iter().map(|i| i.handle).collect();
+    let data_handles = flat_infos(data);
+    let dirs_handles = flat_infos(directives);
+    let ndata = data_handles.len();
+    let ndirs = dirs_handles.len();
     let data_ptr = if ndata > 0 {
         data_handles.as_ptr() as *const ffi::pmix_info_t
     } else {
@@ -706,8 +720,10 @@ pub fn log_data_nb(
     directives: &[Info],
     callback: Box<dyn LogCallback>,
 ) -> Result<(), PmixStatus> {
-    let ndata = data.len();
-    let ndirs = directives.len();
+    let data_handles = flat_infos(data);
+    let dirs_handles = flat_infos(directives);
+    let ndata = data_handles.len();
+    let ndirs = dirs_handles.len();
 
     // Allocate a unique request ID and register the callback.
     let req_id = LOG_REGISTRY.insert_next(callback);
@@ -715,9 +731,6 @@ pub fn log_data_nb(
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
-    // Collect raw handles from the Info objects.
-    let data_handles: Vec<*mut ffi::pmix_info_t> = data.iter().map(|i| i.handle).collect();
-    let dirs_handles: Vec<*mut ffi::pmix_info_t> = directives.iter().map(|i| i.handle).collect();
     let data_ptr = if ndata > 0 {
         data_handles.as_ptr() as *const ffi::pmix_info_t
     } else {

--- a/src/security.rs
+++ b/src/security.rs
@@ -39,6 +39,23 @@ use crate::ffi;
 use crate::threading::invoke_user_callback;
 use crate::{Info, PmixError, PmixStatus};
 
+fn flat_infos(infos: &[Info]) -> Vec<ffi::pmix_info_t> {
+    infos
+        .iter()
+        .flat_map(|info| {
+            if info.handle.is_null() || info.len == 0 {
+                Vec::new()
+            } else {
+                // SAFETY: handle points to len initialized entries owned by the borrow.
+                unsafe { std::slice::from_raw_parts(info.handle, info.len) }
+                    .iter()
+                    .map(|entry| unsafe { std::ptr::read(entry) })
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixCredential — safe wrapper for pmix_byte_object_t
 // ─────────────────────────────────────────────────────────────────────────────
@@ -236,7 +253,8 @@ unsafe fn copy_and_free_pmix_byte_object(cred: *mut ffi::pmix_byte_object_t) -> 
 /// `pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,`
 /// `  pmix_byte_object_t *credential);`
 pub fn get_credential(info: &[Info]) -> Result<PmixCredential, PmixStatus> {
-    let ninfo = info.len();
+    let info_handles = flat_infos(info);
+    let ninfo = info_handles.len();
 
     // Allocate a pmix_byte_object_t on the stack for the output credential.
     // We use Box to get a heap-allocated struct that we can pass to PMIx.
@@ -246,8 +264,6 @@ pub fn get_credential(info: &[Info]) -> Result<PmixCredential, PmixStatus> {
     });
     let cred_ptr = Box::into_raw(cred_box);
 
-    // Collect raw handles from the Info objects.
-    let info_handles: Vec<*mut ffi::pmix_info_t> = info.iter().map(|i| i.handle).collect();
     let info_ptr = if ninfo > 0 {
         info_handles.as_ptr() as *const ffi::pmix_info_t
     } else {
@@ -484,10 +500,8 @@ pub fn get_credential_nb(
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
-    let ninfo = info.len();
-
-    // Collect raw handles from the Info objects.
-    let info_handles: Vec<*mut ffi::pmix_info_t> = info.iter().map(|i| i.handle).collect();
+    let info_handles = flat_infos(info);
+    let ninfo = info_handles.len();
     let info_ptr = if ninfo > 0 {
         info_handles.as_ptr() as *const ffi::pmix_info_t
     } else {
@@ -599,10 +613,8 @@ pub fn validate_credential(
     credential: &PmixCredential,
     info: &[Info],
 ) -> Result<ValidationResults, PmixStatus> {
-    let ninfo = info.len();
-
-    // Collect raw handles from the Info objects.
-    let info_handles: Vec<*mut ffi::pmix_info_t> = info.iter().map(|i| i.handle).collect();
+    let info_handles = flat_infos(info);
+    let ninfo = info_handles.len();
     let info_ptr = if ninfo > 0 {
         info_handles.as_ptr() as *const ffi::pmix_info_t
     } else {
@@ -804,10 +816,8 @@ pub fn validate_credential_nb(
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
-    let ninfo = info.len();
-
-    // Collect raw handles from the Info objects.
-    let info_handles: Vec<*mut ffi::pmix_info_t> = info.iter().map(|i| i.handle).collect();
+    let info_handles = flat_infos(info);
+    let ninfo = info_handles.len();
     let info_ptr = if ninfo > 0 {
         info_handles.as_ptr() as *const ffi::pmix_info_t
     } else {

--- a/src/security.rs
+++ b/src/security.rs
@@ -30,6 +30,7 @@
 //!                                           pmix_validation_cbfunc_t cbfunc, void *cbdata);
 //! ```
 
+use std::collections::HashMap;
 use std::os::raw::{c_uchar, c_void};
 use std::ptr;
 use std::sync::{LazyLock, Mutex};
@@ -359,6 +360,14 @@ impl CredentialResults {
 /// Global registry mapping request IDs to pending credential callbacks.
 static CREDENTIAL_REGISTRY: LazyLock<Registry<Box<dyn CredentialCallback>>> = LazyLock::new(Registry::new);
 
+/// Flattened info arrays retained until the asynchronous credential callback completes.
+struct RetainedCredentialInfo {
+    _info: Vec<ffi::pmix_info_t>,
+}
+unsafe impl Send for RetainedCredentialInfo {}
+static CREDENTIAL_INFO_REGISTRY: LazyLock<Mutex<HashMap<usize, RetainedCredentialInfo>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// C bridge for `pmix_credential_cbfunc_t`.
 ///
 /// Called by PMIx when the non-blocking credential request completes.
@@ -401,6 +410,10 @@ extern "C" fn credential_callback_bridge(
 
     // SAFETY: cbdata is the request ID we passed as a pointer cast.
     let req_id = crate::cbdata::decode_req_id(cbdata);
+    CREDENTIAL_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
 
     // Look up and remove the callback from the registry.
     let cb = {
@@ -507,6 +520,10 @@ pub fn get_credential_nb(
     } else {
         ptr::null()
     };
+    CREDENTIAL_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(req_id, RetainedCredentialInfo { _info: info_handles });
 
     let status = unsafe {
         // SAFETY: PMIx_Get_credential_nb is an async PMIx API call.
@@ -526,6 +543,10 @@ pub fn get_credential_nb(
         // Request rejected — remove the callback from the registry.
         let mut registry = CREDENTIAL_REGISTRY.lock();
         registry.remove(&req_id);
+        CREDENTIAL_INFO_REGISTRY
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -684,6 +705,10 @@ pub trait ValidationCallback: Send {
 /// Global registry mapping request IDs to pending validation callbacks.
 static VALIDATION_REGISTRY: LazyLock<Registry<Box<dyn ValidationCallback>>> = LazyLock::new(Registry::new);
 
+/// Flattened info arrays retained until the asynchronous validation callback completes.
+static VALIDATION_INFO_REGISTRY: LazyLock<Mutex<HashMap<usize, RetainedCredentialInfo>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Map from request ID to the C-allocated credential pointer for async validation.
 /// We store as usize to avoid Send/Sync issues with raw pointers in a shared HashMap.
 type ValidationCredMap = std::collections::HashMap<usize, usize>;
@@ -719,6 +744,10 @@ extern "C" fn validation_callback_bridge(
 
     // SAFETY: cbdata is the request ID we passed as a pointer cast.
     let req_id = crate::cbdata::decode_req_id(cbdata);
+    VALIDATION_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
 
     // Look up and remove the callback from the registry.
     let cb = {
@@ -813,9 +842,6 @@ pub fn validate_credential_nb(
     }
     VALIDATION_REGISTRY.lock().insert(req_id, callback);
 
-    // Encode the request ID as a non-null pointer for cbdata.
-    let cbdata = crate::cbdata::encode_req_id(req_id);
-
     let info_handles = flat_infos(info);
     let ninfo = info_handles.len();
     let info_ptr = if ninfo > 0 {
@@ -823,6 +849,13 @@ pub fn validate_credential_nb(
     } else {
         ptr::null()
     };
+    VALIDATION_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(req_id, RetainedCredentialInfo { _info: info_handles });
+
+    // Encode the request ID as a non-null pointer for cbdata.
+    let cbdata = crate::cbdata::encode_req_id(req_id);
 
     let status = unsafe {
         // SAFETY: PMIx_Validate_credential_nb is an async PMIx API call.
@@ -842,6 +875,10 @@ pub fn validate_credential_nb(
         // Request rejected — remove the callback and free the C credential.
         let mut registry = VALIDATION_REGISTRY.lock();
         registry.remove(&req_id);
+        VALIDATION_INFO_REGISTRY
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         let mut cred_map = VALIDATION_CRED_MAP.lock().expect("mutex poisoned (security.rs)");
         if let Some(cred_ptr) = cred_map.remove(&req_id) {
             unsafe {


### PR DESCRIPTION
Closes #433

## Summary
Flatten nested Info handles into contiguous by-value pmix_info_t arrays before passing them to PMIx, fixing the array-of-pointers/array-of-structs confusion and using total flattened entry counts.

## Affected functions
- fabric_register, fabric_register_nb, compute_distances, compute_distances_nb
- log_data and log_data_nb
- get_credential, get_credential_nb, validate_credential, validate_credential_nb

## Module placement rationale
Each affected wrapper now owns a module-local flat_infos conversion helper, matching established groups and allocation patterns. Callback-owned fabric state retains the flattened array through completion; synchronous paths use local storage.

## Test plan
- PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build
- PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib (mock FFI; 1848 passed, 29 ignored)
- PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo clippy --lib -- -D warnings (blocked by pre-existing generated-bindings safety-doc lints)
- cargo fmt --check (pre-existing repository formatting differences)
- Daemon-dependent tests remain for CI; no daemon was required locally.
