### PR TITLE
fix(data_ops): use real ffi PMIX_RANK_WILDCARD constant instead of -1 (= PMIX_RANK_INVALID)

### DIFF
--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -550,16 +550,13 @@ impl PmixPdata {
     /// populated by [`lookup`][crate::data_ops::lookup] on success.
     pub fn new(key: &str) -> Self {
         Self {
-            proc: Proc::new("", PMIX_RANK_WILDCARD as u32)
+            proc: Proc::new("", ffi::PMIX_RANK_WILDCARD)
                 .unwrap_or_else(|_| Proc::new("", 0).expect("invariant: unwrap in data_ops.rs")),
             key: key.to_string(),
             value: None,
         }
     }
 }
-
-/// PMIX_RANK_WILDCARD constant.
-const PMIX_RANK_WILDCARD: i32 = -1;
 
 /// Lookup information published by this or another process.
 ///
@@ -617,7 +614,7 @@ pub fn lookup(
         }
 
         // Initialize the proc field as wildcard.
-        pdata.proc_.rank = PMIX_RANK_WILDCARD as u32;
+        pdata.proc_.rank = ffi::PMIX_RANK_WILDCARD;
 
         // Zero the value so PMIx writes into it.
         unsafe {

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -410,14 +410,13 @@ use super::*;
 
     #[test]
     fn test_rank_wildcard_value() {
-        assert_eq!(PMIX_RANK_WILDCARD, -1);
+        assert_eq!(ffi::PMIX_RANK_WILDCARD, 0xFFFF_FFFEu32);
+        assert_ne!(ffi::PMIX_RANK_WILDCARD, u32::MAX);
     }
 
     #[test]
     fn test_rank_wildcast_as_u32() {
-        // PMIX_RANK_WILDCARD as u32 wraps to MAX
-        let rank: u32 = PMIX_RANK_WILDCARD as u32;
-        assert_eq!(rank, u32::MAX);
+        assert_eq!(ffi::PMIX_RANK_WILDCARD, 0xFFFF_FFFEu32);
     }
 
     // ─── PmixStatus roundtrip tests for data_ops context ────────────────────
@@ -2488,9 +2487,9 @@ use super::*;
     #[test]
     fn test_mock_proc_wildcard_rank() {
         let _guard = MockGuard::new();
-        let proc =
-            Proc::new("", PMIX_RANK_WILDCARD as u32).unwrap_or_else(|_| Proc::new("", 0).unwrap());
-        assert_eq!(proc.get_rank(), PMIX_RANK_WILDCARD as u32);
+        let proc = Proc::new("", ffi::PMIX_RANK_WILDCARD)
+            .unwrap_or_else(|_| Proc::new("", 0).unwrap());
+        assert_eq!(proc.get_rank(), ffi::PMIX_RANK_WILDCARD);
     }
 
     // ─── PmixPdata mock-aware tests ─────────────────────────────────────────
@@ -2501,6 +2500,7 @@ use super::*;
         let _guard = MockGuard::new();
         let pdata = PmixPdata::new("test.lookup.key");
         assert_eq!(pdata.key, "test.lookup.key");
+        assert_eq!(pdata.proc.get_rank(), ffi::PMIX_RANK_WILDCARD);
         assert!(pdata.value.is_none());
     }
 


### PR DESCRIPTION
Closes #446

## Summary
Use the generated OpenPMIx FFI constant for wildcard ranks instead of the incorrect local `-1` constant, which represented `PMIX_RANK_INVALID`.

## Affected functions
- `PmixPdata::new`
- `lookup`

## Rationale
OpenPMIx defines `PMIX_RANK_WILDCARD` as `0xFFFFFFFE` (`4294967294`), while `-1 as u32` is `0xFFFFFFFF` (`PMIX_RANK_INVALID`). Passing the real binding constant ensures PMIx receives the intended wildcard rank.

## Test plan
- Added/updated mock-based unit coverage for the generated constant and `PmixPdata` wildcard rank; no PMIx daemon is required locally.
- `cargo build` passed.
- `cargo test --lib data_ops::tests` passed (278 tests).
- Full `cargo test` is blocked by pre-existing unrelated group API test compile failures.
- `cargo clippy --all-targets -- -D warnings` is blocked by pre-existing generated-bindings `missing_safety_doc` lints and unrelated test issues; the change itself compiles cleanly.
- `cargo fmt --check` reports pre-existing repository-wide formatting differences outside this change.
- Daemon-based tests are expected to run in CI only in this environment.
