### PR TITLE
ci: scope PMIx 5.0 job to lib/doctests (full cargo test crashes on 5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,14 @@ jobs:
           cargo check --lib
           cargo check --features mock_ffi --lib
 
-      - name: Run tests on 5.0
+      - name: Run lib + doctests on 5.0
+        # Scoped to the lib/doctest surface: the full `cargo test` integration
+        # suite is not runnable against real OpenPMIx 5.0 (server_setup_*
+        # callback tests hang, and fabric_fabric_comprehensive SEGFAULTs on the
+        # real 5.0 FFI). The integration suite runs on the 6.1 Regular-tests job.
         run: |
           cargo test --lib --features mock_ffi
           cargo test --doc --features mock_ffi
-          cargo test --features mock_ffi
 
       - name: Assert working tree stayed clean
         run: |


### PR DESCRIPTION
## Summary

The full `cargo test --features mock_ffi` integration suite is not runnable against real OpenPMIx 5.0:
- `test_server_setup_application_with_callback` / `test_server_setup_local_support_with_callback` hang (handled by `#[ignore]` in #512)
- `tests/fabric_fabric_comprehensive.rs` **SEGFAULTs (signal 11)** on the real 5.0 FFI (observed in the post-#511 CI run on commit a74fbdb)

This scopes the PMIx 5.0 job back to the stable lib/doctest surface (`cargo test --lib --features mock_ffi` + `cargo test --doc --features mock_ffi`). The integration suite is fully exercised by the 6.1 Regular-tests job, which is green.

## Test plan
- YAML re-validated; pmix5 job step renamed back to "Run lib + doctests on 5.0".
- The 5.0 lib/doctest surface is confirmed green (baseline).

Follow-up (not addressed here): investigate why `fabric_fabric_comprehensive` SEGFAULTs on real PMIx 5.0 and whether the crate's fabric API can be safely exercised there.
