### PR TITLE
fix(info,argv,server,security,allocation): address batch of small correctness issues

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -308,8 +308,7 @@ pub trait AllocationCallback: Send + 'static {
 /// Maps request ID -> callback. Entries are removed when the callback fires.
 static ALLOCATION_REGISTRY: LazyLock<Registry<Box<dyn AllocationCallback>>> =
     LazyLock::new(Registry::new);
-static ALLOCATION_INFO_REGISTRY: LazyLock<Registry<(usize, usize)>> =
-    LazyLock::new(Registry::new);
+static ALLOCATION_INFO_REGISTRY: LazyLock<Registry<(usize, usize)>> = LazyLock::new(Registry::new);
 
 fn release_retained_info(req_id: usize) {
     if let Some((address, len)) = ALLOCATION_INFO_REGISTRY.remove(req_id) {

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -308,6 +308,19 @@ pub trait AllocationCallback: Send + 'static {
 /// Maps request ID -> callback. Entries are removed when the callback fires.
 static ALLOCATION_REGISTRY: LazyLock<Registry<Box<dyn AllocationCallback>>> =
     LazyLock::new(Registry::new);
+static ALLOCATION_INFO_REGISTRY: LazyLock<Registry<(usize, usize)>> =
+    LazyLock::new(Registry::new);
+
+fn release_retained_info(req_id: usize) {
+    if let Some((address, len)) = ALLOCATION_INFO_REGISTRY.remove(req_id) {
+        // SAFETY: the pair was created from Box::into_raw for this request and
+        // is removed at most once.
+        unsafe { drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            address as *mut ffi::pmix_info_t,
+            len,
+        ))) };
+    }
+}
 
 /// C bridge for `pmix_info_cbfunc_t` (allocation completion).
 ///
@@ -337,7 +350,8 @@ extern "C" fn allocation_callback_bridge(
     let cb = match cb {
         Some(cb) => cb,
         None => {
-            // Callback already consumed — free the info array to avoid leak.
+            // Callback already consumed — free retained request info and result array.
+            release_retained_info(req_id);
             if !info.is_null() && ninfo > 0 {
                 unsafe {
                     ffi::PMIx_Info_free(info, ninfo);
@@ -357,6 +371,7 @@ extern "C" fn allocation_callback_bridge(
     let _ = invoke_user_callback("allocation", move || {
         cb.on_complete(pmix_status, results);
     });
+    release_retained_info(req_id);
     // release_fn is unused — we manage our own memory via AllocationResults Drop.
     let _ = release_fn;
 }
@@ -414,13 +429,16 @@ pub fn allocation_request_nb(
             }
         })
         .collect();
-    let (info_ptr, ninfo) = if flat_infos.is_empty() {
-        (ptr::null_mut(), 0)
+    let ninfo = flat_infos.len();
+    let retained_infos = flat_infos.into_boxed_slice();
+    let info_ptr = if retained_infos.is_empty() {
+        ptr::null_mut()
     } else {
-        (
-            flat_infos.as_ptr() as *mut ffi::pmix_info_t,
-            flat_infos.len(),
-        )
+        let raw = Box::into_raw(retained_infos);
+        ALLOCATION_INFO_REGISTRY
+            .lock()
+            .insert(req_id, (raw as *mut ffi::pmix_info_t as usize, ninfo));
+        raw as *mut ffi::pmix_info_t
     };
 
     let status = unsafe {
@@ -446,9 +464,10 @@ pub fn allocation_request_nb(
     if pmix_status.is_success() {
         Ok(())
     } else {
-        // Request was rejected — remove the callback so it doesn't leak.
+        // Request was rejected — remove the callback and retained info.
         let mut registry = ALLOCATION_REGISTRY.lock();
         registry.remove(&req_id);
+        release_retained_info(req_id);
         Err(pmix_status)
     }
 }

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -314,10 +314,12 @@ fn release_retained_info(req_id: usize) {
     if let Some((address, len)) = ALLOCATION_INFO_REGISTRY.remove(req_id) {
         // SAFETY: the pair was created from Box::into_raw for this request and
         // is removed at most once.
-        unsafe { drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-            address as *mut ffi::pmix_info_t,
-            len,
-        ))) };
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                address as *mut ffi::pmix_info_t,
+                len,
+            )))
+        };
     }
 }
 

--- a/src/argv.rs
+++ b/src/argv.rs
@@ -94,6 +94,9 @@ fn read_c_argv(argv: *mut *mut c_char) -> Result<Vec<String>, PmixError> {
 }
 
 fn split_impl(src: &str, delimiter: char, kind: SplitKind) -> Result<Vec<String>, PmixError> {
+    if u32::from(delimiter) > 0xff {
+        return Err(PmixError::ErrBadParam);
+    }
     let source = CString::new(src).map_err(invalid_argument)?;
     let raw = crate::pmix_ffi_or_mock!(
         // SAFETY: source is a live NUL-terminated CString and the delimiter is a valid C int.
@@ -164,6 +167,9 @@ pub fn split_inter(
 
 /// Join strings with PMIx's argv join utility.
 pub fn join(argv: &[String], delimiter: char) -> Result<String, PmixError> {
+    if u32::from(delimiter) > 0xff {
+        return Err(PmixError::ErrBadParam);
+    }
     let cargv = to_c_argv(argv)?;
     let joined = crate::pmix_ffi_or_mock!(
         // SAFETY: cargv.ptr is a valid NULL-terminated array owned by cargv.
@@ -283,6 +289,14 @@ mod tests {
         assert_eq!(copy(&values).unwrap(), values);
         assert_eq!(join(&values, ',').unwrap(), "joined");
         assert_eq!(count(&values), 2);
+    }
+
+    #[test]
+    fn non_latin1_delimiters_are_rejected_before_ffi() {
+        assert_eq!(split("a😀b", '😀'), Err(PmixError::ErrBadParam));
+        assert_eq!(split_with_empty("a😀b", '😀'), Err(PmixError::ErrBadParam));
+        assert_eq!(split_inter("a😀b", '😀', true), Err(PmixError::ErrBadParam));
+        assert_eq!(join(&["a".to_owned()], '😀'), Err(PmixError::ErrBadParam));
     }
 
     #[test]

--- a/src/info.rs
+++ b/src/info.rs
@@ -496,16 +496,54 @@ impl PmixInfoList {
     }
 
     /// Convert the list without mutating it. An empty list returns
-    /// `PMIX_ERR_EMPTY`; on success the caller owns the returned array and must
-    /// release it with `PMIx_Data_array_destruct`.
-    pub fn convert(&self) -> Result<crate::ffi::pmix_data_array_t, crate::PmixStatus> {
+    /// `PMIX_ERR_EMPTY`; the returned array is released when its wrapper drops.
+    pub fn convert(&self) -> Result<ConvertedInfoArray, crate::PmixStatus> {
         // SAFETY: zeroed is a valid initial output value for PMIx to populate.
         let mut array = unsafe { std::mem::zeroed() };
         // SAFETY: self and output pointer are valid for the synchronous call.
         Self::status(crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_convert(self.as_ptr(), &mut array) },
             real = unsafe { crate::ffi::PMIx_Info_list_convert(self.as_ptr(), &mut array) },
-        )).map(|()| array)
+        ))
+        .map(|()| ConvertedInfoArray {
+            array,
+            _not_thread_safe: std::marker::PhantomData,
+        })
+    }
+}
+
+/// An owned array returned by [`PmixInfoList::convert`].
+pub struct ConvertedInfoArray {
+    array: crate::ffi::pmix_data_array_t,
+    _not_thread_safe: std::marker::PhantomData<*mut ()>,
+}
+
+impl ConvertedInfoArray {
+    /// Borrow the PMIx array for a synchronous consumer.
+    pub fn raw(&self) -> &crate::ffi::pmix_data_array_t {
+        &self.array
+    }
+
+    /// Return the mutable PMIx array pointer expected by C APIs.
+    pub fn as_mut_ptr(&mut self) -> *mut crate::ffi::pmix_data_array_t {
+        &mut self.array
+    }
+}
+
+impl std::ops::Deref for ConvertedInfoArray {
+    type Target = crate::ffi::pmix_data_array_t;
+
+    fn deref(&self) -> &Self::Target {
+        &self.array
+    }
+}
+
+impl Drop for ConvertedInfoArray {
+    fn drop(&mut self) {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_data_array_destruct(&mut self.array) },
+            real = unsafe { crate::ffi::PMIx_Data_array_destruct(&mut self.array) },
+        );
     }
 }
 
@@ -551,6 +589,14 @@ mod info_list_tests {
         crate::mock_ffi::set_mock_info_list_size(1);
         assert_eq!(list.len(), 1);
         assert_eq!(list.iter().len(), 1);
+    }
+
+    #[test]
+    fn converted_info_array_is_owned_by_raii_wrapper() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let list = PmixInfoList::new().unwrap();
+        let converted = list.convert().unwrap();
+        let _ = converted.raw();
     }
 
     #[test]

--- a/src/info.rs
+++ b/src/info.rs
@@ -541,7 +541,11 @@ impl std::ops::Deref for ConvertedInfoArray {
 impl Drop for ConvertedInfoArray {
     fn drop(&mut self) {
         crate::pmix_ffi_or_mock!(
+            // SAFETY: self.array owns a valid, destructible mock data array and
+            // this Drop implementation destroys it exactly once.
             mock = unsafe { crate::mock_ffi::mock_data_array_destruct(&mut self.array) },
+            // SAFETY: self.array owns a valid, destructible PMIx data array and
+            // this Drop implementation destroys it exactly once.
             real = unsafe { crate::ffi::PMIx_Data_array_destruct(&mut self.array) },
         );
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1708,7 +1708,7 @@ pub(crate) extern "C" fn setup_application_callback_bridge(
     if let Some(ack) = cbfunc {
         // SAFETY: cbfunc and cbdata are provided by PMIx and are valid
         // for the duration of this callback invocation.
-        unsafe { ack(ffi::PMIX_SUCCESS as ffi::pmix_status_t, cbdata) };
+        unsafe { ack(status, cbdata) };
     }
 
     // Look up and remove the callback from the registry.


### PR DESCRIPTION
Closes #452

## Summary
- Wrap `PmixInfoList::convert` results in an RAII `ConvertedInfoArray` that destructs PMIx data arrays exactly once and is non-Send/non-Sync.
- Reject non-Latin-1 delimiters in argv split/join wrappers before FFI conversion.
- Forward the real setup-application completion status to the PMIx acknowledgement callback.
- `get_credential` already uses `Box::from_raw` for the Rust-allocated output and PMIx `free` only for its byte buffer; no additional change was needed in the current main.
- Retain flattened allocation info in a registry-backed heap allocation until the completion bridge releases it, avoiding the host-server threadshift UAF.

Affected functions: `PmixInfoList::convert`, argv split/join wrappers, `setup_application_callback_bridge`, `get_credential` audit, `allocation_request_nb`, and `allocation_callback_bridge`.

Rationale: preserve PMIx ownership and lifetime contracts across fallible Rust paths, reject lossy character conversions, propagate callback status accurately, and keep asynchronous input arrays alive until PMIx is finished.

## Test plan
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo build` — passed.
- `PMIX_PREFIX=$HOME/.local/openpmix-6.1.0 cargo test --lib` — passed (1859 passed, 29 ignored).
- Mock regression coverage for RAII conversion and non-Latin-1 argv delimiters; daemon tests remain for CI only.
- Full `cargo test`, `cargo clippy --all-targets -- -D warnings`, and repository `cargo fmt --check` remain affected by pre-existing unrelated test/generated-binding warnings and formatting drift; details are in the PR checks/comments.