### PR TITLE
docs(tests): note 5.0 native SEGFAULT in fabric nb without-init tests

### DIFF
--- a/tests/fabric_fabric_comprehensive.rs
+++ b/tests/fabric_fabric_comprehensive.rs
@@ -135,6 +135,14 @@ fn test_fabric_register_nb_without_init() {
     // Mirror the blocking sibling: assert the nb path fails without PMIx init.
     // Do NOT call ensure_pmix_init() — that is the DVM/client path and would
     // invert the "without init" contract this test is named for.
+    //
+    // NOTE: on real OpenPMIx 5.0 this test SEGFAULTs inside native libpmix
+    // (`PMIx_Fabric_register_nb` is not safe to call before `PMIx_Init` on 5.0;
+    // gdb backtrace: SIGSEGV in `PMIx_Fabric_register_nb () from libpmix.so.2`,
+    // reached from the clean FFI forward at src/fabric.rs). On 6.1 the same call
+    // returns an error, so this passes. It is not run by the pmix5 CI job (scoped
+    // to --lib/--doc), so the crash is harmless in CI; a local `cargo test` on 5.0
+    // will hit it.
     let mut fabric = PmixFabric::new(Some("test")).expect("fabric new failed");
     let info = InfoBuilder::new().build().expect("build info");
     let directives: &[pmix::Info] = std::slice::from_ref(&info);
@@ -264,6 +272,14 @@ fn test_compute_distances_nb_without_init() {
     // Mirror the blocking sibling: assert the nb path fails without PMIx init.
     // Do NOT call ensure_pmix_init() — that is the DVM/client path and would
     // invert the "without init" contract this test is named for.
+    //
+    // NOTE: on real OpenPMIx 5.0 this test SEGFAULTs inside native libpmix
+    // (`PMIx_Compute_distances_nb` is not safe to call before `PMIx_Init` on 5.0;
+    // gdb backtrace: SIGSEGV in `PMIx_Compute_distances_nb () from libpmix.so.2`,
+    // reached from the clean FFI forward at src/fabric.rs). On 6.1 the same call
+    // returns an error, so this passes. It is not run by the pmix5 CI job (scoped
+    // to --lib/--doc), so the crash is harmless in CI; a local `cargo test` on 5.0
+    // will hit it.
     let mut topo = PmixTopology::new(None).expect("topology new failed");
     let mut cpuset = PmixCpuset::new();
     let info = InfoBuilder::new().build().expect("build info");


### PR DESCRIPTION
## Summary

Adds a documentation comment (no behavior change) to two tests in `tests/fabric_fabric_comprehensive.rs` that SEGFAULT on real OpenPMIx 5.0:

- `test_fabric_register_nb_without_init`
- `test_compute_distances_nb_without_init`

### Root cause (investigated with gdb)

On OpenPMIx 5.0, `PMIx_Fabric_register_nb` / `PMIx_Compute_distances_nb` are **not safe to call before `PMIx_Init`** — they crash inside native libpmix. gdb backtrace confirms the SIGSEGV is entirely inside `libpmix.so.2`, reached from the clean FFI forward in `src/fabric.rs` (no Rust `unsafe` misuse). On 6.1 the same calls return an error, so the tests pass there.

### Why comment-only

- The `pmix5-tests` CI job is scoped to `--lib`/`--doc` (per #513), so these integration tests are **never run on 5.0 in CI** — no CI impact.
- The 6.1 `Regular tests` job runs them and they pass.
- A defensive init-guard in the nb wrappers would add global client-init tracking that doesn't exist and change public API behavior, which the repo's conventions (simplest implementation, no speculative abstraction) don't justify.

This documents the limitation for anyone running the full suite locally on 5.0.

## Test plan
- `cargo test --features mock_ffi --no-run --test fabric_fabric_comprehensive` compiles clean (comment-only change).
