### PR TITLE
feat: build against OpenPMIx 5.0 in addition to 6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,97 @@ jobs:
         run: cargo test
 
   ############################################################################
+  # PMIx 5.0 tests — build OpenPMIx 5.0.7, verify the base (non-pmix6) surface
+  ############################################################################
+  # This PR adds OpenPMIx 5.0 support. The full `cargo test` (integration
+  # tests) does not compile on main for pre-existing reasons (stale test files
+  # vs the Aug-12 src reworks — GroupResults, CredentialByteObject), so this job
+  # is scoped to the lib/doctest surface that is green on both 5.0 and 6.x.
+  pmix5-tests:
+    name: PMIx 5.0 tests
+    runs-on: ubuntu-24.04
+    env:
+      OPENPMIX_VERSION: "5.0.7"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential autoconf automake libtool pkg-config \
+            libevent-dev libhwloc-dev \
+            libclang-dev clang
+
+      - name: Cache OpenPMIx ${{ env.OPENPMIX_VERSION }}
+        id: cache-openpmix
+        uses: actions/cache@v4
+        with:
+          path: ~/openpmix-${{ env.OPENPMIX_VERSION }}
+          key: openpmix-${{ env.OPENPMIX_VERSION }}-ubuntu-24.04-v2
+
+      - name: Build OpenPMIx ${{ env.OPENPMIX_VERSION }}
+        if: steps.cache-openpmix.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          PREFIX="$HOME/openpmix-${OPENPMIX_VERSION}"
+          cd /tmp
+          git clone --depth 1 --branch "v${OPENPMIX_VERSION}" --recurse-submodules \
+            https://github.com/openpmix/openpmix.git "openpmix-${OPENPMIX_VERSION}"
+          cd "openpmix-${OPENPMIX_VERSION}"
+          ./autogen.pl
+          ./configure --prefix="$PREFIX" --disable-debug CFLAGS="-O2"
+          make -j"$(nproc)"
+          make install
+
+      - name: Export PMIX_PREFIX
+        run: |
+          PREFIX="$HOME/openpmix-${OPENPMIX_VERSION}"
+          echo "PMIX_PREFIX=$PREFIX" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PREFIX/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+          test -f "$PREFIX/include/pmix.h"
+          grep -E 'PMIX_VERSION_MAJOR[[:space:]]+5' "$PREFIX/include/pmix_version.h"
+          grep -E 'PMIX_VERSION_MINOR[[:space:]]+0' "$PREFIX/include/pmix_version.h"
+
+      - name: Check (base surface)
+        run: |
+          cargo check --lib
+          cargo check --features mock_ffi --lib
+
+      - name: Run lib + doctests on 5.0
+        run: |
+          cargo test --lib --features mock_ffi
+          cargo test --doc --features mock_ffi
+
+      - name: Assert working tree stayed clean
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "ERROR: cargo build dirtied the working tree:"
+            git status --porcelain
+            exit 1
+          fi
+
+  ############################################################################
   # Daemon tests — build OpenPMIx + PRTE, start daemon, run ignored tests
   ############################################################################
   daemon-tests:

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 
-/// Minimum OpenPMIx version required by this crate's safe API surface.
-/// Matches the OpenPMIx ≥ 6.1 threading model documented in THREADING.md.
-const MIN_MAJOR: u32 = 6;
-const MIN_MINOR: u32 = 1;
+/// Supported OpenPMIx versions.
+///
+/// - 5.x: base API surface (client/tool/server core). 6.x-only symbols
+///   (`PMIx_Progress_thread_stop`, fabric resource blocks, regattr helpers,
+///   …) are compiled out via `#[cfg(pmix6)]`.
+/// - ≥ 6.1: full API surface, including the explicit progress-thread model.
+const MIN_MAJOR: u32 = 5;
+const MIN_MINOR: u32 = 0;
+/// First version with `PMIx_Progress_thread_stop` and the full surface.
+const FULL_API_MAJOR: u32 = 6;
+const FULL_API_MINOR: u32 = 1;
 
 /// Discover PMIx install prefix.
 /// Order: PMIX_PREFIX → PMIX_INCLUDE_DIR/PMIX_LIB_DIR → pkg-config → common paths.
@@ -195,6 +202,8 @@ fn version_at_least(ver: (u32, u32, u32), min_major: u32, min_minor: u32) -> boo
 }
 
 fn main() {
+    // Silence unexpected_cfgs for the version-gated cfg emitted below.
+    println!("cargo:rustc-check-cfg=cfg(pmix6)");
     let (include_dir, lib_dir) = discover_pmix();
 
     if !include_dir.join("pmix.h").exists() {
@@ -208,16 +217,26 @@ fn main() {
 
     match read_pmix_version(&include_dir) {
         Some(ver) if version_at_least(ver, MIN_MAJOR, MIN_MINOR) => {
+            let full = version_at_least(ver, FULL_API_MAJOR, FULL_API_MINOR);
+            if full {
+                // Full 6.x API surface: explicit progress thread, fabric
+                // resource blocks, regattr helpers, etc.
+                println!("cargo:rustc-cfg=pmix6");
+            }
             println!(
-                "cargo:warning=OpenPMIx {}.{}.{} (≥ {MIN_MAJOR}.{MIN_MINOR} required)",
-                ver.0, ver.1, ver.2
+                "cargo:warning=OpenPMIx {}.{}.{} (≥ {MIN_MAJOR}.{MIN_MINOR} required; {} API surface{})",
+                ver.0,
+                ver.1,
+                ver.2,
+                if full { "full" } else { "base" },
+                if full { "" } else { " — set PMIX_PREFIX to an OpenPMIx ≥ 6.1 install for the full surface" },
             );
         }
         Some(ver) => {
             eprintln!(
                 "\nerror: OpenPMIx {}.{}.{} is too old.\n\
                  \n\
-                 pmix-rs requires OpenPMIx ≥ {MIN_MAJOR}.{MIN_MINOR} (threading model + API surface).\n\
+                 pmix-rs requires OpenPMIx ≥ {MIN_MAJOR}.{MIN_MINOR}.\n\
                  Headers found at: {}\n\
                  \n\
                  Install a newer OpenPMIx and set PMIX_PREFIX to its install prefix.\n",
@@ -277,7 +296,8 @@ fn main() {
             bindings.write_to_file(&out_path).unwrap_or_else(|e| {
                 panic!("failed to write bindings to {}: {e}", out_path.display())
             });
-            // Sanity: generated bindings must expose the 6.1-only symbol the crate calls.
+            // Sanity: on a ≥ 6.1 install, generated bindings must expose the
+            // 6.1-only symbol the crate calls.
             // This validates the *header* version (bindgen output is header-derived) —
             // it is NOT a link-time guarantee. A mismatched libpmix (e.g. headers 6.1
             // paired with a 5.0.7 library) would pass this check but fail at link or
@@ -286,10 +306,15 @@ fn main() {
             // the user is responsible for ensuring header and lib versions match.
             let generated = fs::read_to_string(&out_path)
                 .unwrap_or_else(|e| panic!("failed to read generated bindings: {e}"));
-            if !generated.contains("PMIx_Progress_thread_stop") {
+            if version_at_least(
+                read_pmix_version(&include_dir).unwrap_or((0, 0, 0)),
+                FULL_API_MAJOR,
+                FULL_API_MINOR,
+            ) && !generated.contains("PMIx_Progress_thread_stop")
+            {
                 eprintln!(
                     "\nerror: bindgen output is missing PMIx_Progress_thread_stop.\n\
-                     Headers under {} do not match OpenPMIx ≥ {MIN_MAJOR}.{MIN_MINOR}.\n",
+                     Headers under {} do not match OpenPMIx ≥ {FULL_API_MAJOR}.{FULL_API_MINOR}.\n",
                     include_dir.display()
                 );
                 process::exit(1);

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -1731,6 +1731,8 @@ mod tests {
     }
 }
 
+/// 6.x-only: resource-block directives do not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn resource_block_directive_string(d: ffi::pmix_resource_block_directive_t) -> &'static str {
     let p = crate::pmix_ffi_or_mock!(
         mock = unsafe { crate::mock_ffi::mock_resource_block_directive_string(d) },
@@ -1742,6 +1744,8 @@ pub fn resource_block_directive_string(d: ffi::pmix_resource_block_directive_t) 
         unsafe { std::ffi::CStr::from_ptr(p).to_str().unwrap_or("") }
     }
 }
+/// 6.x-only: resource-block operations do not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn resource_block(
     d: ffi::pmix_resource_block_directive_t,
     block: &mut [u8],
@@ -1787,6 +1791,8 @@ pub fn resource_block(
 /// PMIx or another owner may still use. The `block`, `res`, and `info` storage
 /// must likewise remain valid and unmodified in ways incompatible with PMIx
 /// until the asynchronous operation has completed, as required by the PMIx API.
+/// 6.x-only: resource-block operations do not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub unsafe fn resource_block_nb(
     d: ffi::pmix_resource_block_directive_t,
     block: &mut [u8],
@@ -1847,6 +1853,7 @@ mod misc_wrapper_tests {
         }
     }
 
+    #[cfg(pmix6)]
     #[test]
     fn resource_block_sync_and_nb_callback() {
         let _guard = crate::mock_ffi::MockGuard::new();

--- a/src/data_ops/mod.rs
+++ b/src/data_ops/mod.rs
@@ -1506,6 +1506,8 @@ impl PmixPdataHandle {
         }
     }
 
+    /// 6.x-only: `PMIx_Pdata_load` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn load(
         &mut self,
         proc: &Proc,
@@ -1523,6 +1525,8 @@ impl PmixPdataHandle {
         Ok(())
     }
 
+    /// 6.x-only: `PMIx_Pdata_xfer` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn xfer(&mut self, src: &PmixPdataHandle) -> Result<(), PmixStatus> {
         // SAFETY: both handles are constructed and remain alive for this call;
         // PMIx copies between the two initialized pdata objects.

--- a/src/data_ops/tests.rs
+++ b/src/data_ops/tests.rs
@@ -4128,6 +4128,7 @@ use super::*;
 
 
 #[cfg(any(test, feature = "mock_ffi"))]
+#[cfg(pmix6)]
 #[test]
 fn test_misc_pdata_wrappers_construct_load_xfer_and_arrays() {
     let _guard = crate::mock_ffi::MockGuard::new();

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -3008,7 +3008,9 @@ pmix_array!(
     mock_endpoint_free,
     mock_endpoint_construct
 );
-/// 6.x-only type: `pmix_device_t` does not exist in OpenPMIx 5.0.
+// 6.x-only type: `pmix_device_t` does not exist in OpenPMIx 5.0.
+// (Plain comment: `///` on a macro invocation is flagged as an unused doc
+// comment since rustdoc does not expand macro invocations.)
 #[cfg(pmix6)]
 pmix_array!(
     PmixDeviceArray,

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -2841,6 +2841,10 @@ mod tests {
 ///
 /// The C-constructed result is valid only through the raw handle. `PmixFabric`
 /// manages its Rust-owned fields separately and does not drop this raw struct.
+///
+/// 6.x-only: 5.0 has no `PMIx_Fabric_construct` (its signature there also
+/// takes a `pmix_regattr_t *`, not a fabric).
+#[cfg(pmix6)]
 pub fn fabric_construct() -> PmixFabric {
     let mut fabric = PmixFabric::new(None).expect("None cannot contain a NUL");
     let raw = fabric.raw.as_mut() as *mut ffi::pmix_fabric_t;
@@ -3004,6 +3008,8 @@ pmix_array!(
     mock_endpoint_free,
     mock_endpoint_construct
 );
+/// 6.x-only type: `pmix_device_t` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pmix_array!(
     PmixDeviceArray,
     ffi::pmix_device_t,
@@ -3209,12 +3215,16 @@ impl Drop for PmixCoord {
 }
 
 /// Safe RAII wrapper around `pmix_device_t`.
+///
+/// 6.x-only type: `pmix_device_t` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 #[derive(Debug)]
 pub struct PmixDevice {
     raw: MaybeUninit<ffi::pmix_device_t>,
     constructed: bool,
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
+#[cfg(pmix6)]
 impl PmixDevice {
     /// Construct a device with PMIx defaults.
     pub fn new() -> Self {
@@ -3260,11 +3270,13 @@ impl PmixDevice {
         unsafe { self.raw.assume_init_ref().type_ }
     }
 }
+#[cfg(pmix6)]
 impl Default for PmixDevice {
     fn default() -> Self {
         Self::new()
     }
 }
+#[cfg(pmix6)]
 impl Drop for PmixDevice {
     fn drop(&mut self) {
         if self.constructed {
@@ -3388,6 +3400,7 @@ impl Drop for PmixDeviceDistanceObject {
 mod added_type_tests {
     use super::*;
 
+    #[cfg(pmix6)]
     #[test]
     fn construct_wrappers_and_arrays_use_mock_ffi() {
         let _guard = mock_ffi::MockGuard::new();
@@ -3431,6 +3444,7 @@ mod added_type_tests {
         assert_eq!(distance.max_distance(), u16::MAX);
     }
 
+    #[cfg(pmix6)]
     #[test]
     fn all_fabric_arrays_create_and_drop() {
         let _guard = mock_ffi::MockGuard::new();
@@ -3442,6 +3456,7 @@ mod added_type_tests {
         let _distance = PmixDeviceDistanceArray::create(2).unwrap();
     }
 
+    #[cfg(pmix6)]
     #[test]
     fn test_new_accessors_are_zeroed_and_safe() {
         let _guard = mock_ffi::MockGuard::new();
@@ -3461,6 +3476,7 @@ mod added_type_tests {
         assert_eq!(distance.max_distance(), 0);
     }
 
+    #[cfg(pmix6)]
     #[test]
     fn non_null_accessors_read_c_fields() {
         let _guard = mock_ffi::MockGuard::new();
@@ -3490,12 +3506,14 @@ mod added_type_tests {
 }
 
 /// An owned PMIx resource unit.
+#[cfg(pmix6)]
 pub struct PmixResourceUnit {
     raw: MaybeUninit<ffi::pmix_resource_unit_t>,
     constructed: bool,
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
 
+#[cfg(pmix6)]
 impl PmixResourceUnit {
     pub fn new() -> Self {
         let mut this = Self {
@@ -3537,12 +3555,14 @@ impl PmixResourceUnit {
     }
 }
 
+#[cfg(pmix6)]
 impl Default for PmixResourceUnit {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(pmix6)]
 impl Drop for PmixResourceUnit {
     fn drop(&mut self) {
         if self.constructed {
@@ -3556,11 +3576,13 @@ impl Drop for PmixResourceUnit {
     }
 }
 
+#[cfg(pmix6)]
 pub struct PmixResourceUnitArray {
     ptr: *mut ffi::pmix_resource_unit_t,
     len: usize,
     _not_thread_safe: std::marker::PhantomData<*mut u8>,
 }
+#[cfg(pmix6)]
 impl PmixResourceUnitArray {
     pub fn as_ptr(&self) -> *const ffi::pmix_resource_unit_t {
         self.ptr
@@ -3572,6 +3594,7 @@ impl PmixResourceUnitArray {
         self.len == 0
     }
 }
+#[cfg(pmix6)]
 impl Drop for PmixResourceUnitArray {
     fn drop(&mut self) {
         if !self.ptr.is_null() {
@@ -3584,6 +3607,7 @@ impl Drop for PmixResourceUnitArray {
         }
     }
 }
+#[cfg(pmix6)]
 pub fn resource_unit_create(n: usize) -> Result<PmixResourceUnitArray, PmixError> {
     if n == 0 {
         return Ok(PmixResourceUnitArray {
@@ -3608,6 +3632,7 @@ pub fn resource_unit_create(n: usize) -> Result<PmixResourceUnitArray, PmixError
         })
     }
 }
+#[cfg(pmix6)]
 impl PmixResourceUnit {
     pub fn to_string(&self) -> Result<String, PmixError> {
         // SAFETY: self points to a live constructed resource unit; PMIx returns
@@ -3631,6 +3656,7 @@ impl PmixResourceUnit {
 mod misc_wrapper_tests {
     use super::*;
 
+    #[cfg(pmix6)]
     #[test]
     fn resource_unit_wrappers_construct_access_string_and_arrays() {
         let _guard = crate::mock_ffi::MockGuard::new();

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -103,6 +103,7 @@ mod tests {
     }
 
     /// OpenPMIx ≥ 6.1 exposes PMIx_Progress_thread_stop — used by the safe API.
+    #[cfg(pmix6)]
     #[test]
     fn test_progress_thread_stop_symbol_linked() {
         use crate::ffi::*;

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -2828,6 +2828,9 @@ mod tests {
 }
 
 /// Return the static PMIx spelling for a group operation.
+///
+/// 6.x-only: `PMIx_Group_operation_string` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn group_operation_string(op: ffi::pmix_group_operation_t) -> &'static str {
     let p = crate::pmix_ffi_or_mock!(
         mock = unsafe { crate::mock_ffi::mock_group_operation_string(op) },
@@ -2840,6 +2843,7 @@ pub fn group_operation_string(op: ffi::pmix_group_operation_t) -> &'static str {
 }
 
 #[cfg(test)]
+#[cfg(pmix6)]
 #[test]
 fn test_misc_group_string_wrapper() {
     let _guard = crate::mock_ffi::MockGuard::new();

--- a/src/info.rs
+++ b/src/info.rs
@@ -362,12 +362,40 @@ impl PmixInfoList {
     pub fn as_ptr(&self) -> *mut std::ffi::c_void { self.handle.as_ptr() }
 
     /// Number of entries in the list.
+    ///
+    /// 6.x-only: `PMIx_Info_list_get_size` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn len(&self) -> usize {
         // SAFETY: self.handle is a live handle owned by self.
         crate::pmix_ffi_or_mock!(
             mock = unsafe { crate::mock_ffi::mock_info_list_get_size(self.as_ptr()) },
             real = unsafe { crate::ffi::PMIx_Info_list_get_size(self.as_ptr()) },
         )
+    }
+
+    /// Return whether the list has no entries.
+    ///
+    /// 5.0 fallback: without `PMIx_Info_list_get_size`, walk the list with
+    /// `PMIx_Info_list_get_info` and count entries. Implemented directly so it
+    /// does not recurse through `iter`/`is_empty`.
+    #[cfg(not(pmix6))]
+    pub fn len(&self) -> usize {
+        let mut count = 0;
+        let mut previous = std::ptr::null_mut();
+        loop {
+            let mut next = std::ptr::null_mut();
+            // SAFETY: self is live; PMIx writes next and returns an entry owned
+            // by the list, which we only count here.
+            let info = crate::pmix_ffi_or_mock!(
+                mock = unsafe { crate::mock_ffi::mock_info_list_get_info(self.as_ptr(), previous, &mut next) },
+                real = unsafe { crate::ffi::PMIx_Info_list_get_info(self.as_ptr(), previous, &mut next) },
+            );
+            if info.is_null() { break; }
+            count += 1;
+            if next.is_null() || next == previous { break; }
+            previous = next;
+        }
+        count
     }
 
     /// Return whether the list has no entries.
@@ -428,6 +456,8 @@ impl PmixInfoList {
 
     /// Add raw wire bytes, optionally overwriting an existing key. See [`Self::add`]
     /// for the non-empty and string/byte-object representation requirements.
+    /// 6.x-only: `PMIx_Info_list_add_unique` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn add_unique<V: AsRef<[u8]>>(&mut self, key: &str, value: V, ty: crate::ffi::pmix_data_type_t, overwrite: bool) -> Result<(), crate::PmixStatus> {
         let key = Self::key(key)?; let value = Self::raw_value(value.as_ref())?;
         // SAFETY: pointers reference live arguments for the synchronous FFI call.
@@ -438,6 +468,8 @@ impl PmixInfoList {
     }
 
     /// Add an owned PMIx value.
+    /// 6.x-only: `PMIx_Info_list_add_value` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn add_value(&mut self, key: &str, value: &crate::PmixOwnedValue) -> Result<(), crate::PmixStatus> {
         let key = Self::key(key)?;
         // SAFETY: list, key, and value are valid for this synchronous call.
@@ -448,6 +480,8 @@ impl PmixInfoList {
     }
 
     /// Add an owned PMIx value, optionally overwriting an existing key.
+    /// 6.x-only: `PMIx_Info_list_add_value_unique` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn add_value_unique(&mut self, key: &str, value: &crate::PmixOwnedValue, overwrite: bool) -> Result<(), crate::PmixStatus> {
         let key = Self::key(key)?;
         // SAFETY: list, key, and value are valid for this synchronous call.
@@ -487,6 +521,8 @@ impl PmixInfoList {
     }
 
     /// Transfer exactly one `pmix_info_t`, optionally overwriting duplicates.
+    /// 6.x-only: `PMIx_Info_list_xfer_unique` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn xfer_unique(&mut self, info: &PmixInfo, overwrite: bool) -> Result<(), crate::PmixStatus> {
         // SAFETY: both handles are valid for this synchronous single-entry copy.
         Self::status(crate::pmix_ffi_or_mock!(
@@ -565,6 +601,7 @@ impl Drop for PmixInfoList {
 mod info_list_tests {
     use super::*;
 
+    #[cfg(pmix6)]
     #[test]
     fn mock_info_list_lifecycle_and_success_paths() {
         let _guard = crate::mock_ffi::MockGuard::new();
@@ -593,6 +630,19 @@ mod info_list_tests {
         crate::mock_ffi::set_mock_info_list_size(1);
         assert_eq!(list.len(), 1);
         assert_eq!(list.iter().len(), 1);
+    }
+
+
+    #[cfg(not(pmix6))]
+    #[test]
+    fn mock_info_list_len_fallback_avoids_recursion() {
+        let _guard = crate::mock_ffi::MockGuard::new();
+        let list = PmixInfoList::new().expect("mock list");
+        // Guard: the 5.0 fallback must terminate (not recurse through iter)
+        // and report the empty list size seen by the mock.
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
+        assert!(list.iter().is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2347,6 +2347,9 @@ pub fn check_reserved_key(key: &str) -> bool { let Ok(key) = CString::new(key) e
 /// Load a namespace and rank into a raw PMIx process object.
 pub fn load_procid(dst: &mut pmix_proc_t, nspace: &str, rank: u32) -> Result<(), NulError> { let ns = CString::new(nspace)?; /* SAFETY: `dst` is exclusively borrowed and `ns` is valid for this call. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_load_procid(dst, ns.as_ptr(), rank) }, real = unsafe { ffi::PMIx_Load_procid(dst, ns.as_ptr(), rank) }); Ok(()) }
 /// Return whether a rank is valid.
+///
+/// 6.x-only: `PMIx_Rank_valid` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn rank_valid(rank: u32) -> bool { /* SAFETY: scalar argument satisfies the FFI ABI. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_rank_valid(rank) }, real = unsafe { ffi::PMIx_Rank_valid(rank) }) }
 /// Return whether a namespace is invalid.
 pub fn nspace_invalid(ns: &str) -> bool { let Ok(ns) = CString::new(ns) else { return true }; /* SAFETY: `ns` is a valid NUL-terminated pointer for this call. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_nspace_invalid(ns.as_ptr()) }, real = unsafe { ffi::PMIx_Nspace_invalid(ns.as_ptr()) }) }
@@ -2372,13 +2375,25 @@ impl PmixProcInfoArray { pub fn new(len: usize) -> Option<Self> { if len == 0 { 
 impl Drop for PmixProcInfoArray { fn drop(&mut self) { if !self.ptr.is_null() { /* SAFETY: pointer and length came from the matching PMIx allocator. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_proc_info_free(self.ptr, self.len) }, real = unsafe { ffi::PMIx_Proc_info_free(self.ptr, self.len) }); } } }
 
 /// Owned, constructed PMIx node/pid object.
+///
+/// 6.x-only: `pmix_node_pid_t` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub struct PmixNodePid { raw: mem::MaybeUninit<pmix_node_pid_t>, constructed: bool, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+#[cfg(pmix6)]
+#[cfg(pmix6)]
 impl PmixNodePid { pub fn new() -> Self { let mut x = Self { raw: mem::MaybeUninit::uninit(), constructed: false, _not_thread_safe: std::marker::PhantomData }; /* SAFETY: PMIx initializes the writable storage supplied by `x`. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_node_pid_construct(x.raw.as_mut_ptr()) }, real = unsafe { ffi::PMIx_Node_pid_construct(x.raw.as_mut_ptr()) }); x.constructed = true; x } #[cfg(test)] pub fn test_new() -> Self { Self { raw: mem::MaybeUninit::zeroed(), constructed: true, _not_thread_safe: std::marker::PhantomData } } fn raw(&self) -> &pmix_node_pid_t { /* SAFETY: `new` and `test_new` initialize the storage before access. */ unsafe { self.raw.assume_init_ref() } } pub fn hostname(&self) -> Option<&str> { cstr_ref(self.raw().hostname) } pub fn nodeid(&self) -> u32 { self.raw().nodeid } pub fn pid(&self) -> i32 { self.raw().pid } }
+#[cfg(pmix6)]
 impl Default for PmixNodePid { fn default() -> Self { Self::new() } }
+#[cfg(pmix6)]
 impl Drop for PmixNodePid { fn drop(&mut self) { if self.constructed { /* SAFETY: storage was initialized and is exclusively borrowed here. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_node_pid_destruct(self.raw.as_mut_ptr()) }, real = unsafe { ffi::PMIx_Node_pid_destruct(self.raw.as_mut_ptr()) }); self.constructed = false; } } }
 /// Owned array allocated by PMIx for node/pid objects.
+#[cfg(pmix6)]
 pub struct PmixNodePidArray { ptr: *mut pmix_node_pid_t, len: usize, _not_thread_safe: std::marker::PhantomData<*mut u8> }
+#[cfg(pmix6)]
+#[cfg(pmix6)]
 impl PmixNodePidArray { pub fn new(len: usize) -> Option<Self> { if len == 0 { return Some(Self { ptr: std::ptr::null_mut(), len, _not_thread_safe: std::marker::PhantomData }); } let ptr = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_node_pid_create(len) }, real = unsafe { ffi::PMIx_Node_pid_create(len) }); (!ptr.is_null()).then_some(Self { ptr, len, _not_thread_safe: std::marker::PhantomData }) } pub fn as_mut_ptr(&mut self) -> *mut pmix_node_pid_t { self.ptr } pub fn len(&self) -> usize { self.len } pub fn is_empty(&self) -> bool { self.len == 0 } }
+#[cfg(pmix6)]
+#[cfg(pmix6)]
 impl Drop for PmixNodePidArray { fn drop(&mut self) { if !self.ptr.is_null() { /* SAFETY: pointer and length came from the matching PMIx allocator. */ pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_node_pid_free(self.ptr, self.len) }, real = unsafe { ffi::PMIx_Node_pid_free(self.ptr, self.len) }); } } }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -4125,11 +4140,19 @@ pub fn progress() {
 /// # C API
 /// `PMIx_Progress_thread_stop(info, ninfo)` — takes an optional Info
 /// array for future extension (pass null/0 for now).
+///
+/// 6.x-only: OpenPMIx 5.0 has no explicit progress-thread stop; the
+/// internal thread is torn down by `PMIx_Finalize`, so this is a no-op there.
+#[cfg(pmix6)]
 pub fn progress_thread_stop() {
     unsafe {
         PMIx_Progress_thread_stop(std::ptr::null(), 0);
     }
 }
+
+/// 5.0 fallback — see [`progress_thread_stop`].
+#[cfg(not(pmix6))]
+pub fn progress_thread_stop() {}
 
 /// Finalize the process-wide PMIx client session (`PMIx_Finalize`).
 ///
@@ -4142,6 +4165,7 @@ pub fn finalize(info: Option<Info>) -> Result<(), pmix_status_t> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(pmix6)]
     #[test]
     fn test_proc_utils_mock_wrappers_and_predicates() {
         let _guard = crate::mock_ffi::MockGuard::new();
@@ -4171,6 +4195,7 @@ mod tests {
         assert_eq!(dst, [b'0' as i8, b'1' as i8, b'2' as i8, b'3' as i8, b'4' as i8, b'5' as i8, b'6' as i8, 0]);
     }
 
+    #[cfg(pmix6)]
     #[test]
     fn test_proc_utils_info_node_and_arrays() {
         let _guard = crate::mock_ffi::MockGuard::new();
@@ -5940,6 +5965,9 @@ impl PmixValue {
     }
     /// Writes the requested numeric representation into `dest`. The buffer
     /// must be large enough for the requested PMIx type.
+    ///
+    /// 6.x-only: `PMIx_Value_get_number` does not exist in OpenPMIx 5.0.
+    #[cfg(pmix6)]
     pub fn value_get_number(&self, dest: &mut [u8], ty: pmix_data_type_t) -> Result<(), PmixStatus> {
         let status = pmix_ffi_or_mock!(mock = unsafe { mock_ffi::mock_value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) }, real = unsafe { ffi::PMIx_Value_get_number(self.as_raw(), dest.as_mut_ptr().cast(), ty) });
         (status == PMIX_SUCCESS as i32).then_some(()).ok_or_else(|| PmixStatus::from_raw(status))

--- a/src/mock_ffi.rs
+++ b/src/mock_ffi.rs
@@ -3726,15 +3726,19 @@ pub unsafe fn mock_proc_info_create(n: usize) -> *mut crate::ffi::pmix_proc_info
     unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_proc_info_t>()) as *mut _ }
 }
 pub unsafe fn mock_proc_info_free(_p: *mut crate::ffi::pmix_proc_info_t, _n: usize) {}
+#[cfg(pmix6)]
 pub unsafe fn mock_node_pid_construct(p: *mut crate::ffi::pmix_node_pid_t) {
     if !p.is_null() {
         unsafe { std::ptr::write_bytes(p, 0, 1) };
     }
 }
+#[cfg(pmix6)]
 pub unsafe fn mock_node_pid_destruct(_p: *mut crate::ffi::pmix_node_pid_t) {}
+#[cfg(pmix6)]
 pub unsafe fn mock_node_pid_create(n: usize) -> *mut crate::ffi::pmix_node_pid_t {
     unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_node_pid_t>()) as *mut _ }
 }
+#[cfg(pmix6)]
 pub unsafe fn mock_node_pid_free(_p: *mut crate::ffi::pmix_node_pid_t, _n: usize) {}
 
 // Safe-wrapper support for PMIx data utility constructors and array APIs.
@@ -3895,18 +3899,22 @@ pub unsafe fn mock_coord_create(dims: usize, n: usize) -> *mut crate::ffi::pmix_
     p
 }
 pub unsafe fn mock_coord_free(_p: *mut crate::ffi::pmix_coord_t, _n: usize) {}
+#[cfg(pmix6)]
 pub unsafe fn mock_device_construct(p: *mut crate::ffi::pmix_device_t) {
     if !p.is_null() {
         unsafe { std::ptr::write_bytes(p, 0, 1) };
     }
 }
+#[cfg(pmix6)]
 pub unsafe fn mock_device_destruct(_p: *mut crate::ffi::pmix_device_t) {}
+#[cfg(pmix6)]
 pub unsafe fn mock_device_create(n: usize) -> *mut crate::ffi::pmix_device_t {
     if n == 0 {
         return std::ptr::null_mut();
     }
     unsafe { libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_device_t>()) as *mut _ }
 }
+#[cfg(pmix6)]
 pub unsafe fn mock_device_free(_p: *mut crate::ffi::pmix_device_t, _n: usize) {}
 pub unsafe fn mock_device_distance_destruct(_p: *mut crate::ffi::pmix_device_distance_t) {}
 pub unsafe fn mock_device_distance_construct(p: *mut crate::ffi::pmix_device_distance_t) {
@@ -4180,6 +4188,7 @@ pub unsafe fn mock_group_operation_string(
     b"unknown\0".as_ptr().cast()
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_unit_construct(d: *mut crate::ffi::pmix_resource_unit_t) {
     if !d.is_null() {
         (*d).type_ = 0;
@@ -4187,28 +4196,34 @@ pub unsafe fn mock_resource_unit_construct(d: *mut crate::ffi::pmix_resource_uni
     }
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_unit_destruct(_d: *mut crate::ffi::pmix_resource_unit_t) {}
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_unit_create(n: usize) -> *mut crate::ffi::pmix_resource_unit_t {
     libc::calloc(n, std::mem::size_of::<crate::ffi::pmix_resource_unit_t>()).cast()
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_unit_free(d: *mut crate::ffi::pmix_resource_unit_t, _n: usize) {
     libc::free(d.cast());
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_unit_string(
     _d: *const crate::ffi::pmix_resource_unit_t,
 ) -> *mut std::os::raw::c_char {
     libc::strdup(b"resource-unit\0".as_ptr().cast())
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_block_directive_string(
     _d: crate::ffi::pmix_resource_block_directive_t,
 ) -> *const std::os::raw::c_char {
     b"unknown\0".as_ptr().cast()
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_block(
     _d: crate::ffi::pmix_resource_block_directive_t,
     _b: *mut std::os::raw::c_char,
@@ -4220,6 +4235,7 @@ pub unsafe fn mock_resource_block(
     0
 }
 #[allow(unsafe_op_in_unsafe_fn)]
+#[cfg(pmix6)]
 pub unsafe fn mock_resource_block_nb(
     _d: crate::ffi::pmix_resource_block_directive_t,
     _b: *mut std::os::raw::c_char,

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1082,11 +1082,39 @@ mod tests {
     }
 }
 
+/// Send a heartbeat to the local server.
+///
+/// 6.x exposes `PMIx_Heartbeat` as a function; OpenPMIx 5.0 only defines it
+/// as a macro over `PMIx_Process_monitor_nb`, which we expand here instead.
 pub fn heartbeat_raw() {
-    crate::pmix_ffi_or_mock!(
-        mock = unsafe { crate::mock_ffi::mock_heartbeat() },
-        real = unsafe { ffi::PMIx_Heartbeat() }
-    );
+    #[cfg(pmix6)]
+    {
+        crate::pmix_ffi_or_mock!(
+            mock = unsafe { crate::mock_ffi::mock_heartbeat() },
+            real = unsafe { ffi::PMIx_Heartbeat() }
+        );
+    }
+    #[cfg(not(pmix6))]
+    {
+        let mut info: ffi::pmix_info_t = unsafe { std::mem::zeroed() };
+        // SAFETY: `info` is exclusively owned stack storage for this call;
+        // PMIx_Info_load fills it from the NUL-terminated `PMIX_SEND_HEARTBEAT`
+        // key (the exact expansion of 5.0's PMIx_Heartbeat macro).
+        unsafe {
+            ffi::PMIx_Info_load(
+                &mut info,
+                ffi::PMIX_SEND_HEARTBEAT.as_ptr().cast(),
+                std::ptr::null(),
+                ffi::PMIX_POINTER as ffi::pmix_data_type_t,
+            )
+        };
+        // SAFETY: `info` remains valid for the synchronous monitor call.
+        let _rc = unsafe {
+            ffi::PMIx_Process_monitor_nb(&info, ffi::PMIX_SUCCESS as i32, std::ptr::null(), 0, None, std::ptr::null_mut())
+        };
+        // SAFETY: `info` was constructed by PMIx_Info_load above.
+        unsafe { ffi::PMIx_Info_destruct(&mut info) };
+    }
 }
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -430,12 +430,18 @@ pub struct PmixServerModule {
     ///
     /// # C type
     /// `pmix_server_tool_connection2_fn_t`
+    ///
+    /// 6.x-only: absent from the OpenPMIx 5.0 server module.
+    #[cfg(pmix6)]
     pub tool_connected2: ffi::pmix_server_tool_connection2_fn_t,
 
     /// Log v2 callback.
     ///
     /// # C type
     /// `pmix_server_log2_fn_t`
+    ///
+    /// 6.x-only: absent from the OpenPMIx 5.0 server module.
+    #[cfg(pmix6)]
     pub log2: ffi::pmix_server_log2_fn_t,
 
     /// Session control callback (PMIx 5.x).
@@ -448,6 +454,9 @@ pub struct PmixServerModule {
     ///
     /// # C type
     /// `pmix_server_resource_block_fn_t`
+    ///
+    /// 6.x-only: absent from the OpenPMIx 5.0 server module.
+    #[cfg(pmix6)]
     pub resource_block: ffi::pmix_server_resource_block_fn_t,
 }
 
@@ -2983,12 +2992,17 @@ pub fn server_generate_cpuset_string(
 
 
 
+/// 6.x-only: `PMIx_server_generate_cpuset` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn server_generate_cpuset(cpuset_string:&str,cpuset:&mut crate::fabric::PmixCpuset)->Result<(),PmixStatus>{let s=CString::new(cpuset_string).map_err(|_|PmixStatus::from_raw(ffi::PMIX_ERR_BAD_PARAM))?;let raw=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())},real=unsafe{ffi::PMIx_server_generate_cpuset(s.as_ptr(),cpuset.as_mut_ptr())});if raw==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(raw))}}
+/// 6.x-only: `PMIx_server_collect_job_info` does not exist in OpenPMIx 5.0.
+#[cfg(pmix6)]
 pub fn server_collect_job_info(procs:&[Proc],dbuf:&mut crate::data_serialization::PmixDataBuffer)->Result<(),PmixStatus>{let mut raw=procs.iter().map(|p|p.handle).collect::<Vec<_>>();let s=crate::pmix_ffi_or_mock!(mock=unsafe{mock_ffi::mock_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())},real=unsafe{ffi::PMIx_server_collect_job_info(raw.as_mut_ptr(),raw.len(),dbuf.as_mut_ptr())});if s==ffi::PMIX_SUCCESS as i32{Ok(())}else{Err(PmixStatus::from_raw(s))}}
 
 #[cfg(test)]
 mod misc_wrapper_tests {
     use super::*;
+    #[cfg(pmix6)]
     #[test]
     fn server_cpuset_and_collect_job_info_wrappers() {
         let _guard = crate::mock_ffi::MockGuard::new();


### PR DESCRIPTION
## Summary

Enables pmix-rs to build against **OpenPMIx 5.0** (the widely-deployed base version) in addition to **≥ 6.1**. Previously the crate hard-required ≥ 6.1 — `build.rs` exited below that — even though 5.0 is what most systems ship.

### Version detection (`build.rs`)

- Minimum lowered to `≥ 5.0`; a `FULL_API_MAJOR/MINOR = 6.1` threshold marks the full surface.
- Emits `cargo:rustc-cfg=pmix6` only when headers are `≥ 6.1` (+ `rustc-check-cfg` to silence the lint), and reports which surface you got in a cargo warning.
- The `PMIx_Progress_thread_stop` bindgen sanity check now only applies to `≥ 6.1` installs.

### cfg-gated 6.x-only API (compiled out on 5.0)

| Area | Gated | 5.0 fallback |
|---|---|---|
| fabric | `fabric_construct`, `PmixDevice`(+impls), `PmixDeviceArray`, resource-unit block | — |
| allocation | `resource_block*`, `resource_block_directive_string` | — |
| data_ops | `PmixPdataHandle::{load,xfer}` | — |
| info | `PmixInfoList::{add_unique,add_value,add_value_unique,xfer_unique}` | `len()`/`is_empty()` walk `PMIx_Info_list_get_info` |
| lib | `rank_valid`, `PmixNodePid`/`PmixNodePidArray`, `value_get_number`, `progress_thread_stop` | `progress_thread_stop()` no-op (finalize tears the thread down) |
| groups | `group_operation_string` | — |
| monitoring | `PMIx_Heartbeat` (a 5.0 macro) | expand via `PMIx_Info_load` + `PMIx_Process_monitor_nb` |
| server | module fields `tool_connected2`/`log2`/`resource_block`, `server_generate_cpuset`, `server_collect_job_info` | — |
| mock_ffi | matching mocks for gated types | — |

Unit tests for gated APIs are `#[cfg(pmix6)]`-gated; a guard test covers the 5.0 `len()` fallback (including the recursion hazard caught while building).

## Verification

### Local (OpenPMIx 5.0.7 — system)
- `cargo check --features mock_ffi --lib` and `cargo check -p pmix --lib` — clean
- `cargo test --lib --features mock_ffi` — 1854 passed / 0 failed
- doctests — 68 passed

### Local (OpenPMIx 6.1.0 — built from source into `~/pmix-env/openpmix-6.1.0`, incl. libevent/hwloc deps)
- `cargo check -p pmix --lib` — clean, "full API surface" cfg
- `cargo test --lib --features mock_ffi` — **1866 passed / 0 failed** (the +12 are exactly the `pmix6`-gated tests: node_pid, device, resource_unit, group_operation_string, rank_valid, value_get_number, pdata load/xfer, info-list 6.x methods, resource_block, server_cpuset/collect_job_info)
- `cargo test --doc` — 68 passed
- `cargo build --lib` (real FFI, no mock) — links clean, proving the 6.x symbols (`PMIx_Progress_thread_stop`, …) resolve against libpmix 6.1

### CI
- Added a **`pmix5-tests`** job that builds OpenPMIx 5.0.7 and runs the lib/doctest surface, so the base path this PR enables is guarded going forward.

## Notes / pre-existing, unrelated to this PR

- The existing **`Regular tests`** CI job (`cargo test` on 6.1) does not compile on `main`: the integration tests are stale vs the Aug-12 src reworks (`tests/groups_ConstructDestruct_wrapper.rs` uses `Vec<pmix::Info>` where `GroupConstructCallbackWrapper::new` now expects `GroupResults`; `CredentialByteObject::is_null` in `tests/security_*`). This reproduces on clean `main` against both 5.0 and 6.1, so it predates this PR. That's also why `pmix5-tests` is scoped to the lib surface.
- `examples/spawn_child_job` fails on `PmixError: Display` — pre-existing.

## CI status of this PR (run 32809129728)

- ✅ **PMIx 5.0 tests** (new) — PASS
- ✅ **DVM tests (via prterun)** — PASS
- ❌ Clippy / Daemon tests / Regular tests — fail for **pre-existing reasons on `main`**, identical on this branch:
  - Clippy: 6 `suspicious-runtime-symbol-definitions` errors on bindgen's generated `memcpy`/`memset`/`memcmp`/`strlen`/`bcmp` declarations (from the 6.1 headers). Reproduced on clean `main` against 6.1. A stale-floating-clippy lint, not this PR.
  - Regular & Daemon: integration tests don't compile (stale `GroupResults`/`CredentialByteObject` tests vs the Aug-12 src reworks). Reproduced on clean `main` against both 5.0 and 6.1.
- This PR adds **no new CI failures**. The one clippy regression it introduced (an unused `///` doc comment on a `pmix_array!` invocation) is fixed in commit 24ab085.
