### PR TITLE
fix(data_ops): zero pdata value source in nb lookup bridge to prevent double-free

### DIFF
--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -773,6 +773,8 @@ extern "C" fn lookup_callback_bridge(
                 let pmix_undef: ffi::pmix_data_type_t = ffi::PMIX_UNDEF as u16;
                 let value = if pdata_ref.value.type_ != pmix_undef {
                     let val = ptr::read(&pdata_ref.value);
+                    // SAFETY: `val` owns the payload copied from the PMIx result;
+                    // clear the source before PMIx frees the pdata array.
                     std::ptr::write_bytes(&mut pdata_ref.value, 0, 1);
                     pdata_ref.value.type_ = pmix_undef;
                     Some(PmixOwnedValue { inner: val, 

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -756,7 +756,7 @@ extern "C" fn lookup_callback_bridge(
         unsafe {
             for i in 0..ndata {
                 let pdata = data.add(i);
-                let pdata_ref = &*pdata;
+                let pdata_ref = &mut *pdata;
 
                 let nspace_str = std::ffi::CStr::from_ptr(pdata_ref.proc_.nspace.as_ptr())
                     .to_string_lossy()
@@ -773,6 +773,8 @@ extern "C" fn lookup_callback_bridge(
                 let pmix_undef: ffi::pmix_data_type_t = ffi::PMIX_UNDEF as u16;
                 let value = if pdata_ref.value.type_ != pmix_undef {
                     let val = ptr::read(&pdata_ref.value);
+                    std::ptr::write_bytes(&mut pdata_ref.value, 0, 1);
+                    pdata_ref.value.type_ = pmix_undef;
                     Some(PmixOwnedValue { inner: val, 
             _not_thread_safe: std::marker::PhantomData,
         })

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2151,6 +2151,44 @@ use super::*;
 
     // ─── Mock-aware lookup_nb callback tests ────────────────────────────────
 
+    /// Verify lookup callback ownership survives PMIx freeing the pdata array.
+    #[test]
+    fn test_lookup_callback_bridge_transfers_value_before_pdata_free() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static RECEIVED: AtomicBool = AtomicBool::new(false);
+
+        struct Callback;
+        impl LookupCallback for Callback {
+            fn on_result(self: Box<Self>, _status: PmixStatus, mut data: Vec<PmixPdata>) {
+                RECEIVED.store(
+                    data.pop().and_then(|pdata| pdata.value).is_some(),
+                    Ordering::SeqCst,
+                );
+            }
+        }
+
+        RECEIVED.store(false, Ordering::SeqCst);
+        let req_id = LOOKUP_REGISTRY.next_req_id();
+        LOOKUP_REGISTRY.lock().insert(req_id, Box::new(Callback));
+
+        let data = unsafe {
+            let data = libc::calloc(1, std::mem::size_of::<ffi::pmix_pdata_t>())
+                as *mut ffi::pmix_pdata_t;
+            assert!(!data.is_null());
+            (*data).value.type_ = PMIX_STRING_U16;
+            (*data).value.data.string = std::ffi::CString::new("value").unwrap().into_raw();
+            data
+        };
+
+        lookup_callback_bridge(
+            PMIX_SUCCESS,
+            data,
+            1,
+            crate::cbdata::encode_req_id(req_id),
+        );
+        assert!(RECEIVED.load(Ordering::SeqCst));
+    }
+
     /// Test lookup_nb callback bridge with success status.
     #[test]
     fn test_lookup_callback_bridge_success() {

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2175,7 +2175,7 @@ use super::*;
             let data = libc::calloc(1, std::mem::size_of::<ffi::pmix_pdata_t>())
                 as *mut ffi::pmix_pdata_t;
             assert!(!data.is_null());
-            (*data).value.type_ = PMIX_STRING as _;
+            (*data).value.type_ = crate::ffi::PMIX_STRING as _;
             let string = std::ffi::CString::new("value").unwrap();
             (*data).value.data.string = libc::strdup(string.as_ptr());
             assert!(!(*data).value.data.string.is_null());

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -2175,8 +2175,10 @@ use super::*;
             let data = libc::calloc(1, std::mem::size_of::<ffi::pmix_pdata_t>())
                 as *mut ffi::pmix_pdata_t;
             assert!(!data.is_null());
-            (*data).value.type_ = PMIX_STRING_U16;
-            (*data).value.data.string = std::ffi::CString::new("value").unwrap().into_raw();
+            (*data).value.type_ = PMIX_STRING as _;
+            let string = std::ffi::CString::new("value").unwrap();
+            (*data).value.data.string = libc::strdup(string.as_ptr());
+            assert!(!(*data).value.data.string.is_null());
             data
         };
 


### PR DESCRIPTION
Closes #434

## Summary
- Zero and mark each transferred non-blocking lookup pdata value as PMIX_UNDEF before PMIx cleanup.
- Add a mock-based regression test covering value transfer through the lookup callback bridge.

## Affected function
`lookup_callback_bridge` in `src/data_ops/mod.rs`.

## Rationale
The bridge moves value payload ownership into `PmixOwnedValue`; marking the source `PMIX_UNDEF` prevents `PMIx_Pdata_free` from destructing the same payload a second time.

## Test plan
- Local mock-based callback regression test (no PMIx daemon required).
- `cargo build` with `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0`.
- `cargo test --lib` passes.
- Full `cargo test` and `cargo clippy --all-targets -- -D warnings` remain blocked by pre-existing repository test/lint failures; daemon tests require CI infrastructure.
- `cargo fmt --check` remains blocked by pre-existing formatting diffs outside this change.