### PR TITLE
fix(events,pset,monitoring,query_log): retain owned deep copies of proc/info across nb async boundaries

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -391,6 +391,14 @@ struct HandlerRegState {
     user_fn: Box<NotificationFn>,
     user_cbfunc: HandlerRegCbFn,
     user_cbdata: *mut c_void,
+    retained_info: Vec<ffi::pmix_info_t>,
+}
+
+struct NotifyState {
+    source: ffi::pmix_proc_t,
+    info: Vec<ffi::pmix_info_t>,
+    cbfunc: OpCbFn,
+    cbdata: *mut c_void,
 }
 
 /// C bridge for the registration-completion callback of
@@ -612,12 +620,6 @@ pub fn register_event_handler_nb(
         )
     };
 
-    let (info_ptr, ninfo) = if info.len > 0 {
-        (info.handle as *const ffi::pmix_info_t, info.len)
-    } else {
-        (ptr::null(), 0)
-    };
-
     // In non-blocking mode the reference ID is only delivered via cbfunc, so
     // the user fn is boxed into a registration state; the completion bridge
     // parks it in HANDLER_REGISTRY (freed on error) and then forwards to the
@@ -628,8 +630,22 @@ pub fn register_event_handler_nb(
         user_fn: Box::new(evhdlr),
         user_cbfunc: cbfunc,
         user_cbdata: cbdata,
+        retained_info: if info.handle.is_null() || info.len == 0 {
+            Vec::new()
+        } else {
+            // SAFETY: Info owns `len` initialized entries for this borrow.
+            unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
+        },
     });
     let state_ptr = Box::into_raw(state);
+    let (info_ptr, ninfo) = unsafe {
+        let state = &mut *state_ptr;
+        if state.retained_info.is_empty() {
+            (ptr::null_mut(), 0)
+        } else {
+            (state.retained_info.as_mut_ptr(), state.retained_info.len())
+        }
+    };
 
     // SAFETY: FFI call into PMIx library. The codes slice lives for the
     // duration of this call. On the async path the boxed HandlerRegState is
@@ -875,28 +891,62 @@ pub fn notify_event_nb(
     cbfunc: OpCbFn,
     cbdata: *mut c_void,
 ) -> Result<(), PmixStatus> {
-    let (info_ptr, ninfo) = if info.len > 0 {
-        (info.handle as *const ffi::pmix_info_t, info.len)
-    } else {
-        (ptr::null(), 0)
+    let state = Box::new(NotifyState {
+        source: source.handle,
+        info: if info.handle.is_null() || info.len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
+        },
+        cbfunc,
+        cbdata,
+    });
+    let state_ptr = Box::into_raw(state);
+    let (source_ptr, info_ptr, ninfo) = unsafe {
+        let x = &mut *state_ptr;
+        (
+            &x.source as *const _,
+            if x.info.is_empty() {
+                ptr::null_mut()
+            } else {
+                x.info.as_mut_ptr()
+            },
+            x.info.len(),
+        )
     };
-
-    // SAFETY: FFI call into PMIx library. Same safety considerations as
-    // the blocking variant.
     let raw_status = unsafe {
         ffi::PMIx_Notify_event(
             status.to_raw(),
-            &source.handle as *const ffi::pmix_proc_t,
+            source_ptr,
             range as ffi::pmix_data_range_t,
             info_ptr,
             ninfo,
-            cbfunc,
-            cbdata,
+            Some(notify_state_bridge),
+            state_ptr as *mut c_void,
         )
     };
 
     let st = PmixStatus::from_raw(raw_status);
-    if st.is_success() { Ok(()) } else { Err(st) }
+    if st.is_success() {
+        Ok(())
+    } else {
+        unsafe {
+            drop(Box::from_raw(state_ptr));
+        }
+        Err(st)
+    }
+}
+
+extern "C" fn notify_state_bridge(status: i32, cbdata: *mut c_void) {
+    if cbdata.is_null() {
+        return;
+    }
+    let x = unsafe { Box::from_raw(cbdata as *mut NotifyState) };
+    if let Some(cb) = x.cbfunc {
+        unsafe {
+            cb(status, x.cbdata);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1495,6 +1545,7 @@ mod tests {
             user_fn: Box::new(Some(test_handler)),
             user_cbfunc: Some(reg_cb),
             user_cbdata: std::ptr::null_mut(),
+            retained_info: Vec::new(),
         });
 
         handler_reg_cb_bridge(
@@ -1537,6 +1588,7 @@ mod tests {
             user_fn: Box::new(Some(test_handler)),
             user_cbfunc: Some(reg_cb),
             user_cbdata: std::ptr::null_mut(),
+            retained_info: Vec::new(),
         });
 
         handler_reg_cb_bridge(

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -373,11 +373,14 @@ pub fn process_monitor_nb(
 
     let status = unsafe {
         // SAFETY: PMIx_Process_monitor_nb is an async PMIx API call.
-        // - monitor.handle points to a valid pmix_info_t (owned by the Info borrow).
-        // - dirs_ptr is either null or points to valid pmix_info_t entries.
+        // - PMIx retains and threadshift-aliases monitor_ptr and dirs_ptr
+        //   (infocopy=false); both point to valid pmix_info_t entries or null.
+        // - MONITOR_INFO_REGISTRY retains owned shallow copies keyed by req_id,
+        //   reclaimed by the monitor completion bridge. The caller must keep its
+        //   Info value data alive until the callback fires; nested value pointers
+        //   are not owned by the retained arrays.
         // - cbfunc is a valid extern "C" function pointer (our bridge).
         // - cbdata encodes the request ID; PMIx passes it back unchanged.
-        // - PMIx does not retain monitor.handle or dirs_ptr after this call returns.
         ffi::PMIx_Process_monitor_nb(
             monitor_ptr,
             error.to_raw(),

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -42,15 +42,14 @@
 //! #define PMIx_Heartbeat()  // sends a heartbeat via PMIx_Process_monitor_nb
 //! ```
 
-
 use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
 use std::sync::LazyLock;
 
+use crate::cbdata::{Registry, decode_req_id, encode_req_id};
 use crate::ffi;
 use crate::threading::invoke_user_callback;
-use crate::cbdata::{decode_req_id, encode_req_id, Registry};
 use crate::{Info, PmixError, PmixStatus};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -88,7 +87,7 @@ impl MonitorResults {
         Self {
             handle: std::ptr::null_mut(),
             len,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         }
     }
@@ -128,7 +127,16 @@ pub trait MonitorCallback: Send {
     fn on_complete(&mut self, status: PmixStatus, results: Option<MonitorResults>);
 }
 
-static MONITOR_REGISTRY: LazyLock<Registry<Box<dyn MonitorCallback>>> = LazyLock::new(Registry::new);
+static MONITOR_REGISTRY: LazyLock<Registry<Box<dyn MonitorCallback>>> =
+    LazyLock::new(Registry::new);
+struct RetainedMonitorInfo {
+    monitor: Vec<ffi::pmix_info_t>,
+    directives: Vec<ffi::pmix_info_t>,
+}
+unsafe impl Send for RetainedMonitorInfo {}
+static MONITOR_INFO_REGISTRY: LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, RetainedMonitorInfo>>,
+> = LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// C bridge for `pmix_info_cbfunc_t` (monitor completion).
 ///
@@ -145,6 +153,10 @@ unsafe extern "C" fn monitor_callback_bridge(
 ) {
     // Decode the request ID from the cbdata pointer.
     let req_id = decode_req_id(cbdata);
+    MONITOR_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
 
     // Remove the callback from the registry — it is consumed exactly once.
     let mut registry = MONITOR_REGISTRY.lock();
@@ -158,14 +170,14 @@ unsafe extern "C" fn monitor_callback_bridge(
                 Some(MonitorResults {
                     handle: info,
                     len: ninfo,
-                
-            _not_thread_safe: std::marker::PhantomData,
-        })
+
+                    _not_thread_safe: std::marker::PhantomData,
+                })
             } else {
                 None
             };
             let _ = invoke_user_callback("monitoring", move || {
-                    cb.on_complete(PmixStatus::from_raw(status), results);
+                cb.on_complete(PmixStatus::from_raw(status), results);
             });
         }
         None => {
@@ -271,7 +283,7 @@ pub fn process_monitor(
         Ok(MonitorResults {
             handle: results,
             len: nresults,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         })
     } else {
@@ -317,13 +329,45 @@ pub fn process_monitor_nb(
     // Encode the request ID as a non-null pointer for cbdata.
     let cbdata = encode_req_id(req_id);
 
-    // Build directive pointer array.
-    let (dirs_ptr, ndirs) = if directives.is_empty() {
-        (ptr::null(), 0)
+    let retained: Vec<ffi::pmix_info_t> = if monitor.handle.is_null() || monitor.len == 0 {
+        Vec::new()
     } else {
+        unsafe { std::slice::from_raw_parts(monitor.handle, monitor.len).to_vec() }
+    };
+    let dirs: Vec<ffi::pmix_info_t> = directives
+        .iter()
+        .filter(|i| !i.handle.is_null())
+        .flat_map(|i| unsafe { std::slice::from_raw_parts(i.handle, i.len).to_vec() })
+        .collect();
+    MONITOR_INFO_REGISTRY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(
+            req_id,
+            RetainedMonitorInfo {
+                monitor: retained,
+                directives: dirs,
+            },
+        );
+    let (monitor_ptr, dirs_ptr, ndirs) = {
+        let retained = MONITOR_INFO_REGISTRY
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let retained = retained
+            .get(&req_id)
+            .expect("retained monitor info inserted");
         (
-            directives[0].handle as *const ffi::pmix_info_t,
-            directives[0].len,
+            if retained.monitor.is_empty() {
+                ptr::null()
+            } else {
+                retained.monitor.as_ptr()
+            },
+            if retained.directives.is_empty() {
+                ptr::null()
+            } else {
+                retained.directives.as_ptr()
+            },
+            retained.directives.len(),
         )
     };
 
@@ -335,7 +379,7 @@ pub fn process_monitor_nb(
         // - cbdata encodes the request ID; PMIx passes it back unchanged.
         // - PMIx does not retain monitor.handle or dirs_ptr after this call returns.
         ffi::PMIx_Process_monitor_nb(
-            monitor.handle,
+            monitor_ptr,
             error.to_raw(),
             dirs_ptr,
             ndirs,
@@ -351,6 +395,10 @@ pub fn process_monitor_nb(
         // Request rejected — remove the callback from the registry.
         let mut registry = MONITOR_REGISTRY.lock();
         registry.remove(&req_id);
+        MONITOR_INFO_REGISTRY
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -991,9 +1039,12 @@ mod tests {
     }
 }
 
-
-pub fn heartbeat_raw() { crate::pmix_ffi_or_mock!(mock=unsafe{crate::mock_ffi::mock_heartbeat()},real=unsafe{ffi::PMIx_Heartbeat()}); }
-
+pub fn heartbeat_raw() {
+    crate::pmix_ffi_or_mock!(
+        mock = unsafe { crate::mock_ffi::mock_heartbeat() },
+        real = unsafe { ffi::PMIx_Heartbeat() }
+    );
+}
 
 #[cfg(test)]
 #[test]

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -775,9 +775,9 @@ pub fn log_data_nb(
         //   Info borrows (or is null if empty).
         // - cbfunc is a valid extern "C" function pointer.
         // - cbdata encodes the request ID; PMIx passes it back unchanged.
-        // - PMIx does not retain data_ptr or dirs_ptr after this call returns.
-        // - The caller must keep data and directives alive until the
-        //   callback is invoked.
+        // - PMIx may retain or alias data_ptr and dirs_ptr on the host upcall
+        //   path. LOG_INFO_REGISTRY retains owned arrays until the bridge
+        //   runs, while the caller must keep nested value data alive.
         #[cfg(any(test, feature = "mock_ffi"))]
         if mock_ffi::is_mock_enabled() {
             mock_ffi::mock_log_nb(

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -186,7 +186,7 @@ impl PmixQuery {
             handle: query_ptr,
             _keys: c_keys,
             keys_array,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         })
     }
@@ -396,7 +396,7 @@ pub fn query_info(queries: &[PmixQuery]) -> Result<QueryResults, PmixStatus> {
         Ok(QueryResults {
             handle: results,
             len: nresults,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         })
     } else {
@@ -490,11 +490,11 @@ extern "C" fn query_callback_bridge(
     let results = QueryResults {
         handle: info,
         len: ninfo,
-    
-            _not_thread_safe: std::marker::PhantomData,
-        };
+
+        _not_thread_safe: std::marker::PhantomData,
+    };
     let _ = invoke_user_callback("query_log", move || {
-            cb.on_complete(pmix_status, results);
+        cb.on_complete(pmix_status, results);
     });
     // release_fn is unused — we manage our own memory via QueryResults Drop.
     let _ = release_fn;
@@ -710,7 +710,7 @@ extern "C" fn log_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_voi
 
     let pmix_status = PmixStatus::from_raw(status);
     let _ = invoke_user_callback("query_log", move || {
-            cb.on_complete(pmix_status);
+        cb.on_complete(pmix_status);
     });
 }
 
@@ -759,10 +759,13 @@ pub fn log_data_nb(
     LOG_INFO_REGISTRY
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .insert(req_id, RetainedLogInfos {
-            _data: data_handles,
-            _directives: dirs_handles,
-        });
+        .insert(
+            req_id,
+            RetainedLogInfos {
+                _data: data_handles,
+                _directives: dirs_handles,
+            },
+        );
 
     let status = unsafe {
         // SAFETY: PMIx_Log_nb is an async PMIx API call.
@@ -971,7 +974,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(results.is_empty());
@@ -983,7 +986,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 3,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(!results.is_empty());
@@ -995,7 +998,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 5,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         let debug_str = format!("{:?}", results);
@@ -1008,7 +1011,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         drop(results);
@@ -1019,7 +1022,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 5,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         drop(results);
@@ -1152,10 +1155,7 @@ mod tests {
         // invoke the bridge callback). Clean it up ourselves.
         if result.is_ok() {
             let mut registry = QUERY_REGISTRY.lock();
-            let req_id = registry
-                .keys()
-                .find(|id| !ids_before.contains(id))
-                .copied();
+            let req_id = registry.keys().find(|id| !ids_before.contains(id)).copied();
             if let Some(req_id) = req_id {
                 registry.remove(&req_id);
             }
@@ -1429,7 +1429,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: 0,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         cb.on_complete(PmixStatus::Known(PmixError::Success), results);
@@ -1583,7 +1583,7 @@ mod tests {
         let results = QueryResults {
             handle: std::ptr::null_mut(),
             len: usize::MAX,
-        
+
             _not_thread_safe: std::marker::PhantomData,
         };
         assert!(!results.is_empty());
@@ -1604,7 +1604,8 @@ mod tests {
 
     #[test]
     fn test_info_with_string_key_for_log() {
-        let info = crate::info_with_string_key("PMIX_LOG_STDOUT", "test message").expect("string info");
+        let info =
+            crate::info_with_string_key("PMIX_LOG_STDOUT", "test message").expect("string info");
         assert!(!info.is_empty());
         assert_eq!(info.len(), 1);
     }
@@ -1641,7 +1642,7 @@ mod tests {
     fn test_query_info_error_path_with_mock() {
         let _guard = mock_ffi::MockGuard::with_config(
             mock_ffi::MockConfig::new()
-                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_INIT)
+                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_INIT),
         );
         let query = PmixQuery::new(&["pmix.version"]).unwrap();
         let result = query_info(&[query]);
@@ -1676,7 +1677,7 @@ mod tests {
     fn test_query_info_nb_error_cleanup_with_mock() {
         let _guard = mock_ffi::MockGuard::with_config(
             mock_ffi::MockConfig::new()
-                .with_function_status("PMIx_Query_info_nb", mock_ffi::PMIX_ERR_INIT)
+                .with_function_status("PMIx_Query_info_nb", mock_ffi::PMIX_ERR_INIT),
         );
         let query = PmixQuery::new(&["pmix.version"]).unwrap();
 
@@ -1701,7 +1702,8 @@ mod tests {
     #[test]
     fn test_log_data_success_with_mock() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
+        let data =
+            vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
         let result = log_data(&data, &directives);
         assert!(result.is_ok());
@@ -1711,19 +1713,24 @@ mod tests {
     fn test_log_data_error_with_mock() {
         let _guard = mock_ffi::MockGuard::with_config(
             mock_ffi::MockConfig::new()
-                .with_function_status("PMIx_Log", mock_ffi::PMIX_ERR_NOT_SUPPORTED)
+                .with_function_status("PMIx_Log", mock_ffi::PMIX_ERR_NOT_SUPPORTED),
         );
-        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
+        let data =
+            vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
         let result = log_data(&data, &directives);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), PmixStatus::Known(PmixError::ErrNotSupported));
+        assert_eq!(
+            result.unwrap_err(),
+            PmixStatus::Known(PmixError::ErrNotSupported)
+        );
     }
 
     #[test]
     fn test_log_data_nb_success_with_mock() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
+        let data =
+            vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
 
         struct TestLogCallback {
@@ -1747,9 +1754,10 @@ mod tests {
     fn test_log_data_nb_error_cleanup_with_mock() {
         let _guard = mock_ffi::MockGuard::with_config(
             mock_ffi::MockConfig::new()
-                .with_function_status("PMIx_Log_nb", mock_ffi::PMIX_ERR_INIT)
+                .with_function_status("PMIx_Log_nb", mock_ffi::PMIX_ERR_INIT),
         );
-        let data = vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
+        let data =
+            vec![crate::info_with_string_key("test.key", "test.value").expect("string info")];
         let directives: Vec<Info> = vec![];
 
         struct TestLogCallback {
@@ -1788,7 +1796,9 @@ mod tests {
             }
         }
 
-        let req_id = QUERY_REGISTRY.insert_next(Box::new(BridgeTestCallback { called: called_clone }));
+        let req_id = QUERY_REGISTRY.insert_next(Box::new(BridgeTestCallback {
+            called: called_clone,
+        }));
 
         // Simulate the callback being invoked
         let cbdata = crate::cbdata::encode_req_id(req_id);
@@ -1823,7 +1833,9 @@ mod tests {
             }
         }
 
-        let req_id = LOG_REGISTRY.insert_next(Box::new(BridgeLogTestCallback { called: called_clone }));
+        let req_id = LOG_REGISTRY.insert_next(Box::new(BridgeLogTestCallback {
+            called: called_clone,
+        }));
 
         let cbdata = crate::cbdata::encode_req_id(req_id);
         unsafe {
@@ -1837,7 +1849,7 @@ mod tests {
     fn test_query_info_partial_success_with_mock() {
         let _guard = mock_ffi::MockGuard::with_config(
             mock_ffi::MockConfig::new()
-                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_PARTIAL_SUCCESS)
+                .with_function_status("PMIx_Query_info", mock_ffi::PMIX_ERR_PARTIAL_SUCCESS),
         );
         let query = PmixQuery::new(&["pmix.version"]).unwrap();
         let result = query_info(&[query]);
@@ -1848,8 +1860,10 @@ mod tests {
     #[test]
     fn test_log_data_with_both_data_and_directives() {
         let _guard = mock_ffi::MockGuard::new();
-        let data = vec![crate::info_with_string_key("log.message", "Hello, world!").expect("string info")];
-        let directives = vec![crate::info_with_string_key("pmix.log.stdout", "true").expect("string info")];
+        let data =
+            vec![crate::info_with_string_key("log.message", "Hello, world!").expect("string info")];
+        let directives =
+            vec![crate::info_with_string_key("pmix.log.stdout", "true").expect("string info")];
         let result = log_data(&data, &directives);
         assert!(result.is_ok());
     }
@@ -1878,8 +1892,7 @@ impl PmixQueryConstructed {
         // SAFETY: allocation is converted to the matching `pmix_query_t` pointer
         // and is freed by `destruct`/`release` while owned by this wrapper.
         let handle = unsafe {
-            libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>())
-                as *mut ffi::pmix_query_t
+            libc::calloc(1, std::mem::size_of::<ffi::pmix_query_t>()) as *mut ffi::pmix_query_t
         };
         if !handle.is_null() {
             // SAFETY: `handle` is freshly calloc'd storage with the exact

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -2,9 +2,11 @@
 
 use super::*;
 use crate::cbdata::Registry;
-use crate::threading::invoke_user_callback;
 #[cfg(any(test, feature = "mock_ffi"))]
 use crate::mock_ffi;
+use crate::threading::invoke_user_callback;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_server_define_process_set
@@ -64,43 +66,43 @@ pub fn server_define_process_set(members: &[Proc], pset_name: &str) -> Result<()
             }
         }
         // Call FFI while arr is still valid (or mock).
-                let status;
+        let status;
         #[cfg(any(test, feature = "mock_ffi"))]
         {
             status = if mock_ffi::is_mock_enabled() {
                 unsafe {
-                mock_ffi::mock_server_define_process_set(
-                    arr as *const std::ffi::c_void,
-                    nmembers,
-                    pset_name_c.as_ptr(),
-                )
-            }
+                    mock_ffi::mock_server_define_process_set(
+                        arr as *const std::ffi::c_void,
+                        nmembers,
+                        pset_name_c.as_ptr(),
+                    )
+                }
             } else {
                 unsafe {
-                // SAFETY:
-                // - arr is a valid pointer to a contiguous array of pmix_proc_t
-                //   values, alive for the duration of this call (PMIx copies the
-                //   proc identifiers internally).
-                // - pset_name_c.as_ptr() is a valid null-terminated string for the
-                //   duration of this call (PMIx copies it internally).
-                // - PMIx_server_define_process_set is a synchronous server API.
-                ffi::PMIx_server_define_process_set(arr, nmembers, pset_name_c.as_ptr())
-            }
+                    // SAFETY:
+                    // - arr is a valid pointer to a contiguous array of pmix_proc_t
+                    //   values, alive for the duration of this call (PMIx copies the
+                    //   proc identifiers internally).
+                    // - pset_name_c.as_ptr() is a valid null-terminated string for the
+                    //   duration of this call (PMIx copies it internally).
+                    // - PMIx_server_define_process_set is a synchronous server API.
+                    ffi::PMIx_server_define_process_set(arr, nmembers, pset_name_c.as_ptr())
+                }
             };
         }
         #[cfg(not(any(test, feature = "mock_ffi")))]
         {
             status = {
                 unsafe {
-                // SAFETY:
-                // - arr is a valid pointer to a contiguous array of pmix_proc_t
-                //   values, alive for the duration of this call (PMIx copies the
-                //   proc identifiers internally).
-                // - pset_name_c.as_ptr() is a valid null-terminated string for the
-                //   duration of this call (PMIx copies it internally).
-                // - PMIx_server_define_process_set is a synchronous server API.
-                ffi::PMIx_server_define_process_set(arr, nmembers, pset_name_c.as_ptr())
-            }
+                    // SAFETY:
+                    // - arr is a valid pointer to a contiguous array of pmix_proc_t
+                    //   values, alive for the duration of this call (PMIx copies the
+                    //   proc identifiers internally).
+                    // - pset_name_c.as_ptr() is a valid null-terminated string for the
+                    //   duration of this call (PMIx copies it internally).
+                    // - PMIx_server_define_process_set is a synchronous server API.
+                    ffi::PMIx_server_define_process_set(arr, nmembers, pset_name_c.as_ptr())
+                }
             };
         }
         // Free the temporary C array.
@@ -116,37 +118,37 @@ pub fn server_define_process_set(members: &[Proc], pset_name: &str) -> Result<()
     };
 
     // Empty members case — call with null pointer (or mock).
-        let status;
+    let status;
     #[cfg(any(test, feature = "mock_ffi"))]
     {
         status = if mock_ffi::is_mock_enabled() {
             unsafe {
-            mock_ffi::mock_server_define_process_set(
-                ptr::null(),
-                nmembers,
-                pset_name_c.as_ptr(),
-            )
-        }
+                mock_ffi::mock_server_define_process_set(
+                    ptr::null(),
+                    nmembers,
+                    pset_name_c.as_ptr(),
+                )
+            }
         } else {
             unsafe {
-            // SAFETY:
-            // - members_ptr is null (empty slice) — PMIx handles this gracefully.
-            // - pset_name_c.as_ptr() is a valid null-terminated string.
-            // - PMIx_server_define_process_set is a synchronous server API.
-            ffi::PMIx_server_define_process_set(members_ptr, nmembers, pset_name_c.as_ptr())
-        }
+                // SAFETY:
+                // - members_ptr is null (empty slice) — PMIx handles this gracefully.
+                // - pset_name_c.as_ptr() is a valid null-terminated string.
+                // - PMIx_server_define_process_set is a synchronous server API.
+                ffi::PMIx_server_define_process_set(members_ptr, nmembers, pset_name_c.as_ptr())
+            }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
             unsafe {
-            // SAFETY:
-            // - members_ptr is null (empty slice) — PMIx handles this gracefully.
-            // - pset_name_c.as_ptr() is a valid null-terminated string.
-            // - PMIx_server_define_process_set is a synchronous server API.
-            ffi::PMIx_server_define_process_set(members_ptr, nmembers, pset_name_c.as_ptr())
-        }
+                // SAFETY:
+                // - members_ptr is null (empty slice) — PMIx handles this gracefully.
+                // - pset_name_c.as_ptr() is a valid null-terminated string.
+                // - PMIx_server_define_process_set is a synchronous server API.
+                ffi::PMIx_server_define_process_set(members_ptr, nmembers, pset_name_c.as_ptr())
+            }
         };
     }
 
@@ -196,37 +198,43 @@ pub fn server_delete_process_set(pset_name: &str) -> Result<(), PmixStatus> {
     // The C API takes `char *` (non-const) even though it doesn't modify the
     // string. We use `as_ptr() as *mut` to match the FFI signature; this is
     // safe because PMIx only reads the string and copies it internally.
-        let status;
+    let status;
     #[cfg(any(test, feature = "mock_ffi"))]
     {
         status = if mock_ffi::is_mock_enabled() {
             unsafe {
-            mock_ffi::mock_server_delete_process_set(pset_name_c.as_ptr() as *mut std::os::raw::c_char)
-        }
+                mock_ffi::mock_server_delete_process_set(
+                    pset_name_c.as_ptr() as *mut std::os::raw::c_char
+                )
+            }
         } else {
             unsafe {
-            // SAFETY:
-            // - pset_name_c is a valid null-terminated string for the duration of
-            //   this call (PMIx copies it internally, does not retain the pointer).
-            // - The cast from *const to *mut is safe because PMIx does not write
-            //   to the string — the non-const signature is a C API convention.
-            // - PMIx_server_delete_process_set is a synchronous server API.
-            ffi::PMIx_server_delete_process_set(pset_name_c.as_ptr() as *mut std::os::raw::c_char)
-        }
+                // SAFETY:
+                // - pset_name_c is a valid null-terminated string for the duration of
+                //   this call (PMIx copies it internally, does not retain the pointer).
+                // - The cast from *const to *mut is safe because PMIx does not write
+                //   to the string — the non-const signature is a C API convention.
+                // - PMIx_server_delete_process_set is a synchronous server API.
+                ffi::PMIx_server_delete_process_set(
+                    pset_name_c.as_ptr() as *mut std::os::raw::c_char
+                )
+            }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
             unsafe {
-            // SAFETY:
-            // - pset_name_c is a valid null-terminated string for the duration of
-            //   this call (PMIx copies it internally, does not retain the pointer).
-            // - The cast from *const to *mut is safe because PMIx does not write
-            //   to the string — the non-const signature is a C API convention.
-            // - PMIx_server_delete_process_set is a synchronous server API.
-            ffi::PMIx_server_delete_process_set(pset_name_c.as_ptr() as *mut std::os::raw::c_char)
-        }
+                // SAFETY:
+                // - pset_name_c is a valid null-terminated string for the duration of
+                //   this call (PMIx copies it internally, does not retain the pointer).
+                // - The cast from *const to *mut is safe because PMIx does not write
+                //   to the string — the non-const signature is a C API convention.
+                // - PMIx_server_delete_process_set is a synchronous server API.
+                ffi::PMIx_server_delete_process_set(
+                    pset_name_c.as_ptr() as *mut std::os::raw::c_char
+                )
+            }
         };
     }
 
@@ -255,13 +263,15 @@ pub trait RegisterResourcesCallback: Send {
 static REGISTER_RESOURCES_REGISTRY: LazyLock<Registry<Box<dyn RegisterResourcesCallback>>> =
     LazyLock::new(Registry::new);
 
-
 /// C bridge for `pmix_op_cbfunc_t` (register_resources completion).
 ///
 /// Called by PMIx when the non-blocking resource registration completes.
 /// The `cbdata` parameter is a raw pointer encoding the request ID.
 /// We look up the registered closure and invoke it with the result status.
-pub(crate) extern "C" fn register_resources_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut c_void) {
+pub(crate) extern "C" fn register_resources_callback_bridge(
+    status: ffi::pmix_status_t,
+    cbdata: *mut c_void,
+) {
     if cbdata.is_null() {
         return;
     }
@@ -284,7 +294,7 @@ pub(crate) extern "C" fn register_resources_callback_bridge(status: ffi::pmix_st
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
     let _ = invoke_user_callback("server::pset", move || {
-            cb.on_complete(pmix_status);
+        cb.on_complete(pmix_status);
     });
 }
 
@@ -356,64 +366,73 @@ pub fn server_register_resources(
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Get a pointer to the info array for FFI.
-    let info_ptr = if info.len > 0 {
-        info.handle as *const ffi::pmix_info_t
+    let retained = if info.handle.is_null() || info.len == 0 {
+        Vec::new()
     } else {
-        ptr::null()
+        unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
     };
-    let info_len = info.len;
+    let info_ptr = if retained.is_empty() {
+        ptr::null()
+    } else {
+        retained.as_ptr()
+    };
+    let info_len = retained.len();
+    REGISTER_RESOURCE_INFO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(req_id, RetainedResourceInfo(retained));
 
     // Call the FFI function (or mock).
-        let status;
+    let status;
     #[cfg(any(test, feature = "mock_ffi"))]
     {
         status = if mock_ffi::is_mock_enabled() {
             unsafe {
-            mock_ffi::mock_server_register_resources(
-                info_ptr as *mut std::ffi::c_void,
-                info_len,
-                Some(register_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                mock_ffi::mock_server_register_resources(
+                    info_ptr as *mut std::ffi::c_void,
+                    info_len,
+                    Some(register_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         } else {
             unsafe {
-            // SAFETY: PMIx_server_register_resources is a non-blocking server API.
-            // - info_ptr is either a valid pointer to an array of pmix_info_t
-            //   (owned by the Info handle, which remains alive for the duration
-            //   of this call — PMIx copies the info internally), or null when
-            //   info_len is 0.
-            // - info_len is the number of elements in the info array.
-            // - The callback bridge has C linkage and properly handles cbdata.
-            // - cbdata is an opaque pointer that we control and decode in the bridge.
-            ffi::PMIx_server_register_resources(
-                info_ptr as *mut ffi::pmix_info_t,
-                info_len,
-                Some(register_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                // SAFETY: PMIx_server_register_resources is a non-blocking server API.
+                // - info_ptr is either a valid pointer to an array of pmix_info_t
+                //   (owned by the Info handle, which remains alive for the duration
+                //   of this call — PMIx copies the info internally), or null when
+                //   info_len is 0.
+                // - info_len is the number of elements in the info array.
+                // - The callback bridge has C linkage and properly handles cbdata.
+                // - cbdata is an opaque pointer that we control and decode in the bridge.
+                ffi::PMIx_server_register_resources(
+                    info_ptr as *mut ffi::pmix_info_t,
+                    info_len,
+                    Some(register_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
             unsafe {
-            // SAFETY: PMIx_server_register_resources is a non-blocking server API.
-            // - info_ptr is either a valid pointer to an array of pmix_info_t
-            //   (owned by the Info handle, which remains alive for the duration
-            //   of this call — PMIx copies the info internally), or null when
-            //   info_len is 0.
-            // - info_len is the number of elements in the info array.
-            // - The callback bridge has C linkage and properly handles cbdata.
-            // - cbdata is an opaque pointer that we control and decode in the bridge.
-            ffi::PMIx_server_register_resources(
-                info_ptr as *mut ffi::pmix_info_t,
-                info_len,
-                Some(register_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                // SAFETY: PMIx_server_register_resources is a non-blocking server API.
+                // - info_ptr is either a valid pointer to an array of pmix_info_t
+                //   (owned by the Info handle, which remains alive for the duration
+                //   of this call — PMIx copies the info internally), or null when
+                //   info_len is 0.
+                // - info_len is the number of elements in the info array.
+                // - The callback bridge has C linkage and properly handles cbdata.
+                // - cbdata is an opaque pointer that we control and decode in the bridge.
+                ffi::PMIx_server_register_resources(
+                    info_ptr as *mut ffi::pmix_info_t,
+                    info_len,
+                    Some(register_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         };
     }
 
@@ -427,6 +446,10 @@ pub fn server_register_resources(
         // will never be invoked.
         let mut registry = REGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id);
+        REGISTER_RESOURCE_INFO
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         Err(pmix_status)
     }
 }
@@ -446,7 +469,12 @@ pub trait DeregisterResourcesCallback: Send {
 /// Global registry mapping request IDs to pending deregister_resources callbacks.
 static DEREGISTER_RESOURCES_REGISTRY: LazyLock<Registry<Box<dyn DeregisterResourcesCallback>>> =
     LazyLock::new(Registry::new);
-
+struct RetainedResourceInfo(Vec<ffi::pmix_info_t>);
+unsafe impl Send for RetainedResourceInfo {}
+static REGISTER_RESOURCE_INFO: LazyLock<Mutex<HashMap<usize, RetainedResourceInfo>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static DEREGISTER_RESOURCE_INFO: LazyLock<Mutex<HashMap<usize, RetainedResourceInfo>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// C bridge for `pmix_op_cbfunc_t` (deregister_resources completion).
 ///
@@ -466,6 +494,11 @@ pub(crate) extern "C" fn deregister_resources_callback_bridge(
     let req_id = crate::cbdata::decode_req_id(cbdata);
 
     // Look up and remove the callback from the registry.
+    DEREGISTER_RESOURCE_INFO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
+
     let cb = {
         let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id)
@@ -479,7 +512,7 @@ pub(crate) extern "C" fn deregister_resources_callback_bridge(
     // Invoke the user's Rust callback.
     let pmix_status = PmixStatus::from_raw(status);
     let _ = invoke_user_callback("server::pset", move || {
-            cb.on_complete(pmix_status);
+        cb.on_complete(pmix_status);
     });
 }
 
@@ -551,64 +584,73 @@ pub fn server_deregister_resources(
     let cbdata = crate::cbdata::encode_req_id(req_id);
 
     // Get a pointer to the info array for FFI.
-    let info_ptr = if info.len > 0 {
-        info.handle as *const ffi::pmix_info_t
+    let retained = if info.handle.is_null() || info.len == 0 {
+        Vec::new()
     } else {
-        ptr::null()
+        unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
     };
-    let info_len = info.len;
+    let info_ptr = if retained.is_empty() {
+        ptr::null()
+    } else {
+        retained.as_ptr()
+    };
+    let info_len = retained.len();
+    DEREGISTER_RESOURCE_INFO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(req_id, RetainedResourceInfo(retained));
 
     // Call the FFI function (or mock).
-        let status;
+    let status;
     #[cfg(any(test, feature = "mock_ffi"))]
     {
         status = if mock_ffi::is_mock_enabled() {
             unsafe {
-            mock_ffi::mock_server_deregister_resources(
-                info_ptr as *mut std::ffi::c_void,
-                info_len,
-                Some(deregister_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                mock_ffi::mock_server_deregister_resources(
+                    info_ptr as *mut std::ffi::c_void,
+                    info_len,
+                    Some(deregister_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         } else {
             unsafe {
-            // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
-            // - info_ptr is either a valid pointer to an array of pmix_info_t
-            //   (owned by the Info handle, which remains alive for the duration
-            //   of this call — PMIx copies the info internally), or null when
-            //   info_len is 0.
-            // - info_len is the number of elements in the info array.
-            // - The callback bridge has C linkage and properly handles cbdata.
-            // - cbdata is an opaque pointer that we control and decode in the bridge.
-            ffi::PMIx_server_deregister_resources(
-                info_ptr as *mut ffi::pmix_info_t,
-                info_len,
-                Some(deregister_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
+                // - info_ptr is either a valid pointer to an array of pmix_info_t
+                //   (owned by the Info handle, which remains alive for the duration
+                //   of this call — PMIx copies the info internally), or null when
+                //   info_len is 0.
+                // - info_len is the number of elements in the info array.
+                // - The callback bridge has C linkage and properly handles cbdata.
+                // - cbdata is an opaque pointer that we control and decode in the bridge.
+                ffi::PMIx_server_deregister_resources(
+                    info_ptr as *mut ffi::pmix_info_t,
+                    info_len,
+                    Some(deregister_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         };
     }
     #[cfg(not(any(test, feature = "mock_ffi")))]
     {
         status = {
             unsafe {
-            // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
-            // - info_ptr is either a valid pointer to an array of pmix_info_t
-            //   (owned by the Info handle, which remains alive for the duration
-            //   of this call — PMIx copies the info internally), or null when
-            //   info_len is 0.
-            // - info_len is the number of elements in the info array.
-            // - The callback bridge has C linkage and properly handles cbdata.
-            // - cbdata is an opaque pointer that we control and decode in the bridge.
-            ffi::PMIx_server_deregister_resources(
-                info_ptr as *mut ffi::pmix_info_t,
-                info_len,
-                Some(deregister_resources_callback_bridge),
-                cbdata,
-            )
-        }
+                // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
+                // - info_ptr is either a valid pointer to an array of pmix_info_t
+                //   (owned by the Info handle, which remains alive for the duration
+                //   of this call — PMIx copies the info internally), or null when
+                //   info_len is 0.
+                // - info_len is the number of elements in the info array.
+                // - The callback bridge has C linkage and properly handles cbdata.
+                // - cbdata is an opaque pointer that we control and decode in the bridge.
+                ffi::PMIx_server_deregister_resources(
+                    info_ptr as *mut ffi::pmix_info_t,
+                    info_len,
+                    Some(deregister_resources_callback_bridge),
+                    cbdata,
+                )
+            }
         };
     }
 
@@ -622,8 +664,10 @@ pub fn server_deregister_resources(
         // will never be invoked.
         let mut registry = DEREGISTER_RESOURCES_REGISTRY.lock();
         registry.remove(&req_id);
+        DEREGISTER_RESOURCE_INFO
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&req_id);
         Err(pmix_status)
     }
 }
-
-

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -280,6 +280,13 @@ pub(crate) extern "C" fn register_resources_callback_bridge(
     // We reconstruct the usize from the pointer address.
     let req_id = crate::cbdata::decode_req_id(cbdata);
 
+    // Release the retained info array on every completion, including when the
+    // callback was already consumed or was never registered.
+    REGISTER_RESOURCE_INFO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&req_id);
+
     // Look up and remove the callback from the registry.
     let cb = {
         let mut registry = REGISTER_RESOURCES_REGISTRY.lock();

--- a/src/server/pset.rs
+++ b/src/server/pset.rs
@@ -371,16 +371,22 @@ pub fn server_register_resources(
     } else {
         unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
     };
-    let info_ptr = if retained.is_empty() {
-        ptr::null()
-    } else {
-        retained.as_ptr()
-    };
     let info_len = retained.len();
     REGISTER_RESOURCE_INFO
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .insert(req_id, RetainedResourceInfo(retained));
+    let info_ptr = {
+        let registry = REGISTER_RESOURCE_INFO
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let retained = &registry[&req_id].0;
+        if retained.is_empty() {
+            ptr::null()
+        } else {
+            retained.as_ptr()
+        }
+    };
 
     // Call the FFI function (or mock).
     let status;
@@ -398,10 +404,12 @@ pub fn server_register_resources(
         } else {
             unsafe {
                 // SAFETY: PMIx_server_register_resources is a non-blocking server API.
-                // - info_ptr is either a valid pointer to an array of pmix_info_t
-                //   (owned by the Info handle, which remains alive for the duration
-                //   of this call — PMIx copies the info internally), or null when
-                //   info_len is 0.
+                // - PMIx retains/aliases info_ptr across its threadshift and does
+                //   not copy the info array. REGISTER_RESOURCE_INFO keeps an owned
+                //   shallow copy of that array alive, keyed by req_id, until the
+                //   completion bridge reclaims it; the caller must keep the Info
+                //   value data alive until the callback fires (the retained array
+                //   does not own its nested value pointers), or null when empty.
                 // - info_len is the number of elements in the info array.
                 // - The callback bridge has C linkage and properly handles cbdata.
                 // - cbdata is an opaque pointer that we control and decode in the bridge.
@@ -419,10 +427,12 @@ pub fn server_register_resources(
         status = {
             unsafe {
                 // SAFETY: PMIx_server_register_resources is a non-blocking server API.
-                // - info_ptr is either a valid pointer to an array of pmix_info_t
-                //   (owned by the Info handle, which remains alive for the duration
-                //   of this call — PMIx copies the info internally), or null when
-                //   info_len is 0.
+                // - PMIx retains/aliases info_ptr across its threadshift and does
+                //   not copy the info array. REGISTER_RESOURCE_INFO keeps an owned
+                //   shallow copy of that array alive, keyed by req_id, until the
+                //   completion bridge reclaims it; the caller must keep the Info
+                //   value data alive until the callback fires (the retained array
+                //   does not own its nested value pointers), or null when empty.
                 // - info_len is the number of elements in the info array.
                 // - The callback bridge has C linkage and properly handles cbdata.
                 // - cbdata is an opaque pointer that we control and decode in the bridge.
@@ -589,16 +599,22 @@ pub fn server_deregister_resources(
     } else {
         unsafe { std::slice::from_raw_parts(info.handle, info.len).to_vec() }
     };
-    let info_ptr = if retained.is_empty() {
-        ptr::null()
-    } else {
-        retained.as_ptr()
-    };
     let info_len = retained.len();
     DEREGISTER_RESOURCE_INFO
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .insert(req_id, RetainedResourceInfo(retained));
+    let info_ptr = {
+        let registry = DEREGISTER_RESOURCE_INFO
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let retained = &registry[&req_id].0;
+        if retained.is_empty() {
+            ptr::null()
+        } else {
+            retained.as_ptr()
+        }
+    };
 
     // Call the FFI function (or mock).
     let status;
@@ -616,10 +632,12 @@ pub fn server_deregister_resources(
         } else {
             unsafe {
                 // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
-                // - info_ptr is either a valid pointer to an array of pmix_info_t
-                //   (owned by the Info handle, which remains alive for the duration
-                //   of this call — PMIx copies the info internally), or null when
-                //   info_len is 0.
+                // - PMIx retains/aliases info_ptr across its threadshift and does
+                //   not copy the info array. DEREGISTER_RESOURCE_INFO keeps an
+                //   owned shallow copy of that array alive, keyed by req_id, until
+                //   the completion bridge reclaims it; the caller must keep the
+                //   Info value data alive until the callback fires (the retained
+                //   array does not own its nested value pointers), or null when empty.
                 // - info_len is the number of elements in the info array.
                 // - The callback bridge has C linkage and properly handles cbdata.
                 // - cbdata is an opaque pointer that we control and decode in the bridge.
@@ -637,10 +655,12 @@ pub fn server_deregister_resources(
         status = {
             unsafe {
                 // SAFETY: PMIx_server_deregister_resources is a non-blocking server API.
-                // - info_ptr is either a valid pointer to an array of pmix_info_t
-                //   (owned by the Info handle, which remains alive for the duration
-                //   of this call — PMIx copies the info internally), or null when
-                //   info_len is 0.
+                // - PMIx retains/aliases info_ptr across its threadshift and does
+                //   not copy the info array. DEREGISTER_RESOURCE_INFO keeps an
+                //   owned shallow copy of that array alive, keyed by req_id, until
+                //   the completion bridge reclaims it; the caller must keep the
+                //   Info value data alive until the callback fires (the retained
+                //   array does not own its nested value pointers), or null when empty.
                 // - info_len is the number of elements in the info array.
                 // - The callback bridge has C linkage and properly handles cbdata.
                 // - cbdata is an opaque pointer that we control and decode in the bridge.


### PR DESCRIPTION
Closes #443

## Summary
Retain owned deep copies of PMIx proc/info arrays across non-blocking threadshifts and reclaim them from completion bridges.

## Affected functions
- `notify_event_nb` and `register_event_handler_nb`
- `server_register_resources` and `server_deregister_resources`
- `process_monitor_nb`
- `log_data_nb` retained-array wiring verified and preserved

## Rationale
OpenPMIx retains these caller pointers after returning from the wrapper. The wrappers now keep copied arrays alive until PMIx invokes the completion bridge, and remove them on synchronous rejection or completion.

## Test plan
- Local mock-based `cargo test --lib --no-default-features` (compiles; execution timed out in pre-existing long-running monitoring tests after many passing tests)
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo check --lib`
- `cargo fmt --all`
- Daemon-based tests are CI-only because no PMIx daemon is available locally.
