### PR TITLE
fix(server): zero pdata value source before destruct in server_lookup to prevent double-free

### DIFF
--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -205,7 +205,9 @@ pub fn server_lookup(
         if pdata.value.type_ != pmix_undef {
             // Take ownership of the value.
             let val = unsafe { ptr::read(&pdata.value) };
-            // Destruct the pdata.
+            // Transfer ownership before PMIx destructs the pdata.
+            unsafe { std::ptr::write_bytes(&mut pdata.value, 0, 1) };
+            pdata.value.type_ = pmix_undef;
             unsafe { ffi::PMIx_Pdata_destruct(&mut pdata) };
             Ok(PmixOwnedValue { inner: val, 
             _not_thread_safe: std::marker::PhantomData,
@@ -217,7 +219,6 @@ pub fn server_lookup(
     } else {
         // Clean up.
         unsafe {
-            crate::free_value(&mut pdata.value);
             ffi::PMIx_Pdata_destruct(&mut pdata);
         }
         Err(pmix_status)


### PR DESCRIPTION
Closes #435

## Summary
Fixes server_lookup ownership transfer so PMIx does not destruct the payload after it has been moved into PmixOwnedValue. The error path now relies exclusively on PMIx cleanup.

## Affected function
`src/server/data.rs::server_lookup`

## Rationale
Zeroing the source pmix_value_t and setting its type to PMIX_UNDEF before PMIx_Pdata_destruct prevents a use-after-free/double-free. Builder-specific free_value is not valid for PMIx-originated allocations.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` — passed
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib` — 1848 passed, 1 pre-existing failure in data_ops registry cleanup
- Targeted mock lookup tests — passed
- Daemon-based tests are not run locally; CI coverage is required.