### PR TITLE
fix(fabric): deep-copy device distances; never free PMIx memory with Rust allocators

### DIFF
--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -1172,17 +1172,29 @@ impl PmixDeviceDistance {
     }
 }
 
+/// Release a PMIx-owned distance array after copying its entries.
+unsafe fn free_raw_distances(dist: *mut ffi::pmix_device_distance_t, len: usize) {
+    if dist.is_null() {
+        return;
+    }
+    for i in 0..len {
+        let entry = unsafe { dist.add(i) };
+        unsafe {
+            libc::free((*entry).uuid.cast());
+            libc::free((*entry).osname.cast());
+        }
+    }
+    unsafe { libc::free(dist.cast()) };
+}
+
 /// A collection of device distances returned by [`compute_distances`].
 ///
-/// Owns the C-allocated array and frees it on drop.
+/// The collection owns Rust copies of all returned data. PMIx-owned memory is
+/// released by the API call or callback bridge before this value is delivered.
 pub struct DeviceDistances {
-    /// The parsed distance entries.
+    /// The parsed, Rust-owned distance entries.
     distances: Vec<PmixDeviceDistance>,
-    /// Raw pointer to the C-allocated array (for cleanup).
-    raw_ptr: *mut ffi::pmix_device_distance_t,
-    /// Number of elements in the raw array.
-    len: usize,
-    /// Makes this type `!Send` + `!Sync` (owns PMIx/C memory — not free-threaded).
+    /// Makes this type `!Send` + `!Sync` for consistency with PMIx fabric data.
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
@@ -1209,9 +1221,6 @@ impl DeviceDistances {
     pub fn test_new(distances: Vec<PmixDeviceDistance>) -> Self {
         Self {
             distances,
-            raw_ptr: ptr::null_mut(),
-            len: 0,
-        
             _not_thread_safe: std::marker::PhantomData,
         }
     }
@@ -1222,47 +1231,6 @@ impl std::fmt::Debug for DeviceDistances {
         f.debug_struct("DeviceDistances")
             .field("distances", &self.distances)
             .finish()
-    }
-}
-
-impl Drop for DeviceDistances {
-    fn drop(&mut self) {
-        if !self.raw_ptr.is_null() && self.len > 0 {
-            // SAFETY: We own the C-allocated array returned by PMIx_Compute_distances.
-            // Free each entry's strings, then free the array itself.
-            unsafe {
-                for i in 0..self.len {
-                    let entry = self.raw_ptr.add(i);
-                    if !(*entry).uuid.is_null() {
-                        let _ = std::ffi::CString::from_raw((*entry).uuid);
-                    }
-                    if !(*entry).osname.is_null() {
-                        let _ = std::ffi::CString::from_raw((*entry).osname);
-                    }
-                }
-                // Free the array — PMIx uses standard calloc/free.
-                // The C API uses PMIX_DEVICE_DIST_DESTRUCT which frees strings
-                // but not the array itself. We need to free the array with
-                // the same allocator PMIx used. Since PMIx uses libc calloc/free
-                // internally, we use std::alloc::dealloc with Layout::from_size_align.
-                // However, the safest approach is to let the PMIx library handle it.
-                // Since there's no PMIx-specific free function for this array,
-                // and the strings are already freed, we just null the pointer
-                // to avoid double-free. The C library will clean up on finalize.
-                //
-                // NOTE: In practice, PMIx expects the caller to use
-                // PMIX_DEVICE_DIST_DESTRUCT + free(). We handle string cleanup
-                // above. For the array itself, we rely on libc free.
-                let layout = std::alloc::Layout::from_size_align(
-                    std::mem::size_of::<ffi::pmix_device_distance_t>() * self.len,
-                    std::mem::align_of::<ffi::pmix_device_distance_t>(),
-                )
-                .unwrap();
-                std::alloc::dealloc(self.raw_ptr as *mut u8, layout);
-            }
-            self.raw_ptr = ptr::null_mut();
-            self.len = 0;
-        }
     }
 }
 
@@ -1440,7 +1408,7 @@ pub fn compute_distances(
 
     // SAFETY: On success, PMIx_Compute_distances allocates and returns a
     // valid array of pmix_device_distance_t with ndist elements.
-    // We take ownership of the data and will free it in DeviceDistances::drop.
+    // Copy the data before returning; PMIx owns the source array and its strings.
     let distances: Vec<PmixDeviceDistance> = unsafe {
         if raw_distances.is_null() || ndist == 0 {
             Vec::new()
@@ -1451,13 +1419,14 @@ pub fn compute_distances(
         }
     };
 
+    // PMIx owns this array. The strings were copied above, so release the
+    // PMIx allocation before returning the Rust-only value.
+    unsafe { free_raw_distances(raw_distances, ndist) };
+
     Ok(DeviceDistances {
         distances,
-        raw_ptr: raw_distances,
-        len: ndist,
-    
-            _not_thread_safe: std::marker::PhantomData,
-        })
+        _not_thread_safe: std::marker::PhantomData,
+    })
 }
 
 /// Non-blocking variant of [`compute_distances`].
@@ -1525,19 +1494,13 @@ pub fn compute_distances_nb(
             };
             DeviceDistances {
                 distances: rust_distances,
-                raw_ptr: dist,
-                len: ndist,
-            
-            _not_thread_safe: std::marker::PhantomData,
-        }
+                _not_thread_safe: std::marker::PhantomData,
+            }
         } else {
             DeviceDistances {
                 distances: Vec::new(),
-                raw_ptr: ptr::null_mut(),
-                len: 0,
-            
-            _not_thread_safe: std::marker::PhantomData,
-        }
+                _not_thread_safe: std::marker::PhantomData,
+            }
         };
 
         // Call the release function if provided.
@@ -2557,6 +2520,46 @@ mod tests {
         assert!(result.is_ok());
         let distances = result.unwrap();
         assert_eq!(distances.len(), 0);
+    }
+
+    #[test]
+    fn test_compute_distances_nb_deep_copies_before_release() {
+        let _guard = mock_ffi::MockGuard::new();
+        mock_ffi::mock_set_device_distances(vec![(
+            "nb-uuid".to_string(),
+            "nb-osname".to_string(),
+            0,
+            3,
+            9,
+        )]);
+
+        struct Callback {
+            result: std::sync::Arc<std::sync::Mutex<Option<(String, String)>>>,
+        }
+        impl ComputeDistancesCallback for Callback {
+            fn on_complete(self: Box<Self>, _status: PmixStatus, distances: DeviceDistances) {
+                let entry = &distances.distances()[0];
+                *self.result.lock().unwrap() =
+                    Some((entry.uuid().to_string(), entry.osname().to_string()));
+            }
+        }
+
+        let result = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let mut topo = PmixTopology::new(Some("hwloc")).unwrap();
+        let mut cpuset = PmixCpuset::new();
+        compute_distances_nb(
+            &mut topo,
+            &mut cpuset,
+            &[],
+            Box::new(Callback {
+                result: result.clone(),
+            }),
+        )
+        .unwrap();
+
+        let (uuid, osname) = result.lock().unwrap().take().unwrap();
+        assert_eq!(uuid, "nb-uuid");
+        assert_eq!(osname, "nb-osname");
     }
 
     #[test]

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1641,16 +1641,21 @@ pub fn mock_compute_distances(
             if !mock_distances.is_empty() {
                 let count = mock_distances.len();
                 // Allocate array of device_distance_t
-                let layout = std::alloc::Layout::from_size_align(
-                    std::mem::size_of::<crate::ffi::pmix_device_distance_t>() * count,
-                    std::mem::align_of::<crate::ffi::pmix_device_distance_t>(),
-                ).unwrap();
-                let ptr = unsafe { std::alloc::alloc(layout) as *mut crate::ffi::pmix_device_distance_t };
+                let ptr = unsafe {
+                    libc::calloc(
+                        count,
+                        std::mem::size_of::<crate::ffi::pmix_device_distance_t>(),
+                    ) as *mut crate::ffi::pmix_device_distance_t
+                };
                 if !ptr.is_null() {
                     for (i, (uuid, osname, dtype, mind, maxd)) in mock_distances.iter().enumerate() {
                         let entry = unsafe { &mut *ptr.add(i) };
-                        entry.uuid = std::ffi::CString::new(uuid.as_str()).unwrap().into_raw();
-                        entry.osname = std::ffi::CString::new(osname.as_str()).unwrap().into_raw();
+                        entry.uuid = unsafe {
+                            libc::strdup(std::ffi::CString::new(uuid.as_str()).unwrap().as_ptr())
+                        };
+                        entry.osname = unsafe {
+                            libc::strdup(std::ffi::CString::new(osname.as_str()).unwrap().as_ptr())
+                        };
                         entry.type_ = *dtype;
                         entry.mindist = *mind;
                         entry.maxdist = *maxd;
@@ -1674,7 +1679,7 @@ pub fn mock_compute_distances_nb(
     _cpuset: *mut crate::ffi::pmix_cpuset_t,
     _info: *mut crate::ffi::pmix_info_t,
     _ninfo: usize,
-    _cbfunc: Option<unsafe extern "C" fn(
+    cbfunc: Option<unsafe extern "C" fn(
         i32,
         *mut crate::ffi::pmix_device_distance_t,
         usize,
@@ -1682,13 +1687,61 @@ pub fn mock_compute_distances_nb(
         Option<unsafe extern "C" fn(*mut std::os::raw::c_void)>,
         *mut std::os::raw::c_void,
     )>,
-    _cbdata: *mut std::os::raw::c_void,
+    cbdata: *mut std::os::raw::c_void,
 ) -> i32 {
-    if is_mock_enabled() {
-        get_mock_status("PMIx_Compute_distances_nb")
-    } else {
-        PMIX_ERR_INIT
+    if !is_mock_enabled() {
+        return PMIX_ERR_INIT;
     }
+    let status = get_mock_status("PMIx_Compute_distances_nb");
+    if status != PMIX_SUCCESS {
+        return status;
+    }
+
+    let values = MOCK_DEVICE_DISTANCES.with(|cell| cell.borrow().clone());
+    let count = values.len();
+    let dist = unsafe {
+        libc::calloc(
+            count.max(1),
+            std::mem::size_of::<crate::ffi::pmix_device_distance_t>(),
+        ) as *mut crate::ffi::pmix_device_distance_t
+    };
+    if dist.is_null() {
+        return -5; // PMIX_ERR_NOMEM
+    }
+    for (i, (uuid, osname, dtype, mind, maxd)) in values.iter().enumerate() {
+        unsafe {
+            let entry = &mut *dist.add(i);
+            entry.uuid = libc::strdup(std::ffi::CString::new(uuid.as_str()).unwrap().as_ptr());
+            entry.osname = libc::strdup(std::ffi::CString::new(osname.as_str()).unwrap().as_ptr());
+            entry.type_ = *dtype;
+            entry.mindist = *mind;
+            entry.maxdist = *maxd;
+        }
+    }
+
+    #[repr(C)]
+    struct DistanceCaddy {
+        dist: *mut crate::ffi::pmix_device_distance_t,
+        len: usize,
+    }
+    unsafe extern "C" fn release_distances(data: *mut std::os::raw::c_void) {
+        let caddy = unsafe { Box::from_raw(data as *mut DistanceCaddy) };
+        for i in 0..caddy.len {
+            let entry = unsafe { &*caddy.dist.add(i) };
+            unsafe {
+                libc::free(entry.uuid.cast());
+                libc::free(entry.osname.cast());
+            }
+        }
+        unsafe { libc::free(caddy.dist.cast()) };
+    }
+    if let Some(callback) = cbfunc {
+        let caddy = Box::into_raw(Box::new(DistanceCaddy { dist, len: count }));
+        unsafe { callback(status, dist, count, cbdata, Some(release_distances), caddy.cast()) };
+    } else {
+        unsafe { libc::free(dist.cast()) };
+    }
+    status
 }
 
 /// Mock implementation of `PMIx_Topology_destruct()`.

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1737,8 +1737,17 @@ pub fn mock_compute_distances_nb(
     }
     if let Some(callback) = cbfunc {
         let caddy = Box::into_raw(Box::new(DistanceCaddy { dist, len: count }));
-        unsafe { callback(status, dist, count, cbdata, Some(release_distances), caddy.cast()) };
+        unsafe {
+            callback(status, dist, count, cbdata, Some(release_distances), caddy.cast())
+        };
     } else {
+        for i in 0..count {
+            let entry = unsafe { &*dist.add(i) };
+            unsafe {
+                libc::free(entry.uuid.cast());
+                libc::free(entry.osname.cast());
+            }
+        }
         unsafe { libc::free(dist.cast()) };
     }
     status


### PR DESCRIPTION
Closes #444

## Summary
- Make `DeviceDistances` Rust-only with deep-copied string fields and no C array ownership.
- Release PMIx-owned blocking results with `libc::free` after copying.
- Ensure the non-blocking bridge copies entries before calling `release_fn`, preventing UAF and double-free.

## Affected functions
- `PmixDeviceDistance::from_raw`
- `DeviceDistances::drop` (removed; Rust `Vec` owns all data)
- `compute_distances`
- `compute_distances_nb` callback bridge
- mock distance FFI paths

## Rationale
PMIx allocates device-distance strings and arrays with the C allocator and owns non-blocking callback data until `release_fn`. Rust must copy the data before release and must not reclaim PMIx memory with Rust allocators.

## Test plan
- Local mock-based callback regression test verifies values remain valid after the release callback.
- Local mock-based fabric tests: `cargo test --lib fabric::tests` (87 passed).
- Full local library test suite: 1852 passed, 1 pre-existing flaky failure, 29 ignored; the failure was `data_ops::tests::test_get_nb_failure_removes_qualified_marker`, unrelated to this change.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` passed.
- `cargo clippy --lib -- -D warnings` is blocked by pre-existing generated `OUT_DIR/bindings.rs` missing-safety-doc lints.
- `cargo fmt --check` reports pre-existing repository-wide formatting drift; changed-code `git diff --check` passes.
- Daemon/DVM tests are CI-only in this environment.