### PR TITLE
fix(lib,data_ops): free PMIx-returned values with PMIx allocator, keep free_value for builder values

### DIFF
--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -15,7 +15,7 @@ use std::sync::{LazyLock, Mutex};
 use crate::cbdata::Registry;
 use crate::ffi;
 use crate::threading::invoke_user_callback;
-use crate::{free_value, release_pmix_value, Info, PmixError, PmixOwnedValue, PmixStatus, Proc};
+use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, free_value, release_pmix_value};
 
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
@@ -501,7 +501,10 @@ pub fn get(proc: &Proc, key: &str, info: Option<&Info>) -> Result<PmixOwnedValue
         };
         // `value` is PMIx-allocated; the payload moved into `owned`, so
         // release only the now-empty PMIx struct allocation.
+        // SAFETY: `value` points to the PMIx-allocated struct whose payload
+        // was moved above; zero it before releasing the struct allocation.
         unsafe { ptr::write_bytes(value, 0, 1) };
+        // SAFETY: `value` is the PMIx allocation returned by `PMIx_Get`.
         unsafe { release_pmix_value(value) };
         Ok(PmixOwnedValue {
             inner: owned,

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -15,7 +15,7 @@ use std::sync::{LazyLock, Mutex};
 use crate::cbdata::Registry;
 use crate::ffi;
 use crate::threading::invoke_user_callback;
-use crate::{Info, PmixError, PmixOwnedValue, PmixStatus, Proc, free_value};
+use crate::{free_value, release_pmix_value, Info, PmixError, PmixOwnedValue, PmixStatus, Proc};
 
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
@@ -264,15 +264,19 @@ extern "C" fn get_value_callback_bridge(
             );
             (copy_status == ffi::PMIX_SUCCESS as i32).then_some(PmixOwnedValue {
                 inner: copied,
+                pmix_owned: true,
                 _not_thread_safe: std::marker::PhantomData,
             })
         } else {
             // SAFETY: The ordinary callback path returns an allocated struct.
             let val = unsafe { ptr::read(kv) };
             // SAFETY: `kv` is the allocation returned by PMIx_Get_nb.
-            drop(unsafe { Box::from_raw(kv) });
+            unsafe { ptr::write_bytes(kv, 0, 1) };
+            // SAFETY: `kv` is a PMIx allocation returned to this callback.
+            unsafe { release_pmix_value(kv) };
             Some(PmixOwnedValue {
                 inner: val,
+                pmix_owned: true,
                 _not_thread_safe: std::marker::PhantomData,
             })
         }
@@ -495,7 +499,13 @@ pub fn get(proc: &Proc, key: &str, info: Option<&Info>) -> Result<PmixOwnedValue
             // which will free it on drop.
             ptr::read(value)
         };
-        Ok(PmixOwnedValue { inner: owned, 
+        // `value` is PMIx-allocated; the payload moved into `owned`, so
+        // release only the now-empty PMIx struct allocation.
+        unsafe { ptr::write_bytes(value, 0, 1) };
+        unsafe { release_pmix_value(value) };
+        Ok(PmixOwnedValue {
+            inner: owned,
+            pmix_owned: true,
             _not_thread_safe: std::marker::PhantomData,
         })
     } else {
@@ -663,6 +673,7 @@ pub fn lookup(
             pdata.value.type_ = pmix_undef;
             Some(PmixOwnedValue {
                 inner: val,
+                pmix_owned: true,
                 _not_thread_safe: std::marker::PhantomData,
             })
         } else {
@@ -777,9 +788,11 @@ extern "C" fn lookup_callback_bridge(
                     // clear the source before PMIx frees the pdata array.
                     std::ptr::write_bytes(&mut pdata_ref.value, 0, 1);
                     pdata_ref.value.type_ = pmix_undef;
-                    Some(PmixOwnedValue { inner: val, 
-            _not_thread_safe: std::marker::PhantomData,
-        })
+                    Some(PmixOwnedValue {
+                        inner: val,
+                        pmix_owned: true,
+                        _not_thread_safe: std::marker::PhantomData,
+                    })
                 } else {
                     None
                 };

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -1583,7 +1583,7 @@ use super::*;
         // This verifies the Drop implementation doesn't panic on zeroed data
         let val = PmixOwnedValue {
             inner: unsafe { std::mem::zeroed() },
-        
+            pmix_owned: false,
             _not_thread_safe: std::marker::PhantomData,
         };
         // Drop happens at end of scope — should not panic

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -1590,6 +1590,18 @@ use super::*;
         drop(val);
     }
 
+    #[test]
+    fn test_pmix_owned_value_pmix_owned_drop() {
+        let val = PmixOwnedValue {
+            // SAFETY: The zeroed value is valid for the mock destruct path,
+            // which owns no nested C allocations.
+            inner: unsafe { std::mem::zeroed() },
+            pmix_owned: true,
+            _not_thread_safe: std::marker::PhantomData,
+        };
+        drop(val);
+    }
+
     // ─── Multiple sequential publish calls ──────────────────────────────────
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2758,7 +2758,7 @@ impl PmixValueBuilder {
     pub fn build(self) -> Result<PmixOwnedValue, ValueError> {
         Ok(PmixOwnedValue {
             inner: self.build_raw()?,
-        
+            pmix_owned: false,
             _not_thread_safe: std::marker::PhantomData,
         })
     }
@@ -2959,6 +2959,31 @@ pub fn free_value(v: &mut pmix_value_t) {
     }
 }
 
+/// Destruct nested payloads allocated by PMIx.
+pub(crate) unsafe fn destruct_pmix_value(v: &mut pmix_value_t) {
+    pmix_ffi_or_mock!(
+        mock = unsafe { mock_ffi::mock_value_destruct(v) },
+        real = unsafe { ffi::PMIx_Value_destruct(v) },
+    );
+}
+
+/// Release a PMIx-allocated `pmix_value_t` struct and its nested payloads.
+pub(crate) unsafe fn release_pmix_value(value: *mut pmix_value_t) {
+    if value.is_null() {
+        return;
+    }
+    pmix_ffi_or_mock!(
+        mock = unsafe {
+            mock_ffi::mock_value_destruct(value);
+            mock_ffi::mock_value_free(value, 1);
+        },
+        real = unsafe {
+            ffi::PMIx_Value_destruct(value);
+            libc::free(value.cast());
+        },
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixOwnedValue – RAII wrapper with automatic cleanup
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2970,6 +2995,7 @@ pub fn free_value(v: &mut pmix_value_t) {
 /// ownership to a C API that calls `PMIX_VALUE_RELEASE` itself.
 pub struct PmixOwnedValue {
     inner: pmix_value_t,
+    pmix_owned: bool,
     /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
@@ -3044,7 +3070,12 @@ impl PmixOwnedValue {
 
 impl Drop for PmixOwnedValue {
     fn drop(&mut self) {
-        free_value(&mut self.inner);
+        if self.pmix_owned {
+            // SAFETY: nested payloads were allocated by PMIx.
+            unsafe { destruct_pmix_value(&mut self.inner) };
+        } else {
+            free_value(&mut self.inner);
+        }
     }
 }
 
@@ -3960,14 +3991,15 @@ pub fn get_value(proc: &Proc, key: &[u8], info: Option<Info>) -> Result<PmixOwne
 
     if status.is_success() && !value.is_null() {
         // SAFETY: PMIx returned a valid heap-allocated value on success. The
-        // copy owns nested payloads; reclaiming the Box reclaims only the
-        // C-allocated struct.
-        let owned = unsafe { *value };
-        // SAFETY: `value` is the allocation returned by PMIx_Get and is
-        // reclaimed exactly once after copying its contents.
-        drop(unsafe { Box::from_raw(value) });
+        let owned = unsafe { ptr::read(value) };
+        // The nested payloads moved into `owned`; release only the now-empty
+        // PMIx struct allocation.
+        unsafe { ptr::write_bytes(value, 0, 1) };
+        // SAFETY: `value` is the PMIx allocation returned by PMIx_Get.
+        unsafe { release_pmix_value(value) };
         Ok(PmixOwnedValue {
             inner: owned,
+            pmix_owned: true,
             _not_thread_safe: std::marker::PhantomData,
         })
     } else {

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -209,9 +209,11 @@ pub fn server_lookup(
             unsafe { std::ptr::write_bytes(&mut pdata.value, 0, 1) };
             pdata.value.type_ = pmix_undef;
             unsafe { ffi::PMIx_Pdata_destruct(&mut pdata) };
-            Ok(PmixOwnedValue { inner: val, 
-            _not_thread_safe: std::marker::PhantomData,
-        })
+            Ok(PmixOwnedValue {
+                inner: val,
+                pmix_owned: true,
+                _not_thread_safe: std::marker::PhantomData,
+            })
         } else {
             unsafe { ffi::PMIx_Pdata_destruct(&mut pdata) };
             Err(PmixStatus::Known(PmixError::ErrNotFound))


### PR DESCRIPTION
Closes #439

## Summary
- Track whether `PmixOwnedValue` payloads are Rust-builder-owned or PMIx-owned.
- Keep `free_value` exclusively for builder-produced values.
- Release PMIx-returned structs with `PMIx_Value_destruct` and `libc::free` after transferring payload ownership.

## Affected functions
- `data_ops::get`, `data_ops::get_nb`, `data_ops::lookup`, and the non-blocking lookup/get bridges.
- `get_value`, `server_lookup`, and `PmixOwnedValue::drop`.

## Ownership-regime design and rationale
`PmixOwnedValue` carries an internal ownership-regime flag. Builder values use the existing Rust allocator cleanup path. PMIx-returned values use `PMIx_Value_destruct`; PMIx-allocated result structs are zeroed after their payloads are moved and then released with the PMIx-compatible `libc::free` path. This is the smallest change that preserves the public wrapper while ensuring every allocation is released by its allocator.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build`
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib` (mock-based, no daemon): 1850 passed, 29 ignored.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo clippy --lib -- -D warnings` (blocked by pre-existing generated bindgen missing-safety-doc lints).
- `cargo fmt --check` (blocked by pre-existing repository formatting drift; changed lines were kept formatted).
- Full all-target cargo test/clippy daemon-dependent targets are not runnable locally because no PMIx daemon/prterun is available; CI should exercise those paths.
