### PR TITLE
fix(tests): repair stale integration tests to current API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
         run: |
           cargo test --lib --features mock_ffi
           cargo test --doc --features mock_ffi
+          cargo test --features mock_ffi
 
       - name: Assert working tree stayed clean
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           cargo check --lib
           cargo check --features mock_ffi --lib
 
-      - name: Run lib + doctests on 5.0
+      - name: Run tests on 5.0
         run: |
           cargo test --lib --features mock_ffi
           cargo test --doc --features mock_ffi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,6 @@ impl std::fmt::Display for PmixError {
     }
 }
 
-
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixStatus — the public-facing type that wraps PmixError + Unknown(i32)
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,13 @@ pub enum PmixError {
     //  in `from_raw`. See implementation notes below.)
 }
 
+impl std::fmt::Display for PmixError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PmixStatus — the public-facing type that wraps PmixError + Unknown(i32)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -502,7 +509,7 @@ impl PmixStatus {
 impl std::fmt::Display for PmixStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Known(e) => e.fmt(f),
+            Self::Known(e) => std::fmt::Display::fmt(&e, f),
             Self::Unknown(v) => write!(f, "pmix_status_t({v}) [unknown/user-defined]"),
         }
     }

--- a/tests/daemon_groups_via_daemon.rs
+++ b/tests/daemon_groups_via_daemon.rs
@@ -9,6 +9,7 @@
 mod daemon_helper;
 
 use pmix::groups::{
+    GroupResults,
     GroupConstructCallbackWrapper, GroupDestructCallbackWrapper, GroupInviteCallbackWrapper,
     GroupJoinCallbackWrapper, GroupLeaveCallbackWrapper, group_construct, group_construct_nb,
     group_destruct, group_destruct_nb, group_invite, group_invite_nb, group_join, group_join_nb,
@@ -23,7 +24,7 @@ use pmix::{InfoBuilder, PmixStatus, Proc};
 
 #[test]
 fn test_group_construct_type() {
-    let _f: fn(&str, &[Proc], &[pmix::Info]) -> Result<Vec<pmix::Info>, PmixStatus> =
+    let _f: fn(&str, &[Proc], &[pmix::Info]) -> Result<GroupResults, PmixStatus> =
         group_construct;
 }
 
@@ -39,7 +40,7 @@ fn test_group_construct_nb_type() {
 
 #[test]
 fn test_group_invite_type() {
-    let _f: fn(&str, &[Proc], &[pmix::Info]) -> Result<Vec<pmix::Info>, PmixStatus> = group_invite;
+    let _f: fn(&str, &[Proc], &[pmix::Info]) -> Result<GroupResults, PmixStatus> = group_invite;
 }
 
 #[test]
@@ -55,7 +56,7 @@ fn test_group_join_type() {
         &Proc,
         pmix_group_opt_t,
         &[pmix::Info],
-    ) -> Result<Vec<pmix::Info>, PmixStatus> = group_join;
+    ) -> Result<GroupResults, PmixStatus> = group_join;
 }
 
 #[test]

--- a/tests/daemon_security_via_daemon.rs
+++ b/tests/daemon_security_via_daemon.rs
@@ -77,7 +77,8 @@ fn test_pmix_credential_len_type() {
 #[test]
 fn test_pmix_credential_as_raw_exists() {
     let cred = PmixCredential::from_vec(vec![1u8, 2, 3]);
-    let _raw: *const std::ffi::c_void = cred.as_raw() as *const std::ffi::c_void;
+    let raw = cred.as_raw();
+    let _raw: *const std::ffi::c_void = &*raw as *const _ as *const std::ffi::c_void;
 }
 
 #[test]
@@ -154,7 +155,7 @@ fn test_pmix_credential_as_raw() {
     let data = vec![42u8, 43, 44];
     let cred = PmixCredential::from_vec(data);
     let raw = cred.as_raw();
-    assert!(!raw.is_null());
+    assert!(!raw.bytes.is_null());
 }
 
 #[test]
@@ -201,7 +202,7 @@ fn test_security_all_ffi_via_daemon() {
     assert!(!cred.is_empty());
     assert_eq!(cred.len(), 5);
     assert_eq!(cred.as_bytes(), data.as_slice());
-    assert!(!cred.as_raw().is_null());
+    assert!(!cred.as_raw().bytes.is_null());
 
     // ── 2. get_credential ──
     {

--- a/tests/data_ops_deep.rs
+++ b/tests/data_ops_deep.rs
@@ -88,8 +88,8 @@ fn test_proc_new_empty_nspace() {
 #[test]
 fn test_proc_new_long_nspace() {
     let long_ns = "n".repeat(256);
-    let proc = Proc::new(&long_ns, 0).expect("create proc");
-    let _ = proc;
+    let result = Proc::new(&long_ns, 0);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/tests/groups_ConstructDestruct_wrapper.rs
+++ b/tests/groups_ConstructDestruct_wrapper.rs
@@ -111,7 +111,7 @@ fn test_group_construct_nb_empty_group_id() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         },
     );
@@ -132,7 +132,7 @@ fn test_group_construct_nb_empty_procs() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         },
     );
@@ -153,7 +153,7 @@ fn test_group_construct_nb_no_init() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         },
     );
@@ -171,7 +171,7 @@ fn test_group_construct_nb_with_info() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         },
     );
@@ -190,7 +190,7 @@ fn test_group_construct_nb_deterministic() {
     let called1 = Arc::new(AtomicBool::new(false));
     let c1 = Arc::clone(&called1);
     let cb1 = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             c1.store(true, Ordering::SeqCst);
         },
     );
@@ -199,7 +199,7 @@ fn test_group_construct_nb_deterministic() {
     let called2 = Arc::new(AtomicBool::new(false));
     let c2 = Arc::clone(&called2);
     let cb2 = GroupConstructCallbackWrapper::new(
-        move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        move |_status: PmixStatus, _results: GroupResults| {
             c2.store(true, Ordering::SeqCst);
         },
     );
@@ -214,7 +214,7 @@ fn test_group_construct_nb_deterministic() {
 #[test]
 fn test_group_construct_callback_wrapper_new() {
     let _cb =
-        GroupConstructCallbackWrapper::new(|_status: PmixStatus, _results: Vec<pmix::Info>| {});
+        GroupConstructCallbackWrapper::new(|_status: PmixStatus, _results: GroupResults| {});
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/groups_Group_invite.rs
+++ b/tests/groups_Group_invite.rs
@@ -17,7 +17,7 @@ use pmix::{PmixError, PmixStatus, Proc};
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Extract the error from a Result<Vec<Info>, PmixStatus>.
+/// Extract the error from a Result<GroupResults, PmixStatus>.
 fn extract_err<T>(result: Result<T, PmixStatus>) -> PmixStatus {
     match result {
         Err(e) => e,
@@ -222,7 +222,7 @@ fn group_invite_callback_wrapper_records_status() {
     let status = Arc::new(Mutex::new(None::<PmixStatus>));
     let status_clone = Arc::clone(&status);
 
-    let wrapper = GroupInviteCallbackWrapper::new(move |s: PmixStatus, _info: Vec<_>| {
+    let wrapper = GroupInviteCallbackWrapper::new(move |s: PmixStatus, _info: GroupResults| {
         let mut locked = status_clone.lock().unwrap();
         *locked = Some(s);
     });
@@ -238,7 +238,7 @@ fn group_invite_callback_wrapper_records_info_count() {
     let info_count = Arc::new(Mutex::new(None::<usize>));
     let info_count_clone = Arc::clone(&info_count);
 
-    let _wrapper = GroupInviteCallbackWrapper::new(move |_status: PmixStatus, info: Vec<_>| {
+    let _wrapper = GroupInviteCallbackWrapper::new(move |_status: PmixStatus, info: GroupResults| {
         let mut locked = info_count_clone.lock().unwrap();
         *locked = Some(info.len());
     });

--- a/tests/groups_Group_join.rs
+++ b/tests/groups_Group_join.rs
@@ -17,7 +17,7 @@ use pmix::{PmixError, PmixStatus, Proc};
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Extract the error from a Result<Vec<Info>, PmixStatus>.
+/// Extract the error from a Result<GroupResults, PmixStatus>.
 fn extract_err<T>(result: Result<T, PmixStatus>) -> PmixStatus {
     match result {
         Err(e) => e,
@@ -333,7 +333,7 @@ fn group_join_callback_wrapper_records_status() {
     let status = Arc::new(Mutex::new(None::<PmixStatus>));
     let status_clone = Arc::clone(&status);
 
-    let wrapper = GroupJoinCallbackWrapper::new(move |s: PmixStatus, _info: Vec<_>| {
+    let wrapper = GroupJoinCallbackWrapper::new(move |s: PmixStatus, _info: GroupResults| {
         let mut locked = status_clone.lock().unwrap();
         *locked = Some(s);
     });
@@ -349,7 +349,7 @@ fn group_join_callback_wrapper_records_info_count() {
     let info_count = Arc::new(Mutex::new(None::<usize>));
     let info_count_clone = Arc::clone(&info_count);
 
-    let _wrapper = GroupJoinCallbackWrapper::new(move |_status: PmixStatus, info: Vec<_>| {
+    let _wrapper = GroupJoinCallbackWrapper::new(move |_status: PmixStatus, info: GroupResults| {
         let mut locked = info_count_clone.lock().unwrap();
         *locked = Some(info.len());
     });

--- a/tests/groups_InviteJoin_wrapper.rs
+++ b/tests/groups_InviteJoin_wrapper.rs
@@ -103,7 +103,7 @@ fn test_group_invite_nb_empty_group_id() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let err = unwrap_err_result(group_invite_nb("", &[], &[], cb));
@@ -123,7 +123,7 @@ fn test_group_invite_nb_empty_procs() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let err = unwrap_err_result(group_invite_nb("test_group", &[], &[], cb));
@@ -143,7 +143,7 @@ fn test_group_invite_nb_no_init() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let proc = Proc::new("test_ns", 0).expect("create proc");
@@ -160,7 +160,7 @@ fn test_group_invite_nb_with_info() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let proc = Proc::new("test_ns", 0).expect("create proc");
@@ -178,7 +178,7 @@ fn test_group_invite_nb_deterministic() {
     let called1 = Arc::new(AtomicBool::new(false));
     let c1 = Arc::clone(&called1);
     let cb1 =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             c1.store(true, Ordering::SeqCst);
         });
     let err1 = unwrap_err_result(group_invite_nb("", &[], &[], cb1));
@@ -186,7 +186,7 @@ fn test_group_invite_nb_deterministic() {
     let called2 = Arc::new(AtomicBool::new(false));
     let c2 = Arc::clone(&called2);
     let cb2 =
-        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupInviteCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             c2.store(true, Ordering::SeqCst);
         });
     let err2 = unwrap_err_result(group_invite_nb("", &[], &[], cb2));
@@ -199,7 +199,7 @@ fn test_group_invite_nb_deterministic() {
 /// GroupInviteCallbackWrapper::new works.
 #[test]
 fn test_group_invite_callback_wrapper_new() {
-    let _cb = GroupInviteCallbackWrapper::new(|_status: PmixStatus, _results: Vec<pmix::Info>| {});
+    let _cb = GroupInviteCallbackWrapper::new(|_status: PmixStatus, _results: GroupResults| {});
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -333,7 +333,7 @@ fn test_group_join_nb_empty_group_id() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let err = unwrap_err_result(group_join_nb(
@@ -360,7 +360,7 @@ fn test_group_join_nb_no_init() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let err = unwrap_err_result(group_join_nb(
@@ -383,7 +383,7 @@ fn test_group_join_nb_with_info() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let info = InfoBuilder::new().build().expect("build info");
@@ -407,7 +407,7 @@ fn test_group_join_nb_deterministic() {
     let called1 = Arc::new(AtomicBool::new(false));
     let c1 = Arc::clone(&called1);
     let cb1 =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             c1.store(true, Ordering::SeqCst);
         });
     let err1 = unwrap_err_result(group_join_nb(
@@ -421,7 +421,7 @@ fn test_group_join_nb_deterministic() {
     let called2 = Arc::new(AtomicBool::new(false));
     let c2 = Arc::clone(&called2);
     let cb2 =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             c2.store(true, Ordering::SeqCst);
         });
     let err2 = unwrap_err_result(group_join_nb(
@@ -440,7 +440,7 @@ fn test_group_join_nb_deterministic() {
 /// GroupJoinCallbackWrapper::new works.
 #[test]
 fn test_group_join_callback_wrapper_new() {
-    let _cb = GroupJoinCallbackWrapper::new(|_status: PmixStatus, _results: Vec<pmix::Info>| {});
+    let _cb = GroupJoinCallbackWrapper::new(|_status: PmixStatus, _results: GroupResults| {});
 }
 
 /// group_join_nb with PMIX_GROUP_JOIN_AND_CONSTRUCT option.
@@ -453,7 +453,7 @@ fn test_group_join_nb_join_and_construct() {
     let called = Arc::new(AtomicBool::new(false));
     let called_clone = Arc::clone(&called);
     let cb =
-        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: Vec<pmix::Info>| {
+        GroupJoinCallbackWrapper::new(move |_status: PmixStatus, _results: GroupResults| {
             called_clone.store(true, Ordering::SeqCst);
         });
     let err = unwrap_err_result(group_join_nb(

--- a/tests/groups_deep.rs
+++ b/tests/groups_deep.rs
@@ -67,17 +67,17 @@ fn test_proc_type_check() {
 
 #[test]
 fn test_construct_callback_wrapper() {
-    let _cb = GroupConstructCallbackWrapper::new(|_status: PmixStatus, _info: Vec<pmix::Info>| {});
+    let _cb = GroupConstructCallbackWrapper::new(|_status: PmixStatus, _info: GroupResults| {});
 }
 
 #[test]
 fn test_invite_callback_wrapper() {
-    let _cb = GroupInviteCallbackWrapper::new(|_status: PmixStatus, _info: Vec<pmix::Info>| {});
+    let _cb = GroupInviteCallbackWrapper::new(|_status: PmixStatus, _info: GroupResults| {});
 }
 
 #[test]
 fn test_join_callback_wrapper() {
-    let _cb = GroupJoinCallbackWrapper::new(|_status: PmixStatus, _info: Vec<pmix::Info>| {});
+    let _cb = GroupJoinCallbackWrapper::new(|_status: PmixStatus, _info: GroupResults| {});
 }
 
 #[test]

--- a/tests/lib_type_coverage.rs
+++ b/tests/lib_type_coverage.rs
@@ -635,7 +635,7 @@ fn test_pmix_data_range_from_raw_all() {
     assert_eq!(PmixDataRange::from_raw(6), PmixDataRange::Custom);
     assert_eq!(PmixDataRange::from_raw(7), PmixDataRange::ProcLocal);
     assert_eq!(PmixDataRange::from_raw(255), PmixDataRange::Invalid);
-    assert_eq!(PmixDataRange::from_raw(42), PmixDataRange::Unknown);
+    assert_eq!(PmixDataRange::from_raw(42), PmixDataRange::Unknown(42));
 }
 
 #[test]
@@ -649,14 +649,14 @@ fn test_pmix_data_range_to_raw_all() {
     assert_eq!(PmixDataRange::Custom.to_raw(), 6);
     assert_eq!(PmixDataRange::ProcLocal.to_raw(), 7);
     assert_eq!(PmixDataRange::Invalid.to_raw(), 255);
-    assert_eq!(PmixDataRange::Unknown.to_raw(), 128);
+    assert_eq!(PmixDataRange::Unknown(128).to_raw(), 128);
 }
 
 #[test]
 fn test_pmix_data_range_display() {
     assert_eq!(format!("{}", PmixDataRange::Undef), "UNDEFINED");
     assert_eq!(format!("{}", PmixDataRange::Global), "GLOBAL");
-    assert_eq!(format!("{}", PmixDataRange::Unknown), "UNKNOWN RANGE (128)");
+    assert_eq!(format!("{}", PmixDataRange::Unknown(128)), "UNKNOWN RANGE (128)");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/security_Get_credential.rs
+++ b/tests/security_Get_credential.rs
@@ -108,15 +108,14 @@ fn test_credential_binary_data() {
 #[test]
 fn test_credential_as_raw_non_null() {
     let cred = PmixCredential::from_bytes(&[1, 2, 3]);
-    assert!(!cred.as_raw().is_null());
+    assert!(!cred.as_raw().bytes.is_null());
 }
 
-/// Test that PmixCredential as_raw for empty credential is also non-null
-/// (the struct itself is allocated, just with zero-size bytes).
+/// Test that PmixCredential as_raw for an empty credential has zero size.
 #[test]
 fn test_credential_as_raw_empty_non_null() {
     let cred = PmixCredential::from_bytes(&[]);
-    assert!(!cred.as_raw().is_null());
+    assert_eq!(cred.as_raw().size, 0);
 }
 
 /// Test credential debug formatting does not panic.
@@ -141,9 +140,9 @@ fn test_multiple_credentials() {
     assert!(cred3.is_empty());
 
     // All should still be valid after creation.
-    assert!(!cred1.as_raw().is_null());
-    assert!(!cred2.as_raw().is_null());
-    assert!(!cred3.as_raw().is_null());
+    assert!(!cred1.as_raw().bytes.is_null());
+    assert!(!cred2.as_raw().bytes.is_null());
+    assert_eq!(cred3.as_raw().size, 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/security_credentials.rs
+++ b/tests/security_credentials.rs
@@ -135,14 +135,14 @@ fn credential_single_byte() {
 #[test]
 fn credential_as_raw_non_null() {
     let cred = PmixCredential::from_bytes(&[1, 2, 3]);
-    assert!(!cred.as_raw().is_null());
+    assert!(!cred.as_raw().bytes.is_null());
 }
 
-/// PmixCredential::as_raw returns a non-null pointer even for empty credentials.
+/// PmixCredential::as_raw represents empty credentials with zero size.
 #[test]
 fn credential_as_raw_empty_non_null() {
     let cred = PmixCredential::empty();
-    assert!(!cred.as_raw().is_null());
+    assert_eq!(cred.as_raw().size, 0);
 }
 
 /// PmixCredential implements Debug (compile-time check).
@@ -167,8 +167,8 @@ fn credential_clone_independence() {
     assert_eq!(cred.as_bytes(), cloned.as_bytes());
     assert_eq!(cred.len(), cloned.len());
     // Both should still be valid.
-    assert!(!cred.as_raw().is_null());
-    assert!(!cloned.as_raw().is_null());
+    assert!(!cred.as_raw().bytes.is_null());
+    assert!(!cloned.as_raw().bytes.is_null());
 }
 
 /// Multiple PmixCredential instances can coexist independently.
@@ -182,9 +182,9 @@ fn credential_multiple_coexist() {
     assert_eq!(cred2.as_bytes(), b"second-credential-data");
     assert!(cred3.is_empty());
 
-    assert!(!cred1.as_raw().is_null());
-    assert!(!cred2.as_raw().is_null());
-    assert!(!cred3.as_raw().is_null());
+    assert!(!cred1.as_raw().bytes.is_null());
+    assert!(!cred2.as_raw().bytes.is_null());
+    assert_eq!(cred3.as_raw().size, 0);
 }
 
 /// PmixCredential with a large byte array (1MB) does not panic.

--- a/tests/security_via_prterun.rs
+++ b/tests/security_via_prterun.rs
@@ -74,7 +74,7 @@ fn test_credential_debug() {
 fn test_credential_as_raw() {
     let cred = pmix::security::PmixCredential::from_bytes(&[1, 2, 3]);
     let ptr = cred.as_raw();
-    assert!(!ptr.is_null());
+    assert!(!ptr.bytes.is_null());
 }
 
 /// ValidationResults::empty creates an empty result set.

--- a/tests/server_dmodex_inventory.rs
+++ b/tests/server_dmodex_inventory.rs
@@ -508,7 +508,7 @@ fn define_process_set_proc_various_ranks() {
 /// Proc::new rejects NUL bytes in nspace.
 #[test]
 fn define_process_set_nul_in_nspace_rejected() {
-    let result: Result<Proc, std::ffi::NulError> = Proc::new("test\0ns", 0);
+    let result: Result<Proc, PmixError> = Proc::new("test\0ns", 0);
     assert!(result.is_err());
 }
 
@@ -1010,7 +1010,7 @@ fn proc_construction_valid_nspaces() {
 /// Proc::new rejects NUL bytes.
 #[test]
 fn proc_construction_rejects_nul() {
-    let result: Result<Proc, std::ffi::NulError> = Proc::new("test\0ns", 0);
+    let result: Result<Proc, PmixError> = Proc::new("test\0ns", 0);
     assert!(result.is_err());
 }
 

--- a/tests/server_server_dmodex_request.rs
+++ b/tests/server_server_dmodex_request.rs
@@ -318,7 +318,7 @@ fn dmodex_request_nul_in_nspace_rejected() {
     // Proc::new returns Result<_, NulError>, so it should not panic
     // but return an Err.
     // Actually, let's check the return type.
-    let proc_result: Result<Proc, std::ffi::NulError> = Proc::new("test\0nspace", 0);
+    let proc_result: Result<Proc, PmixError> = Proc::new("test\0nspace", 0);
     assert!(
         proc_result.is_err(),
         "Proc::new should reject nspace with NUL byte"

--- a/tests/utility_Data_range_string.rs
+++ b/tests/utility_Data_range_string.rs
@@ -39,7 +39,7 @@ fn data_range_string_distinct() {
 
 #[test]
 fn data_range_string_unknown() {
-    let result = data_range_string(PmixDataRange::Unknown);
+    let result = data_range_string(PmixDataRange::Unknown(128));
     assert!(
         result.is_ok(),
         "Unknown should handle gracefully, got {:?}",

--- a/tests/utility_string_conversions.rs
+++ b/tests/utility_string_conversions.rs
@@ -305,7 +305,7 @@ fn data_range_string_all_defined() {
 
 #[test]
 fn data_range_string_unknown() {
-    let result = data_range_string(PmixDataRange::Unknown);
+    let result = data_range_string(PmixDataRange::Unknown(128));
     assert!(
         result.is_ok(),
         "data_range_string(Unknown) should handle gracefully, got {:?}",


### PR DESCRIPTION
Closes #510

## Summary
Repairs the integration tests + examples/spawn_child_job that stopped compiling after the Aug-12 GroupResults/CredentialByteObject/Proc::new src reworks. Adds impl Display for PmixError. Widens the pmix5 CI job back to the full test surface.

## Test plan
- cargo build --all-targets (6.1)
- cargo test (6.1): non-ignored pass
- cargo check --features mock_ffi --lib on system 5.0.7 stays green
