### PR TITLE
fix(data_ops): reject over-length keys in lookup with ErrBadParam instead of truncating

### DIFF
--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -591,6 +591,13 @@ pub fn lookup(
         return Err(PmixStatus::Known(PmixError::Error));
     }
 
+    if data
+        .iter()
+        .any(|item| item.key.len() > ffi::PMIX_MAX_KEYLEN as usize)
+    {
+        return Err(PmixStatus::Known(PmixError::ErrBadParam));
+    }
+
     // Build the raw pmix_pdata_t array.
     let ndata = data.len();
     let mut raw_pdata: Vec<ffi::pmix_pdata_t> = Vec::with_capacity(ndata);

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -4,6 +4,22 @@ use super::*;
 
     use super::*;
 
+    #[test]
+    fn lookup_rejects_over_length_key_before_ffi() {
+        mock_ffi::enable_mock_ffi();
+        let mut data = [PmixPdata::new(
+            &"k".repeat(ffi::PMIX_MAX_KEYLEN as usize + 1),
+        )];
+
+        let result = lookup(&mut data, None);
+
+        mock_ffi::disable_mock_ffi();
+        assert!(matches!(
+            result,
+            Err(PmixStatus::Known(PmixError::ErrBadParam))
+        ));
+    }
+
     // ─── PmixPdata construction tests ───────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Closes #447

## Summary
Reject over-length lookup keys with ErrBadParam instead of silently truncating them.

## Affected function
`data_ops::lookup` validates every key before constructing any `pmix_pdata_t` values and returns `PmixStatus::Known(PmixError::ErrBadParam)` when a key exceeds `PMIX_MAX_KEYLEN`.

## Rationale
This prevents a truncated key from looking up the wrong attribute or returning not-found, and ensures no partially constructed pdata values are leaked on validation failure.

## Test plan
- Added a local mock-FFI unit test covering an over-length key and confirming `ErrBadParam`.
- `cargo build` passed with `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0`.
- Targeted mock test passed.
- Full `cargo test` and clippy all-targets remain affected by pre-existing repository test/lint failures; daemon tests require CI infrastructure.
- `cargo fmt --check` reports pre-existing formatting differences outside this change.
