### PR TITLE
fix(lib): correct PmixPersistence repr, make PmixDataRange::Unknown lossless

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -855,7 +855,7 @@ pub fn notify_event(
         ffi::PMIx_Notify_event(
             status.to_raw(),
             &source.handle as *const ffi::pmix_proc_t,
-            range as ffi::pmix_data_range_t,
+            range.to_raw() as ffi::pmix_data_range_t,
             info_ptr,
             ninfo,
             None, // blocking mode
@@ -918,7 +918,7 @@ pub fn notify_event_nb(
         ffi::PMIx_Notify_event(
             status.to_raw(),
             source_ptr,
-            range as ffi::pmix_data_range_t,
+            range.to_raw() as ffi::pmix_data_range_t,
             info_ptr,
             ninfo,
             Some(notify_state_bridge),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1361,7 +1361,7 @@ impl std::fmt::Display for PmixDeviceType {
 /// # C API
 /// `typedef uint8_t pmix_persistence_t`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(usize)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum PmixPersistence {
     /// `PMIX_PERSIST_INDEF` (0) — retain until specifically deleted.
@@ -1383,7 +1383,7 @@ pub enum PmixPersistence {
     Invalid = 255,
 
     /// An unrecognised or future persistence value.
-    Unknown(u8),
+    Unknown(u8) = 128,
 }
 
 impl PmixPersistence {
@@ -1480,7 +1480,7 @@ pub enum PmixDataRange {
     Invalid = 255,
 
     /// An unrecognised or future range value.
-    Unknown = 128,
+    Unknown(u8) = 128,
 }
 
 impl PmixDataRange {
@@ -1496,14 +1496,14 @@ impl PmixDataRange {
             6 => Self::Custom,
             7 => Self::ProcLocal,
             255 => Self::Invalid,
-            _other => Self::Unknown,
+            other => Self::Unknown(other),
         }
     }
 
     /// Return the raw `u8` value suitable for passing to the C API.
     pub fn to_raw(self) -> u8 {
         match self {
-            Self::Unknown => 128,
+            Self::Unknown(v) => v,
             Self::Undef => 0,
             Self::Rm => 1,
             Self::Local => 2,
@@ -1529,7 +1529,7 @@ impl std::fmt::Display for PmixDataRange {
             Self::Custom => write!(f, "CUSTOM"),
             Self::ProcLocal => write!(f, "PROC LOCAL"),
             Self::Invalid => write!(f, "INVALID"),
-            Self::Unknown => write!(f, "UNKNOWN RANGE (128)"),
+            Self::Unknown(v) => write!(f, "UNKNOWN RANGE ({v})"),
         }
     }
 }
@@ -4751,7 +4751,7 @@ mod tests {
 
     #[test]
     fn test_pmix_data_range_from_raw_unknown() {
-        assert_eq!(PmixDataRange::from_raw(99), PmixDataRange::Unknown);
+        assert_eq!(PmixDataRange::from_raw(99), PmixDataRange::Unknown(99));
     }
 
     #[test]
@@ -4766,7 +4766,7 @@ mod tests {
             PmixDataRange::Custom,
             PmixDataRange::ProcLocal,
             PmixDataRange::Invalid,
-            PmixDataRange::Unknown,
+            PmixDataRange::Unknown(128),
         ];
         for range in ranges {
             let raw = range.to_raw();

--- a/src/utility/tests.rs
+++ b/src/utility/tests.rs
@@ -733,7 +733,7 @@ use std::sync::{Arc, Mutex};
     #[test]
     fn test_data_range_string_unknown() {
         use crate::PmixDataRange::Unknown;
-        let range = Unknown;
+        let range = Unknown(99);
         let result = data_range_string(range);
         assert!(
             result.is_ok(),
@@ -801,7 +801,7 @@ use std::sync::{Arc, Mutex};
         assert_eq!(PmixDataRange::from_raw(6), Custom);
         assert_eq!(PmixDataRange::from_raw(7), ProcLocal);
         assert_eq!(PmixDataRange::from_raw(255), Invalid);
-        assert!(matches!(PmixDataRange::from_raw(200), Unknown));
+        assert!(matches!(PmixDataRange::from_raw(200), Unknown(_)));
     }
 
     /// `PmixDataRange::to_raw` returns the expected raw values.
@@ -818,7 +818,7 @@ use std::sync::{Arc, Mutex};
         assert_eq!(Custom.to_raw(), 6);
         assert_eq!(ProcLocal.to_raw(), 7);
         assert_eq!(Invalid.to_raw(), 255);
-        assert_eq!(Unknown.to_raw(), 128);
+        assert_eq!(Unknown(128).to_raw(), 128);
     }
 
     /// `PmixDataRange` implements Display.
@@ -835,7 +835,7 @@ use std::sync::{Arc, Mutex};
         assert_eq!(format!("{}", Custom), "CUSTOM");
         assert_eq!(format!("{}", ProcLocal), "PROC LOCAL");
         assert_eq!(format!("{}", Invalid), "INVALID");
-        assert_eq!(format!("{}", Unknown), "UNKNOWN RANGE (128)");
+        assert_eq!(format!("{}", Unknown(128)), "UNKNOWN RANGE (128)");
     }
 
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #483
Closes #484

## Summary
- PmixPersistence: #[repr(usize)] -> #[repr(u8)] to match C pmix_persistence_t (uint8_t).
- PmixDataRange::Unknown: unit variant (discriminant 128) -> Unknown(u8) so to_raw(from_raw(x)) round-trips losslessly, matching sibling enums (PmixScope, PmixJobState, PmixPersistence).
- Updated test call sites that constructed Unknown as a unit variant.
- Updated event FFI conversions to use the enum's lossless to_raw conversion now that PmixDataRange carries unknown values.

## Test plan
- cargo build: pass
- cargo test --lib -- --test-threads=1: pass (1859 passed, 29 ignored)
- cargo clippy --lib -- -D warnings: blocked by pre-existing generated bindings missing safety docs
- cargo check --features mock_ffi --lib: pass
