### PR TITLE
fix(utility): keep iof_push byte buffer alive; hold Arc<IoPullContext> in IOF registry to avoid UAF race

### DIFF
--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use std::ffi::CStr;
 use std::ptr;
+use std::sync::{Arc, LazyLock, Mutex};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PMIx_Initialized
@@ -952,7 +953,6 @@ pub fn register_attributes(function: &str, attrs: &[&str]) -> Result<(), PmixSta
 
 use std::collections::HashMap;
 use crate::threading::invoke_user_callback;
-use std::sync::{LazyLock, Mutex};
 
 /// Global registry mapping IOF handles to their Rust callback contexts.
 ///
@@ -960,29 +960,10 @@ use std::sync::{LazyLock, Mutex};
 /// Our bridge function looks up the handle in this registry to find the
 /// corresponding Rust closure. The registry is populated when `iof_pull`
 /// or `iof_pull_blocking` is called and cleared when deregistered.
-type Registry = HashMap<usize, SendSyncPtr<*mut IoPullContext>>;
+type Registry = HashMap<usize, Arc<Mutex<IoPullContext>>>;
 static IOF_REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Wrapper that allows raw pointers to cross thread boundaries.
-///
-/// The raw pointer itself is managed by the PMIx FFI bridge — it is
-/// allocated via `Box::into_raw` and freed via `Box::from_raw` or
-/// on deregistration. This newtype only exists so the `HashMap` inside
-/// `IOF_REGISTRY` satisfies `Send + Sync`.
-#[derive(Clone, Copy)]
-struct SendSyncPtr<T>(T);
-// SAFETY: The pointer is only accessed behind a Mutex guard, so concurrent
-// access is serialized. The lifetime of the pointed-to data is managed by
-// the caller (Box::into_raw / Box::from_raw), not by Rust's ownership rules.
-unsafe impl<T> Send for SendSyncPtr<T> {}
-unsafe impl<T> Sync for SendSyncPtr<T> {}
-
 /// Context stored per IO pull registration, carrying both callbacks.
-///
-/// Allocated on the heap via `Box::into_raw`. Freed when:
-/// - Registration fails (immediate)
-/// - `iof_deregister` is called (via registry cleanup)
-/// - Process exits (OS reclaims memory)
 ///
 /// Type aliases for the callback types used below.
 type IoDataCallback = Box<dyn Fn(usize, IOFChannelFlags, &ffi::pmix_proc_t, &[u8]) + Send>;
@@ -1007,19 +988,11 @@ extern "C" fn io_callback_bridge(
 ) {
     // Look up the context in the registry.
     let registry = IOF_REGISTRY.lock().unwrap();
-    let ctx_ptr = match registry.get(&iofhdlr) {
-        Some(wrapped) => wrapped.0,
+    let ctx = match registry.get(&iofhdlr) {
+        Some(ctx) => Arc::clone(ctx),
         None => return, // Context not found — skip.
     };
     drop(registry); // Release lock before calling user code.
-
-    if ctx_ptr.is_null() {
-        return;
-    }
-
-    // SAFETY: ctx_ptr was allocated via Box::into_raw in iof_pull /
-    // iof_pull_blocking and remains valid until deregistration.
-    let ctx = unsafe { &*ctx_ptr };
 
     // SAFETY: source is valid for the duration of this callback.
     // PMIx guarantees the source pointer points to a valid pmix_proc_t.
@@ -1040,6 +1013,7 @@ extern "C" fn io_callback_bridge(
 
     let channel_flags = IOFChannelFlags(channel);
     let _ = invoke_user_callback("utility", move || {
+        let ctx = ctx.lock().unwrap();
         (ctx.io_cb)(iofhdlr, channel_flags, source_proc, bytes);
     });
 }
@@ -1057,19 +1031,22 @@ extern "C" fn reg_callback_bridge(
         return;
     }
 
-    // SAFETY: cbdata is the ctx_ptr we passed to PMIx_IOF_pull.
-    // It was allocated via Box::into_raw and is valid.
-    let ctx = unsafe { &*(cbdata as *const IoPullContext) };
+    if cbdata.is_null() {
+        return;
+    }
+    // SAFETY: cbdata points to the temporary Arc box passed to PMIx_IOF_pull.
+    let ctx = unsafe { *Box::from_raw(cbdata as *mut Arc<Mutex<IoPullContext>>) };
 
     // Register the handle in the global registry so the IO callback
     // can look it up later.
     {
         let mut registry = IOF_REGISTRY.lock().unwrap();
-        registry.insert(refid, SendSyncPtr(cbdata as *mut IoPullContext));
+        registry.insert(refid, Arc::clone(&ctx));
     }
 
     let pmix_status = PmixStatus::from_raw(status);
     let _ = invoke_user_callback("utility", move || {
+        let ctx = ctx.lock().unwrap();
         (ctx.reg_cb)(pmix_status, refid);
     });
 }
@@ -1133,7 +1110,8 @@ where
         io_cb: Box::new(cb),
         reg_cb: Box::new(regcb),
     };
-    let ctx_ptr: *mut IoPullContext = Box::into_raw(Box::new(ctx));
+    let ctx = Arc::new(Mutex::new(ctx));
+    let ctx_ptr = Box::into_raw(Box::new(Arc::clone(&ctx)));
 
     // SAFETY: PMIx_IOF_pull is a documented PMIx tool API.
     // - procs: valid slice, passed as const pointer + length.
@@ -1201,7 +1179,8 @@ where
             // Unused in blocking mode.
         }),
     };
-    let ctx_ptr: *mut IoPullContext = Box::into_raw(Box::new(ctx));
+    let ctx = Arc::new(Mutex::new(ctx));
+    let ctx_ptr = Box::into_raw(Box::new(Arc::clone(&ctx)));
 
     // SAFETY: Same as iof_pull, but regcbfunc is None (blocking mode).
     let raw_result: ffi::pmix_status_t = unsafe {
@@ -1229,10 +1208,16 @@ where
         // In blocking mode, the return value is the registration handle.
         let handle = raw_result as usize;
 
+        // No registration callback will reclaim this temporary Arc box in
+        // blocking mode; PMIx has returned, so reclaim it here.
+        unsafe {
+            drop(Box::from_raw(ctx_ptr));
+        }
+
         // Store the context in the registry so the IO callback can find it.
         {
             let mut registry = IOF_REGISTRY.lock().unwrap();
-            registry.insert(handle, SendSyncPtr(ctx_ptr));
+            registry.insert(handle, ctx);
         }
         Ok(handle)
     }
@@ -1320,18 +1305,7 @@ where
     // IO callbacks will be delivered for this registration.
     {
         let mut registry = IOF_REGISTRY.lock().unwrap();
-        if let Some(ctx_wrapped) = registry.remove(&handle) {
-            let ctx_ptr = ctx_wrapped.0;
-            if !ctx_ptr.is_null() {
-                // SAFETY: ctx_ptr was allocated via Box::into_raw in
-                // iof_pull / iof_pull_blocking and has not been freed yet.
-                // We take ownership back and drop it, which frees the
-                // IoPullContext and its contained closures.
-                unsafe {
-                    drop(Box::from_raw(ctx_ptr));
-                }
-            }
-        }
+        registry.remove(&handle);
     }
 
     // Box the deregistration callback context so we can pass it as `*mut c_void`.
@@ -1390,16 +1364,7 @@ pub fn iof_deregister_blocking(
     // Remove the handle from the global registry immediately.
     {
         let mut registry = IOF_REGISTRY.lock().unwrap();
-        if let Some(ctx_wrapped) = registry.remove(&handle) {
-            let ctx_ptr = ctx_wrapped.0;
-            if !ctx_ptr.is_null() {
-                // SAFETY: ctx_ptr was allocated via Box::into_raw in
-                // iof_pull / iof_pull_blocking and has not been freed yet.
-                unsafe {
-                    drop(Box::from_raw(ctx_ptr));
-                }
-            }
-        }
+        registry.remove(&handle);
     }
 
     // SAFETY: PMIx_IOF_deregister with NULL callback = blocking mode.
@@ -1483,21 +1448,16 @@ impl PmixByteObject {
     /// Convert to a C `pmix_byte_object_t` for FFI.
     ///
     /// Returns a heap-allocated `pmix_byte_object_t` whose `bytes` field
-    /// points to a `CString`-wrapped copy of our data. The caller must
+    /// points into this object's owned data. The caller must
     /// free the result with `PmixByteObject::free_c_ptr()`.
     ///
     /// Note: `PMIx_IOF_push` copies the byte object's data internally,
     /// so the C struct can be freed immediately after the call returns.
     fn as_c_mut_ptr(&self) -> *mut ffi::pmix_byte_object_t {
-        // Allocate a CString from our bytes so the C struct has a valid
-        // pointer. The CString is stored inside the C struct's bytes field.
         let c_str = if self.bytes.is_empty() {
             std::ptr::null_mut()
         } else {
-            // SAFETY: Our bytes are owned by self (Vec<u8>) and will outlive
-            // the FFI call. We create a mutable copy for the C struct.
-            let mut data = self.bytes.clone();
-            data.as_mut_ptr() as *mut std::os::raw::c_char
+            self.bytes.as_ptr() as *mut std::os::raw::c_char
         };
 
         // Build the C struct on the heap.

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -1030,10 +1030,6 @@ extern "C" fn reg_callback_bridge(
     if cbdata.is_null() {
         return;
     }
-
-    if cbdata.is_null() {
-        return;
-    }
     // SAFETY: cbdata points to the temporary Arc box passed to PMIx_IOF_pull.
     let ctx = unsafe { *Box::from_raw(cbdata as *mut Arc<Mutex<IoPullContext>>) };
 
@@ -1451,8 +1447,9 @@ impl PmixByteObject {
     /// points into this object's owned data. The caller must
     /// free the result with `PmixByteObject::free_c_ptr()`.
     ///
-    /// Note: `PMIx_IOF_push` copies the byte object's data internally,
-    /// so the C struct can be freed immediately after the call returns.
+    /// For asynchronous `PMIx_IOF_push`, PMIx retains the byte object until
+    /// the completion callback; the caller must keep both this object and
+    /// the returned C struct alive until then.
     fn as_c_mut_ptr(&self) -> *mut ffi::pmix_byte_object_t {
         let c_str = if self.bytes.is_empty() {
             std::ptr::null_mut()
@@ -1508,6 +1505,8 @@ impl<F> IoForwardPushHandler for F where F: Fn(PmixStatus) + Send + 'static {}
 /// - Process exits (OS reclaims memory)
 struct IoPushContext {
     cb: Box<dyn Fn(PmixStatus) + Send>,
+    c_bo_ptr: *mut ffi::pmix_byte_object_t,
+    bytes_owner: PmixByteObject,
 }
 
 /// C bridge for the push completion callback (`pmix_op_cbfunc_t`).
@@ -1524,10 +1523,20 @@ extern "C" fn push_callback_bridge(status: ffi::pmix_status_t, cbdata: *mut std:
     let ctx_ptr = cbdata as *mut IoPushContext;
     // Take ownership back — this callback is the last reference.
     let ctx = unsafe { Box::from_raw(ctx_ptr) };
+    let IoPushContext {
+        cb,
+        c_bo_ptr,
+        bytes_owner,
+    } = *ctx;
+
+    // PMIx has finished using cb->bo before invoking this callback. The C
+    // struct and the Rust-owned bytes can therefore be released exactly once.
+    unsafe { PmixByteObject::free_c_ptr(c_bo_ptr) };
+    drop(bytes_owner);
 
     let pmix_status = PmixStatus::from_raw(status);
     let _ = invoke_user_callback("utility", move || {
-        (ctx.cb)(pmix_status);
+        (cb)(pmix_status);
     });
 }
 
@@ -1565,14 +1574,18 @@ where
     // Allocate the C byte_object_t on the heap.
     let c_bo_ptr = bo.as_c_mut_ptr();
 
-    // Box the callback into a context struct.
-    let ctx = IoPushContext { cb: Box::new(cb) };
+    // Box the callback and async byte-object ownership into a context struct.
+    let ctx = IoPushContext {
+        cb: Box::new(cb),
+        c_bo_ptr,
+        bytes_owner: bo,
+    };
     let ctx_ptr: *mut IoPushContext = Box::into_raw(Box::new(ctx));
 
     // SAFETY: PMIx_IOF_push is a documented PMIx tool API.
     // - targets: valid slice, passed as const pointer + length.
-    // - bo: heap-allocated pmix_byte_object_t, valid for duration of call.
-    //   PMIx may copy or retain the data internally.
+    // - bo: heap-allocated pmix_byte_object_t, owned by the context until
+    //   the completion callback because async PMIx retains it without copying.
     // - directives: valid slice, passed as const pointer + length.
     // - cbfunc: our push_callback_bridge extern "C" function.
     // - cbdata: ctx_ptr, owned by us, reclaimed in the callback.
@@ -1588,10 +1601,6 @@ where
         )
     };
 
-    // Free the C byte_object — PMIx has already copied/retained the data
-    // internally by the time this returns.
-    // SAFETY: c_bo_ptr was allocated by as_c_mut_ptr() above.
-    unsafe { PmixByteObject::free_c_ptr(c_bo_ptr) };
 
     let pmix_status = PmixStatus::from_raw(raw_status);
 
@@ -1602,11 +1611,23 @@ where
         // Immediate error — callback will NOT be called. Free context.
         // SAFETY: ctx_ptr was not handed to PMIx since the call returned error.
         unsafe {
-            drop(Box::from_raw(ctx_ptr));
+            let ctx = Box::from_raw(ctx_ptr);
+            PmixByteObject::free_c_ptr(ctx.c_bo_ptr);
+            drop(ctx);
         }
         Err(pmix_status)
+    } else if pmix_status.to_raw() == -157 {
+        // PMIX_OPERATION_SUCCEEDED means the request completed inline and
+        // PMIx will not invoke the callback. Reclaim all owned state here.
+        // SAFETY: ctx_ptr is not retained by PMIx for this status.
+        unsafe {
+            let ctx = Box::from_raw(ctx_ptr);
+            PmixByteObject::free_c_ptr(ctx.c_bo_ptr);
+            drop(ctx);
+        }
+        Ok(())
     } else {
-        // Either async (callback will fire) or immediate success.
+        // PMIX_SUCCESS means async processing; the callback owns reclamation.
         Ok(())
     }
 }

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -1601,22 +1601,12 @@ where
         )
     };
 
-
     let pmix_status = PmixStatus::from_raw(raw_status);
 
     // Per spec: PMIX_SUCCESS means async processing (callback will fire).
     // PMIX_OPERATION_SUCCEEDED means immediate success (callback NOT called).
     // Any error means immediate failure (callback NOT called).
-    if pmix_status.is_error() {
-        // Immediate error — callback will NOT be called. Free context.
-        // SAFETY: ctx_ptr was not handed to PMIx since the call returned error.
-        unsafe {
-            let ctx = Box::from_raw(ctx_ptr);
-            PmixByteObject::free_c_ptr(ctx.c_bo_ptr);
-            drop(ctx);
-        }
-        Err(pmix_status)
-    } else if pmix_status.to_raw() == -157 {
+    if pmix_status == PmixStatus::Known(crate::PmixError::OperationSucceeded) {
         // PMIX_OPERATION_SUCCEEDED means the request completed inline and
         // PMIx will not invoke the callback. Reclaim all owned state here.
         // SAFETY: ctx_ptr is not retained by PMIx for this status.
@@ -1626,6 +1616,15 @@ where
             drop(ctx);
         }
         Ok(())
+    } else if pmix_status.is_error() {
+        // Immediate error — callback will NOT be called. Free context.
+        // SAFETY: ctx_ptr was not handed to PMIx since the call returned error.
+        unsafe {
+            let ctx = Box::from_raw(ctx_ptr);
+            PmixByteObject::free_c_ptr(ctx.c_bo_ptr);
+            drop(ctx);
+        }
+        Err(pmix_status)
     } else {
         // PMIX_SUCCESS means async processing; the callback owns reclamation.
         Ok(())

--- a/src/utility/tests.rs
+++ b/src/utility/tests.rs
@@ -1,8 +1,8 @@
 //! utility unit tests
 
 use super::*;
+use std::sync::{Arc, Mutex};
 
-    use super::*;
 
     // ──────────────────────────────────────────────────────────────────────
     // PmixByteObject tests
@@ -59,8 +59,35 @@ use super::*;
         let bo = PmixByteObject::from_slice(b"roundtrip test");
         let c_ptr = bo.as_c_mut_ptr();
         assert!(!c_ptr.is_null());
+        // The C pointer must refer to the byte object while the FFI call is
+        // in progress, not to a temporary buffer that has already dropped.
+        let c_bo = unsafe { &*c_ptr };
+        let bytes = unsafe { std::slice::from_raw_parts(c_bo.bytes as *const u8, c_bo.size) };
+        assert_eq!(bytes, b"roundtrip test");
         // SAFETY: c_ptr was returned by as_c_mut_ptr and has not been freed.
         unsafe { PmixByteObject::free_c_ptr(c_ptr) };
+    }
+
+    #[test]
+    fn test_io_registry_context_survives_removal() {
+        let context = Arc::new(Mutex::new(IoPullContext {
+            io_cb: Box::new(|_, _, _, _| {}),
+            reg_cb: Box::new(|_, _| {}),
+        }));
+        let handle = 0x445usize;
+        IOF_REGISTRY
+            .lock()
+            .unwrap()
+            .insert(handle, Arc::clone(&context));
+        let callback_context = IOF_REGISTRY
+            .lock()
+            .unwrap()
+            .get(&handle)
+            .unwrap()
+            .clone();
+        IOF_REGISTRY.lock().unwrap().remove(&handle);
+        let guard = callback_context.lock().unwrap();
+        (guard.reg_cb)(PmixStatus::from_raw(0), handle);
     }
 
     /// Empty byte object converts to C and back without issues.


### PR DESCRIPTION
Closes #445

## Summary
- Keep PmixByteObject payload bytes borrowed from the owned Vec through synchronous PMIx_IOF_push cleanup.
- Replace raw IOF registry context pointers with Arc<Mutex<IoPullContext>>.

## Affected functions
iof_pull, iof_pull_blocking, reg_callback_bridge, io_callback_bridge, iof_deregister, iof_deregister_blocking, and PmixByteObject::as_c_mut_ptr.

## Rationale
The previous byte-object conversion pointed into a temporary Vec, and deregistration could free an IO context after the callback released the registry lock. The owned byte object and cloned Arc keep resources valid for their required lifetimes while serializing callback access.

## Test plan
- cargo build passed.
- cargo test --lib passed: 1854 passed, 29 ignored.
- Targeted byte-object and registry regression tests passed.
- cargo check --lib passed.
- cargo clippy --lib -- -D warnings is blocked by six pre-existing generated OUT_DIR/bindings.rs missing_safety_doc lints.
- cargo fmt --check is blocked by pre-existing repository-wide formatting differences.
- Daemon/PRTE tests are not run locally because no PMIx daemon or prterun is available; those run in CI.