### PR TITLE
fix(allocation,query_log,server): correct cbdata/release_cbdata order in info callback bridges

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -710,9 +710,9 @@ extern "C" fn job_control_callback_bridge(
     status: ffi::pmix_status_t,
     info: *mut ffi::pmix_info_t,
     ninfo: usize,
-    _release_cbdata: *mut std::ffi::c_void,
-    release_fn: ffi::pmix_release_cbfunc_t,
     cbdata: *mut std::ffi::c_void,
+    release_fn: ffi::pmix_release_cbfunc_t,
+    _release_cbdata: *mut std::ffi::c_void,
 ) {
     if cbdata.is_null() {
         return;

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -318,9 +318,9 @@ extern "C" fn allocation_callback_bridge(
     status: ffi::pmix_status_t,
     info: *mut ffi::pmix_info_t,
     ninfo: usize,
-    _release_cbdata: *mut std::ffi::c_void,
-    release_fn: ffi::pmix_release_cbfunc_t,
     cbdata: *mut std::ffi::c_void,
+    release_fn: ffi::pmix_release_cbfunc_t,
+    _release_cbdata: *mut std::ffi::c_void,
 ) {
     if cbdata.is_null() {
         return;
@@ -922,9 +922,9 @@ extern "C" fn session_control_callback_bridge(
     status: ffi::pmix_status_t,
     info: *mut ffi::pmix_info_t,
     ninfo: usize,
-    _release_cbdata: *mut c_void,
-    release_fn: ffi::pmix_release_cbfunc_t,
     cbdata: *mut c_void,
+    release_fn: ffi::pmix_release_cbfunc_t,
+    _release_cbdata: *mut c_void,
 ) {
     if cbdata.is_null() {
         return;

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -448,9 +448,9 @@ extern "C" fn query_callback_bridge(
     status: ffi::pmix_status_t,
     info: *mut ffi::pmix_info_t,
     ninfo: usize,
-    _release_cbdata: *mut c_void,
-    release_fn: ffi::pmix_release_cbfunc_t,
     cbdata: *mut c_void,
+    release_fn: ffi::pmix_release_cbfunc_t,
+    _release_cbdata: *mut c_void,
 ) {
     if cbdata.is_null() {
         return;
@@ -1046,6 +1046,29 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────
     // query_callback_bridge tests (pmix_status_t is c_int, not an enum)
     // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_query_callback_bridge_uses_cbdata_parameter_four() {
+        let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        struct TestCallback {
+            called: Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl QueryCallback for TestCallback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus, _results: QueryResults) {
+                self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let req_id = QUERY_REGISTRY.insert_next(Box::new(TestCallback {
+            called: Arc::clone(&called),
+        }));
+        let cbdata = crate::cbdata::encode_req_id(req_id);
+        let release_cbdata = std::ptr::dangling_mut::<std::ffi::c_void>();
+
+        query_callback_bridge(0, std::ptr::null_mut(), 0, cbdata, None, release_cbdata);
+
+        assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
 
     #[test]
     fn test_query_callback_bridge_null_cbdata() {
@@ -1774,9 +1797,9 @@ mod tests {
                 0, // PMIX_SUCCESS
                 std::ptr::null_mut(),
                 0,
-                std::ptr::null_mut(),
-                None,
                 cbdata,
+                None,
+                std::ptr::null_mut(),
             );
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2351,9 +2351,9 @@ pub(crate) extern "C" fn collect_inventory_callback_bridge(
     status: ffi::pmix_status_t,
     info: *mut ffi::pmix_info_t,
     ninfo: usize,
-    _release_cbdata: *mut c_void,
-    release_fn: ffi::pmix_release_cbfunc_t,
     cbdata: *mut c_void,
+    release_fn: ffi::pmix_release_cbfunc_t,
+    _release_cbdata: *mut c_void,
 ) {
     if cbdata.is_null() {
         return;


### PR DESCRIPTION
Closes #436

## Summary
Correct the pmix_info_cbfunc_t parameter order in the allocation, query-log, and collect-inventory callback bridges.

## Affected bridges
- allocation_callback_bridge
- query_callback_bridge
- collect_inventory_callback_bridge
- session_control_callback_bridge also matched the same pmix_info_cbfunc_t ABI ordering and is corrected.

## Rationale
OpenPMIx passes the request-id cbdata as parameter 4 and release_cbdata as parameter 6. The swapped declarations decoded the release context, so registry lookup missed and user callbacks were not invoked.

## Test plan
- Local mock-based callback regression test verifies parameter 4 cbdata invokes the registered query callback while parameter 6 is independent release context.
- Local cargo build passed.
- Targeted mock-based query callback tests passed.
- Full cargo test and all-target clippy remain subject to pre-existing repository test compile failures and generated-binding clippy failures; daemon tests require CI infrastructure.
- cargo fmt --check reports pre-existing repository formatting diffs; changed files were checked with git diff --check.
