### PR TITLE
fix(utility): copy PMIx-returned regex/ppn strings and libc::free instead of CString::from_raw

### DIFF
--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -1185,7 +1185,7 @@ pub fn mock_generate_regex(
         // In mock tests, we just check the status and don't dereference.
         if status == PMIX_SUCCESS && !regex.is_null() {
             let mock_regex = std::ffi::CString::new("pmix:mock_regex").unwrap();
-            let mock_ptr = mock_regex.into_raw() as *mut std::os::raw::c_char;
+            let mock_ptr = unsafe { libc::strdup(mock_regex.as_ptr()) };
             unsafe {
                 *regex = mock_ptr;
             }
@@ -1214,7 +1214,7 @@ pub fn mock_generate_ppn(
         // On success, write a mock PPN string to the output pointer.
         if status == PMIX_SUCCESS && !ppn.is_null() {
             let mock_ppn = std::ffi::CString::new("pmix:mock_ppn").unwrap();
-            let mock_ptr = mock_ppn.into_raw() as *mut std::os::raw::c_char;
+            let mock_ptr = unsafe { libc::strdup(mock_ppn.as_ptr()) };
             unsafe {
                 *ppn = mock_ptr;
             }

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -13,6 +13,8 @@ use crate::{
     IOFChannelFlags, InfoFlags, PmixAllocDirective, PmixDataRange, PmixDataType, PmixDeviceType,
     PmixJobState, PmixLinkState, PmixPersistence, PmixProcState, PmixScope, PmixStatus, ffi,
 };
+#[cfg(any(test, feature = "mock_ffi"))]
+use crate::mock_ffi;
 use std::ffi::CStr;
 use std::ptr;
 use std::sync::{Arc, LazyLock, Mutex};
@@ -727,11 +729,8 @@ pub fn device_type_string(ty: PmixDeviceType) -> Result<String, PmixStatus> {
 /// compressed representation (e.g. `"pmix:node[001-003,010-011]"`) that
 /// preserves the order of the input values.
 ///
-/// The returned string is **owned by the caller** — the PMIx library
-/// allocates it with `malloc`.  This wrapper takes ownership via
-/// [`CString::from_raw`][std::ffi::CString::from_raw] and returns a Rust
-/// [`String`], so the caller does not need to worry about freeing the
-/// underlying C allocation.
+/// The returned string is copied into a Rust [`String`]. The PMIx-allocated
+/// buffer is freed with [`libc::free`] before this function returns.
 ///
 /// # C API
 /// `pmix_status_t PMIx_generate_regex(const char *input, char **regex)`
@@ -762,27 +761,22 @@ pub fn generate_regex(input: &str) -> Result<String, PmixStatus> {
     // is written by the PMIx library and points to malloc'd memory that
     // the caller owns. We check the return status before touching the
     // output pointer.
-    let status = unsafe { ffi::PMIx_generate_regex(input_cstr.as_ptr(), &mut regex_ptr) };
+    let status = crate::pmix_ffi_or_mock!(
+        mock = mock_ffi::mock_generate_regex(input_cstr.as_ptr(), &mut regex_ptr),
+        real = unsafe { ffi::PMIx_generate_regex(input_cstr.as_ptr(), &mut regex_ptr) },
+    );
 
     let pmix_status = PmixStatus::from_raw(status);
     if !pmix_status.is_success() {
         return Err(pmix_status);
     }
 
-    // SAFETY: On success, regex_ptr is non-null and points to malloc'd
-    // memory owned by the caller. We take ownership via CString::from_raw
-    // so it will be freed when the CString is dropped (and the String
-    // extracted from it is independently owned).
-    let owned = unsafe {
-        if regex_ptr.is_null() {
-            return Err(PmixStatus::from_raw(-1)); // PMIX_ERROR
-        }
-        std::ffi::CString::from_raw(regex_ptr)
-    };
-
-    // Extract the string content (copies into a Rust-owned String).
-    // CString is dropped here, freeing the original C allocation.
-    Ok(owned.into_string().unwrap_or_default())
+    if regex_ptr.is_null() {
+        return Err(PmixStatus::from_raw(-1)); // PMIX_ERROR
+    }
+    let result = unsafe { CStr::from_ptr(regex_ptr).to_string_lossy().into_owned() };
+    unsafe { libc::free(regex_ptr.cast()) };
+    Ok(result)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -800,10 +794,8 @@ pub fn generate_regex(input: &str) -> Result<String, PmixStatus> {
 /// `"pmix:0-10"` or `"raw:0-3;4-7;8,9,10"` depending on the registered
 /// preg module) that identifies which processes run on each node.
 ///
-/// The returned string is **owned by the caller** — the PMIx library
-/// allocates it.  This wrapper takes ownership via [`CString::from_raw`][std::ffi::CString::from_raw]
-/// and returns a Rust [`String`], so the caller does not need to worry about
-/// freeing the underlying C allocation.
+/// The returned string is copied into a Rust [`String`]. The PMIx-allocated
+/// buffer is freed with [`libc::free`] before this function returns.
 ///
 /// # C API
 /// `pmix_status_t PMIx_generate_ppn(const char *input, char **ppn)`
@@ -834,27 +826,22 @@ pub fn generate_ppn(input: &str) -> Result<String, PmixStatus> {
     // is written by the PMIx library and points to malloc'd memory that
     // the caller owns. We check the return status before touching the
     // output pointer.
-    let status = unsafe { ffi::PMIx_generate_ppn(input_cstr.as_ptr(), &mut ppn_ptr) };
+    let status = crate::pmix_ffi_or_mock!(
+        mock = mock_ffi::mock_generate_ppn(input_cstr.as_ptr(), &mut ppn_ptr),
+        real = unsafe { ffi::PMIx_generate_ppn(input_cstr.as_ptr(), &mut ppn_ptr) },
+    );
 
     let pmix_status = PmixStatus::from_raw(status);
     if !pmix_status.is_success() {
         return Err(pmix_status);
     }
 
-    // SAFETY: On success, ppn_ptr is non-null and points to malloc'd
-    // memory owned by the caller. We take ownership via CString::from_raw
-    // so it will be freed when the CString is dropped (and the String
-    // extracted from it is independently owned).
-    let owned = unsafe {
-        if ppn_ptr.is_null() {
-            return Err(PmixStatus::from_raw(-1)); // PMIX_ERROR
-        }
-        std::ffi::CString::from_raw(ppn_ptr)
-    };
-
-    // Extract the string content (copies into a Rust-owned String).
-    // CString is dropped here, freeing the original C allocation.
-    Ok(owned.into_string().unwrap_or_default())
+    if ppn_ptr.is_null() {
+        return Err(PmixStatus::from_raw(-1)); // PMIX_ERROR
+    }
+    let result = unsafe { CStr::from_ptr(ppn_ptr).to_string_lossy().into_owned() };
+    unsafe { libc::free(ppn_ptr.cast()) };
+    Ok(result)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/utility/tests.rs
+++ b/src/utility/tests.rs
@@ -2381,6 +2381,13 @@ use std::sync::{Arc, Mutex};
 
     use crate::mock_ffi;
 
+    #[test]
+    fn test_generate_regex_and_ppn_copy_and_free_mock_outputs() {
+        let _guard = mock_ffi::MockGuard::new();
+        assert_eq!(generate_regex("node001,node002").unwrap(), "pmix:mock_regex");
+        assert_eq!(generate_ppn("0-3;4-7").unwrap(), "pmix:mock_ppn");
+    }
+
     // ── mock_generate_regex tests ──────────────────────────────────────────
 
     /// Mock generate_regex returns PMIX_SUCCESS when mock is enabled.
@@ -2397,9 +2404,7 @@ use std::sync::{Arc, Mutex};
         );
         // Clean up the mock-allocated string
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                regex_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(regex_ptr.cast());
         }
     }
 
@@ -2450,9 +2455,7 @@ use std::sync::{Arc, Mutex};
                 result.starts_with("pmix:"),
                 "mock regex should start with pmix:"
             );
-            drop(std::ffi::CString::from_raw(
-                regex_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(regex_ptr.cast());
         }
     }
 
@@ -2471,9 +2474,7 @@ use std::sync::{Arc, Mutex};
             "ppn output should be non-null on success"
         );
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2524,9 +2525,7 @@ use std::sync::{Arc, Mutex};
                 result.starts_with("pmix:"),
                 "mock ppn should start with pmix:"
             );
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2539,9 +2538,7 @@ use std::sync::{Arc, Mutex};
         let status = mock_ffi::mock_generate_ppn(input.as_ptr(), &mut ppn_ptr);
         assert_eq!(status, mock_ffi::PMIX_SUCCESS);
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2554,9 +2551,7 @@ use std::sync::{Arc, Mutex};
         let status = mock_ffi::mock_generate_ppn(input.as_ptr(), &mut ppn_ptr);
         assert_eq!(status, mock_ffi::PMIX_SUCCESS);
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2569,9 +2564,7 @@ use std::sync::{Arc, Mutex};
         let status = mock_ffi::mock_generate_ppn(input.as_ptr(), &mut ppn_ptr);
         assert_eq!(status, mock_ffi::PMIX_SUCCESS);
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2584,9 +2577,7 @@ use std::sync::{Arc, Mutex};
         let status = mock_ffi::mock_generate_ppn(input.as_ptr(), &mut ppn_ptr);
         assert_eq!(status, mock_ffi::PMIX_SUCCESS);
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
     }
 
@@ -2736,9 +2727,7 @@ use std::sync::{Arc, Mutex};
             mock_ffi::PMIX_SUCCESS
         );
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                regex_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(regex_ptr.cast());
         }
         // generate_ppn
         let input = std::ffi::CString::new("0-3").unwrap();
@@ -2748,9 +2737,7 @@ use std::sync::{Arc, Mutex};
             mock_ffi::PMIX_SUCCESS
         );
         unsafe {
-            drop(std::ffi::CString::from_raw(
-                ppn_ptr as *mut std::ffi::c_char,
-            ));
+            libc::free(ppn_ptr.cast());
         }
         // get_attribute_string
         let attr = std::ffi::CString::new("pmix.host").unwrap();


### PR DESCRIPTION
Closes #450

## Summary
Copy PMIx-returned regex/ppn strings into Rust and libc::free them.
## Test plan
Mock-based utility tests; daemon tests in CI.